### PR TITLE
Accept labels as objects on start and end span

### DIFF
--- a/lib/hooks/core/hook-http.js
+++ b/lib/hooks/core/hook-http.js
@@ -51,15 +51,10 @@ function requestWrap(request) {
 
     var namespace = cls.getNamespace();
     var uri = uriFromOptions(options);
-    var methodLabel = {
-      key: TraceLabels.HTTP_METHOD_LABEL_KEY,
-      value: options.method
-    };
-    var urlLabel = {
-      key: TraceLabels.HTTP_URL_LABEL_KEY,
-      value: uri
-    };
-    var span = agent.startSpan(uri, [methodLabel, urlLabel]);
+    var labels = {};
+    labels[TraceLabels.HTTP_METHOD_LABEL_KEY] = options.method;
+    labels[TraceLabels.HTTP_URL_LABEL_KEY] = uri;
+    var span = agent.startSpan(uri, labels);
     if (options.headers) {
       // Adding context to the headers lets us trace the request
       // as it makes it through other layers of the Google infrastructure
@@ -74,15 +69,10 @@ function requestWrap(request) {
         numBytes += chunk.length;
       });
       res.on('end', function() {
-        var sizeLabel = {
-          key: TraceLabels.HTTP_RESPONSE_SIZE_LABEL_KEY,
-          value: numBytes
-        };
-        var codeLabel = {
-          key: TraceLabels.HTTP_RESPONSE_CODE_LABEL_KEY,
-          value: res.statusCode
-        };
-        agent.endSpan(span, [sizeLabel, codeLabel]);
+        var labels = {};
+        labels[TraceLabels.HTTP_RESPONSE_SIZE_LABEL_KEY] = numBytes;
+        labels[TraceLabels.HTTP_RESPONSE_CODE_LABEL_KEY] = res.statusCode;
+        agent.endSpan(span, labels);
       });
 
       if (callback) {
@@ -91,16 +81,10 @@ function requestWrap(request) {
     });
     namespace.bindEmitter(returned);
     returned.on('error', function(e) {
-      var labels = [];
+      var labels = {};
       if (e) {
-        labels.push({
-          key: TraceLabels.ERROR_DETAILS_NAME,
-          value: e.name
-        });
-        labels.push({
-          key: TraceLabels.ERROR_DETAILS_MESSAGE,
-          value: e.message
-        });
+        labels[TraceLabels.ERROR_DETAILS_NAME] = e.name;
+        labels[TraceLabels.ERROR_DETAILS_MESSAGE] = e.message;
       } else {
         agent.logger_.error('HTTP Request error was null or undefined');
       }

--- a/lib/hooks/userspace/hook-mongodb-core.js
+++ b/lib/hooks/userspace/hook-mongodb-core.js
@@ -28,7 +28,7 @@ function nextWrap(next) {
       agent.logger_.warn('Cannot create mongo span outside of a supported framework.');
       return next.apply(this, arguments);
     }
-    var span = agent.startSpan('mongo-cursor', [{ key: 'db', value: this.ns }]);
+    var span = agent.startSpan('mongo-cursor', { db: this.ns });
     return next.call(this, wrapCallback(span, cb));
   };
 }
@@ -41,7 +41,7 @@ function wrapWithLabel(label) {
         agent.logger_.warn('Cannot create mongo span outside of a supported framework.');
         return original.apply(this, arguments);
       }
-      var span = agent.startSpan(label, [{key: 'db', value: ns}]);
+      var span = agent.startSpan(label, { db: ns });
       if (typeof options === 'function') {
         return original.call(this, ns, ops,
           wrapCallback(span, options));

--- a/lib/trace-agent.js
+++ b/lib/trace-agent.js
@@ -65,7 +65,7 @@ TraceAgent.prototype.config = function() {
 /**
  * Begin a new custom span.
  * @param {string} name The name of the span.
- * @param {Array<{key: string, value: string}>=} labels Labels to be attached
+ * @param {Object<string, string}>=} labels Labels to be attached
  *   to the newly created span.
  * @return {OpaqueSpan} The newly created span.
  */
@@ -74,8 +74,8 @@ TraceAgent.prototype.startSpan = function(name, labels) {
   if (rootSpan) {
     var newSpan = rootSpan.createChildSpanData(name);
     if (labels) {
-      labels.forEach(function(label) {
-        newSpan.span.setLabel(label.key, label.value);
+      Object.keys(labels).forEach(function(key) {
+        newSpan.span.setLabel(key, labels[key]);
       });
     }
     return new OpaqueSpan(newSpan);
@@ -89,13 +89,13 @@ TraceAgent.prototype.startSpan = function(name, labels) {
 /**
  * Close the provided span.
  * @param {OpaqueSpan} opaque The span to be ended.
- * @param {Array<{key: string, value: string}>=} labels Labels to be attached
+ * @param {Object<string, string}>=} labels Labels to be attached
  *   to the terminated span.
  */
 TraceAgent.prototype.endSpan = function(opaque, labels) {
   if (labels) {
-    labels.forEach(function(label) {
-      opaque.addLabel(label.key, label.value);
+    Object.keys(labels).forEach(function(key) {
+      opaque.addLabel(key, labels[key]);
     });
   }
   opaque.end();
@@ -107,7 +107,7 @@ TraceAgent.prototype.endSpan = function(opaque, labels) {
  * async and is given a continuation to terminate the span after its
  * work is completed.
  * @param {string} name The name of the resulting span.
- * @param {Array<{key: string, value: string}>=} labels Labels to be attached
+ * @param {Object<string, string}>=} labels Labels to be attached
  *   to the resulting span.
  * @param {function(function()=)} fn The function to trace.
  */

--- a/test/standalone/test-index.js
+++ b/test/standalone/test-index.js
@@ -158,11 +158,8 @@ describe('index.js', function() {
     agent.start();
     cls.getNamespace().run(function() {
       var root = agent.private_().createRootSpanData('root', 1, 0);
-      var testLabel = {
-        key: 'key',
-        value: 'val'
-      };
-      agent.runInSpan('sub', [testLabel], function() {});
+      var testLabel = { key: 'val' };
+      agent.runInSpan('sub', testLabel, function() {});
       root.close();
       var spanPredicate = function(spanData) {
         return spanData.spans[1].name === 'sub';
@@ -180,13 +177,10 @@ describe('index.js', function() {
     agent.start();
     cls.getNamespace().run(function() {
       var root = agent.private_().createRootSpanData('root', 1, 0);
-      var testLabel = {
-        key: 'key',
-        value: 'val'
-      };
+      var testLabel = { key: 'val' };
       agent.runInSpan('sub', function(endSpan) {
         setTimeout(function() {
-          endSpan([testLabel]);
+          endSpan(testLabel);
           root.close();
           var spanPredicate = function(spanData) {
             return spanData.spans[1].name === 'sub';


### PR DESCRIPTION
Previously, labels were passed to start and end span calls
with the structure [{ key: 'key', value: 'val' }]. This has been
replaced with the more concise { key: 'val' } structure.

@ofrobots PTAL.