### PR TITLE
stringify spans when they're queued

### DIFF
--- a/lib/trace-writer.js
+++ b/lib/trace-writer.js
@@ -41,7 +41,7 @@ function TraceWriter(logger, config) {
   /** @private {function} authenticated request function */
   this.request_ = utils.authorizedRequestFactory(SCOPES);
 
-  /** @private {Array<Trace>} array to cache buffers */
+  /** @private {Array<string>} stringified traces to be published */
   this.buffer_ = [];
 
   // Schedule periodic flushing of the buffer, but only if we are able to get
@@ -83,7 +83,7 @@ TraceWriter.prototype.queueTrace_ = function(trace) {
     if (err) { return; } // ignore as index.js takes care of this.
 
     trace.projectId = project;
-    var length = that.buffer_.push(trace);
+    var length = that.buffer_.push(JSON.stringify(trace));
 
     that.logger_.info('queued trace. new size:', length);
 
@@ -121,13 +121,7 @@ TraceWriter.prototype.flushBuffer_ = function(projectId) {
   var buffer = this.buffer_;
   this.buffer_ = [];
 
-  var traces = { traces: buffer };
-  // FIXME(ofrobots): if the buffer is large, this is going to burn
-  // a lot of CPU and block the event loop. Figure out a way to do this some
-  // other way. Since node-core doesn't have a streaming JSON stringifier
-  // we'll need to look at npm modules for this.
-  // Alternatively, we should switch to protobufs
-  this.publish_(projectId, JSON.stringify(traces));
+  this.publish_(projectId, '{"traces":[' + buffer.join() + ']}');
 };
 
 /**

--- a/test/hooks/common.js
+++ b/test/hooks/common.js
@@ -46,7 +46,7 @@ function cleanTraces() {
 }
 
 function getTraces() {
-  return agent.traceWriter.buffer_;
+  return agent.traceWriter.buffer_.map(JSON.parse);
 }
 
 function getMatchingSpan(predicate) {

--- a/test/test-span-data.js
+++ b/test/test-span-data.js
@@ -95,7 +95,7 @@ describe('SpanData', function() {
       var span = agent.createRootSpanData('hi');
       span.createChildSpanData('sub');
       span.close();
-      var traces = agent.traceWriter.buffer_;
+      var traces = agent.traceWriter.buffer_.map(JSON.parse);
       for (var i = 0; i < traces.length; i++) {
         for (var j = 0; j < traces[i].spans.length; j++) {
           assert.notEqual(traces[i].spans[j].endTime, '');


### PR DESCRIPTION
This will avoid a huge stringify call holding down the cpu on publish.