### PR TITLE
Run standalone tests on travis

### DIFF
--- a/bin/run-test.sh
+++ b/bin/run-test.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 jshint . || exit 1
-istanbul test ./node_modules/.bin/_mocha -- test --timeout 4000 --R spec || exit 1
-for test in test/hooks/test-*.js ;
+istanbul test $(npm bin)/_mocha -- test test/hooks --timeout 4000 --R spec || exit 1
+for test in test/standalone/test-*.js ;
 do
-  istanbul test ./node_modules/.bin/_mocha -- ${test} --timeout 4000 --R spec || exit 1
+  istanbul test $(npm bin)/_mocha -- ${test} --timeout 4000 --R spec || exit 1
 done

--- a/test/standalone/test-trace-cluster.js
+++ b/test/standalone/test-trace-cluster.js
@@ -16,7 +16,7 @@
 
 'use strict';
 
-var common = require('./common.js');
+var common = require('../hooks/common.js');
 var cluster = require('cluster');
 var express = require('express');
 

--- a/test/test-utils.js
+++ b/test/test-utils.js
@@ -29,6 +29,9 @@ var utils = require('../lib/utils.js');
 nock.disableNetConnect();
 
 describe('utils', function() {
+  after(function() {
+    nock.enableNetConnect();
+  });
 
   describe('getProjectNumber', function() {
 
@@ -46,8 +49,10 @@ describe('utils', function() {
         var scope = nock('http://metadata')
                       .get('/computeMetadata/v1/project/numeric-project-id')
                       .reply(200, '567');
+        var num = process.env.GCLOUD_PROJECT_NUM;
         delete process.env.GCLOUD_PROJECT_NUM;
         utils.getProjectNumber(function(err, project) {
+          process.env.GCLOUD_PROJECT_NUM = num;
           assert.ok(!err);
           assert.strictEqual(project, '567');
           scope.done();


### PR DESCRIPTION
Also moved cluster test to standalone so hooks can be run in the same mocha invocation as unit tests.