### PR TITLE
Added tests for enviroment variables

### DIFF
--- a/config.js
+++ b/config.js
@@ -18,10 +18,9 @@
 // Default configuration
 module.exports = {
   // Log levels: 0-disabled,1-error,2-warn,3-info,4-debug
-  logLevel: process.env.hasOwnProperty('GCLOUD_LOG_LEVEL') ?
-    process.env.GCLOUD_LOG_LEVEL : 1,
+  logLevel: 1,
 
-  enabled: !process.env.hasOwnProperty('GCLOUD_TRACE_DISABLE'),
+  enabled: true,
 
   // Valid entries are:
   // 'express', 'hapi', 'http', 'mongodb-core', restify'

--- a/test/standalone/test-env-disable.js
+++ b/test/standalone/test-env-disable.js
@@ -1,0 +1,36 @@
+/**
+ * Copyright 2015 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+process.env.GCLOUD_TRACE_DISABLE = 1;
+
+var assert = require('assert');
+var agent = require('../..');
+
+describe('should respect environment variables', function() {
+  it('should respect GCLOUD_TRACE_DISABLE', function() {
+    agent.start();
+    assert(!agent.isActive());
+    agent.stop();
+  });
+
+  it('should prefer env to config', function() {
+    agent.start({enabled: true});
+    assert(!agent.isActive());
+    agent.stop();
+  });
+});

--- a/test/standalone/test-env-log-level.js
+++ b/test/standalone/test-env-log-level.js
@@ -1,0 +1,36 @@
+/**
+ * Copyright 2015 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+process.env.GCLOUD_LOG_LEVEL = 4;
+
+var assert = require('assert');
+var agent = require('../..');
+
+describe('should respect environment variables', function() {
+  it('should respect GCLOUD_LOG_LEVEL', function() {
+    agent.start();
+    assert.equal(agent.private_().config_.logLevel, 4);
+    agent.stop();
+  });
+
+  it('should prefer env to config', function() {
+    agent.start({logLevel: 2});
+    assert.equal(agent.private_().config_.logLevel, 4);
+    agent.stop();
+  });
+});

--- a/test/standalone/test-env-project-id.js
+++ b/test/standalone/test-env-project-id.js
@@ -1,0 +1,36 @@
+/**
+ * Copyright 2015 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+process.env.GCLOUD_PROJECT_NUM = 1729;
+
+var assert = require('assert');
+var agent = require('../..');
+
+describe('should respect environment variables', function() {
+  it('should respect GCLOUD_PROJECT_NUM', function() {
+    agent.start();
+    assert.equal(agent.private_().config_.projectId, 1729);
+    agent.stop();
+  });
+
+  it('should prefer env to config', function() {
+    agent.start({projectId: 1927});
+    assert.equal(agent.private_().config_.projectId, 1729);
+    agent.stop();
+  });
+});

--- a/test/standalone/test-index.js
+++ b/test/standalone/test-index.js
@@ -33,14 +33,6 @@ describe('index.js', function() {
     agent.stop();
   });
 
-  it('should complain when config.projectId is not a string or number', function() {
-    agent.start({projectId: 0, enabled: true, logLevel: 0});
-    assert.strictEqual(agent.isActive(), true);
-    agent.stop();
-    agent.start({projectId: {test: false}, enabled: true, logLevel: 0});
-    assert.strictEqual(agent.isActive(), false);
-  });
-
   function wrapTest(nodule, property) {
     agent.stop(); // harmless to stop before a start.
     assert(!nodule[property].__unwrap,

--- a/test/standalone/test-invalid-project-id.js
+++ b/test/standalone/test-invalid-project-id.js
@@ -1,0 +1,32 @@
+/**
+ * Copyright 2015 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+delete process.env.GCLOUD_PROJECT_NUM;
+
+var assert = require('assert');
+var agent = require('../..');
+
+describe('index.js', function() {
+  it('should complain when config.projectId is not a string or number', function() {
+    agent.start({projectId: 0, enabled: true, logLevel: 0});
+    assert(agent.isActive());
+    agent.stop();
+    agent.start({projectId: {test: false}, enabled: true, logLevel: 0});
+    assert(!agent.isActive());
+  });
+});


### PR DESCRIPTION
There was another problem with the enabled config option
being completely ignored this time. This patch fixes the bug and
introduces stand alone tests for each of our current environment
variable flags.

@ofrobots PTAL.