### PR TITLE
Removed iojs from travis test targets

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,8 @@ language: node_js
 
 node_js:
   - "0.12"
+  - "2"
   - "4"
-  - "iojs"
 
 services:
   - mongodb


### PR DESCRIPTION
We have moved over to version 2 as it is referred to after
the iojs/node merge.

Fixes #67