### PR TITLE
Fixes null reference in express

### DIFF
--- a/lib/hooks/userspace/hook-express.js
+++ b/lib/hooks/userspace/hook-express.js
@@ -36,11 +36,14 @@ function applicationActionWrap(method) {
 }
 
 function middleware(req, res, next) {
-  var originalEnd = res.end;
-
   var namespace = cls.getNamespace();
+  if (!namespace) {
+    return next();
+  }
   namespace.bindEmitter(req);
   namespace.bindEmitter(res);
+
+  var originalEnd = res.end;
 
   namespace.run(function() {
     var rootContext = startRootSpanForRequest(req);

--- a/lib/hooks/userspace/hook-hapi.js
+++ b/lib/hooks/userspace/hook-hapi.js
@@ -32,13 +32,17 @@ function connectionWrap(connection) {
 }
 
 function middleware(request, reply) {
+  var namespace = cls.getNamespace();
+  if (!namespace) {
+    return reply.continue();
+  }
   var req = request.raw.req;
   var res = request.raw.res;
-  var originalEnd = res.end;
 
-  var namespace = cls.getNamespace();
   namespace.bindEmitter(req);
   namespace.bindEmitter(res);
+
+  var originalEnd = res.end;
 
   namespace.run(function() {
     var rootContext = startRootSpanForRequest(req);

--- a/lib/hooks/userspace/hook-restify.js
+++ b/lib/hooks/userspace/hook-restify.js
@@ -33,11 +33,14 @@ function createServerWrap(createServer) {
 }
 
 function middleware(req, res, next) {
-  var originalEnd = res.end;
-
   var namespace = cls.getNamespace();
+  if (!namespace) {
+    return next();
+  }
   namespace.bindEmitter(req);
   namespace.bindEmitter(res);
+
+  var originalEnd = res.end;
 
   namespace.run(function() {
     var rootContext = startRootSpanForRequest(req);

--- a/test/standalone/test-agent-stopped.js
+++ b/test/standalone/test-agent-stopped.js
@@ -1,0 +1,103 @@
+/**
+ * Copyright 2015 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+var assert = require('assert');
+var http = require('http');
+
+process.env.GCLOUD_PROJECT_NUM = 0;
+
+describe('express', function() {
+  it('should not break if no project number is found', function(done) {
+    var agent = require('../..');
+    agent.start();
+    var app = require('express')();
+    agent.stop();
+    app.get('/', function (req, res) {
+      res.send('hi');
+    });
+    var server = app.listen(8080, function() {
+      http.get('http://localhost:8080', function(res) {
+        var result = '';
+        res.on('data', function(data) { result += data; });
+        res.on('end', function() {
+          assert.equal('hi', result);
+          server.close();
+          done();
+        });
+      });
+    });
+  });
+});
+
+describe('hapi', function() {
+  it('should not break if no project number is found', function(done) {
+    var agent = require('../..');
+    agent.start();
+    var hapi = require('hapi');
+    var server = new hapi.Server();
+    server.connection({ port: 8081 });
+    agent.stop();
+    server.route({
+      method: 'GET',
+      path: '/',
+      handler: function(req, reply) {
+        reply('hi');
+      }
+    });
+    server.start(function() {
+      http.get('http://localhost:8081', function(res) {
+        var result = '';
+        res.on('data', function(data) { result += data; });
+        res.on('end', function() {
+          assert.equal('hi', result);
+          server.stop();
+          done();
+        });
+      });
+    });
+  });
+});
+
+describe('restify', function() {
+  it('should not break if no project number is found', function(done) {
+    var agent = require('../..');
+    agent.start();
+    var restify = require('restify');
+    var server = restify.createServer();
+    agent.stop();
+    server.get('/', function (req, res, next) {
+      res.writeHead(200, {
+        'Content-Type': 'text/plain'
+      });
+      res.write('hi');
+      res.end();
+      return next();
+    });
+    server.listen(8082, function() {
+      http.get('http://localhost:8082', function(res) {
+        var result = '';
+        res.on('data', function(data) { result += data; });
+        res.on('end', function() {
+          assert.equal('hi', result);
+          server.close();
+          done();
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
A null reference was occuring when the agent disabled after
attaching express middleware. Middleware now verifies that
the agent is enabled before starting the trace.

Fixes #70 

@ofrobots PTAL