### PR TITLE
Moved methods dep from dev to normal dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
     "hapi": "^8.8.0",
     "istanbul": "^0.3.17",
     "jshint": "^2.7.0",
-    "methods": "^1.1.1",
     "mocha": "^2.2.4",
     "mongodb-core": "^1.2.10",
     "mongoose": "^4.1.1",
@@ -58,6 +57,7 @@
   "dependencies": {
     "@google/cloud-diagnostics-common": "^0.2.0",
     "continuation-local-storage": "^3.1.4",
+    "methods": "^1.1.1",
     "semver": "^5.0.1",
     "shimmer": "^1.0.0",
     "uuid": "^2.0.1"


### PR DESCRIPTION
It is required for the express hook. This wasn't caught by CI since all dev dependencies are installed there.

@ofrobots PTAL