### PR TITLE
Removed dev dependencies badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 [![NPM Version][npm-image]][npm-url]
 [![Build Status][travis-image]][travis-url]
 [![Dependency Status][david-image]][david-url]
-[![devDependency Status][david-dev-image]][david-dev-url]
 
 This module implements experimental support for Google
 [Cloud Trace](https://cloud.google.com/cloud-trace/) for Node.js. This module is
@@ -22,5 +21,3 @@ deprecation policy, and may be changed without notice.
 [travis-url]: https://travis-ci.org/GoogleCloudPlatform/cloud-trace-nodejs
 [david-image]: https://david-dm.org/GoogleCloudPlatform/cloud-trace-nodejs.svg
 [david-url]: https://david-dm.org/GoogleCloudPlatform/cloud-trace-nodejs
-[david-dev-image]: https://david-dm.org/GoogleCloudPlatform/cloud-trace-nodejs/dev-status.svg
-[david-dev-url]: https://david-dm.org/GoogleCloudPlatform/cloud-trace-nodejs#info=devDependencies


### PR DESCRIPTION
As per offline: it doesn't make sense for us to have up to date dev dependencies since we need to trace older versions of supported frameworks.