### PR TITLE
Patched express on public interface

### DIFF
--- a/lib/hooks/userspace/hook-express.js
+++ b/lib/hooks/userspace/hook-express.js
@@ -19,17 +19,19 @@
 var cls = require('../../cls.js');
 var TraceLabels = require('../../trace-labels.js');
 var shimmer = require('shimmer');
+var patchedMethods = require('methods');
+patchedMethods.push('use', 'route', 'param', 'all');
 var constants = require('../../constants.js');
 var agent;
 var express;
 
-function applicationLazyRouterWrap(lazyrouter) {
-  return function lazyrouterTrace() {
+function applicationActionWrap(method) {
+  return function expressActionTrace() {
     if (!this._google_trace_patched && !this._router) {
       this._google_trace_patched = true;
       this.use(middleware);
     }
-    return lazyrouter.apply(this, arguments);
+    return method.apply(this, arguments);
   };
 }
 
@@ -107,12 +109,16 @@ module.exports = {
     if (!express) {
       agent = agent_;
       express = express_;
-      shimmer.wrap(express.application, 'lazyrouter', applicationLazyRouterWrap);
+      patchedMethods.forEach(function(method) {
+        shimmer.wrap(express.application, method, applicationActionWrap);
+      });
     }
   },
   unpatch: function() {
     if (express) {
-      shimmer.unwrap(express.application, 'lazyrouter');
+      patchedMethods.forEach(function(method) {
+        shimmer.unwrap(express.application, method);
+      });
       express = null;
       agent = null;
     }

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "hapi": "^8.8.0",
     "istanbul": "^0.3.17",
     "jshint": "^2.7.0",
+    "methods": "^1.1.1",
     "mocha": "^2.2.4",
     "mongodb-core": "^1.2.10",
     "mongoose": "^4.1.1",

--- a/test/standalone/test-index.js
+++ b/test/standalone/test-index.js
@@ -73,7 +73,11 @@ describe('index.js', function() {
   it('should wrap/unwrap express on start/stop', function() {
     agent.start();
     var express = require('express');
-    wrapTest(express.application, 'lazyrouter');
+    var patchedMethods = require('methods');
+    patchedMethods.push('use', 'route', 'param', 'all');
+    patchedMethods.forEach(function(method) {
+      wrapTest(express.application, method);
+    });
     agent.stop();
   });
 


### PR DESCRIPTION
Unit and non-interference tests pass with these changes. I don't believe it is necessary to update unit tests with full coverage of the method interface as the code paths are fully shared. @ofrobots PTAL.