### PR TITLE
Test coverage for adding context to headers

### DIFF
--- a/lib/hooks/core/hook-http.js
+++ b/lib/hooks/core/hook-http.js
@@ -101,8 +101,6 @@ function uriFromOptions(options) {
   var uri;
   if (typeof options === 'string') {
     uri = options;
-  } else if (options.uri && options.uri.href) {
-    uri = options.uri.href;
   } else {
     // In theory we should use url.format here. However, that is
     // broken. See: https://github.com/joyent/node/issues/9117 and

--- a/test/test-trace-agent.js
+++ b/test/test-trace-agent.js
@@ -68,6 +68,16 @@ describe('Trace Agent', function() {
         assert.equal(parsed.options, 1);
       });
     });
+
+    it('noop on nullSpan', function() {
+      cls.getNamespace().run(function() {
+        var options = {
+          headers: {}
+        };
+        agent.addContextToHeaders(OpaqueSpan.nullSpan, options.headers);
+        assert.equal(options.headers[constants.TRACE_CONTEXT_HEADER_NAME], undefined);
+      });
+    });
   });
 
   describe('parseContextFromHeader', function() {


### PR DESCRIPTION
We already have other tests guaranteeing the formatting of the headers. This just ensures that code path is exercised and the api is called correctly.