### PR TITLE
Check framework versions using package.json

### DIFF
--- a/lib/hooks/index.js
+++ b/lib/hooks/index.js
@@ -18,7 +18,7 @@
 var Module = require('module');
 var shimmer = require('shimmer');
 var assert = require('assert');
-
+var path = require('path');
 
 //
 // All these operations need to be reversible
@@ -36,7 +36,8 @@ var toInstrument = Object.create(null, {
     value: {
       file: './userspace/hook-express.js',
       module: null,
-      hook: null
+      hook: null,
+      version: null
     }
   },
   'hapi': {
@@ -44,7 +45,8 @@ var toInstrument = Object.create(null, {
     value: {
       file: './userspace/hook-hapi.js',
       module: null,
-      hook: null
+      hook: null,
+      version: null
     }
   },
   'http': {
@@ -52,7 +54,8 @@ var toInstrument = Object.create(null, {
     value: {
       file: './core/hook-http.js',
       module: null,
-      hook: null
+      hook: null,
+      version: null
     }
   },
   'mongodb-core': {
@@ -60,7 +63,8 @@ var toInstrument = Object.create(null, {
     value: {
       file: './userspace/hook-mongodb-core.js',
       module: null,
-      hook: null
+      hook: null,
+      version: null
     }
   },
   'redis': {
@@ -68,7 +72,8 @@ var toInstrument = Object.create(null, {
     value: {
       file: './userspace/hook-redis.js',
       module: null,
-      hook: null
+      hook: null,
+      version: null
     }
   },
   'restify': {
@@ -76,10 +81,26 @@ var toInstrument = Object.create(null, {
     value: {
       file: './userspace/hook-restify.js',
       module: null,
-      hook: null
+      hook: null,
+      version: null
     }
   }
 });
+
+function findModuleVersion(request, parent, load) {
+  var mainScriptDir = path.dirname(require.resolve(request));
+  var resolvedModule = Module._resolveLookupPaths(request, parent);
+  var paths = resolvedModule[1];
+  for (var i = 0, PL = paths.length; i < PL; i++) {
+    if (mainScriptDir.indexOf(paths[i]) === 0) {
+      // This is unsafe on windows if request contains a namespace
+      // TODO: convert path separators in request
+      var pjson = load(path.join(paths[i], request, 'package.json'));
+      return pjson.version;
+    }
+  }
+  return null;
+}
 
 function activate(agent) {
 
@@ -90,7 +111,7 @@ function activate(agent) {
     // Load the hook. This file, i.e. index.js, becomes the parent module.
     var moduleHook = loadFn(instrumentation.file, module, false);
     instrumentation.hook = moduleHook;
-    moduleHook.patch(instrumentation.module, agent);
+    moduleHook.patch(instrumentation.module, agent, instrumentation.version);
   }
 
   // hook into Module._load so that we can hook into userspace frameworks
@@ -116,6 +137,8 @@ function activate(agent) {
         if (instrumentation && agent.config().excludedHooks &&
             agent.config().excludedHooks.indexOf(request) === -1 &&
             !instrumentation.hook) { // not already patched.
+          instrumentation.version = findModuleVersion(request, arguments[1],
+              originalModuleLoad);
           instrumentation.module = loaded;
           loadHookAndPatch(originalModuleLoad, instrumentation);
         }
@@ -142,7 +165,8 @@ function deactivate() {
 
 module.exports = {
   activate: activate,
-  deactivate: deactivate
+  deactivate: deactivate,
+  findModuleVersion: findModuleVersion
 };
 
 

--- a/lib/hooks/userspace/hook-express.js
+++ b/lib/hooks/userspace/hook-express.js
@@ -19,11 +19,14 @@
 var cls = require('../../cls.js');
 var TraceLabels = require('../../trace-labels.js');
 var shimmer = require('shimmer');
+var semver = require('semver');
 var patchedMethods = require('methods');
 patchedMethods.push('use', 'route', 'param', 'all');
 var constants = require('../../constants.js');
 var agent;
 var express;
+
+var SUPPORTED_VERSIONS = '4.13.x';
 
 function applicationActionWrap(method) {
   return function expressActionTrace() {
@@ -101,12 +104,8 @@ function endRootSpanForRequest(rootContext, req, res) {
 }
 
 module.exports = {
-  patch: function(express_, agent_) {
-    // We only support express v4. In the past express exported a version property
-    // that would have been great for this purpose, but v3.x removed it. Instead
-    // we rely on 'createServer' export that was removed in v4.
-    // See: https://github.com/strongloop/express/wiki/Migrating-from-3.x-to-4.x
-    if (typeof module.createServer !== 'undefined') {
+  patch: function(express_, agent_, version_) {
+    if (!semver.satisfies(version_, SUPPORTED_VERSIONS)) {
       return;
     }
     if (!express) {

--- a/lib/hooks/userspace/hook-hapi.js
+++ b/lib/hooks/userspace/hook-hapi.js
@@ -19,9 +19,12 @@
 var cls = require('../../cls.js');
 var TraceLabels = require('../../trace-labels.js');
 var shimmer = require('shimmer');
+var semver = require('semver');
 var constants = require('../../constants.js');
 var agent;
 var hapi;
+
+var SUPPORTED_VERSIONS = '8.8.x';
 
 function connectionWrap(connection) {
   return function connectionTrace() {
@@ -100,8 +103,10 @@ function endRootSpanForRequest(rootContext, req, res) {
 }
 
 module.exports = {
-  patch: function(hapi_, agent_) {
-    // TODO(mattloring): version check
+  patch: function(hapi_, agent_, version_) {
+    if (!semver.satisfies(version_, SUPPORTED_VERSIONS)) {
+      return;
+    }
     if (!hapi) {
       agent = agent_;
       hapi = hapi_;

--- a/lib/hooks/userspace/hook-mongodb-core.js
+++ b/lib/hooks/userspace/hook-mongodb-core.js
@@ -18,8 +18,11 @@
 
 var cls = require('../../cls.js');
 var shimmer = require('shimmer');
+var semver = require('semver');
 var agent;
 var mongo;
+
+var SUPPORTED_VERSIONS = '1.2.x';
 
 function nextWrap(next) {
   return function next_trace(cb) {
@@ -64,8 +67,10 @@ function wrapCallback(span, done) {
 }
 
 module.exports = {
-  patch: function(mongo_, agent_) {
-    //TODO(mattloring): version check
+  patch: function(mongo_, agent_, version_) {
+    if (!semver.satisfies(version_, SUPPORTED_VERSIONS)) {
+      return;
+    }
     if (!mongo) {
       agent = agent_;
       mongo = mongo_;

--- a/lib/hooks/userspace/hook-redis.js
+++ b/lib/hooks/userspace/hook-redis.js
@@ -18,8 +18,11 @@
 
 var cls = require('../../cls.js');
 var shimmer = require('shimmer');
+var semver = require('semver');
 var agent;
 var redis;
+
+var SUPPORTED_VERSIONS = '0.12.x';
 
 function createClientWrap(createClient) {
   return function createClientTrace() {
@@ -63,8 +66,10 @@ function wrapCallback(span, done) {
 }
 
 module.exports = {
-  patch: function(redis_, agent_) {
-    // TODO(mattloring): version check
+  patch: function(redis_, agent_, version_) {
+    if (!semver.satisfies(version_, SUPPORTED_VERSIONS)) {
+      return;
+    }
     if (!redis) {
       agent = agent_;
       redis = redis_;

--- a/lib/hooks/userspace/hook-restify.js
+++ b/lib/hooks/userspace/hook-restify.js
@@ -19,9 +19,12 @@
 var cls = require('../../cls.js');
 var TraceLabels = require('../../trace-labels.js');
 var shimmer = require('shimmer');
+var semver = require('semver');
 var constants = require('../../constants.js');
 var agent;
 var restify;
+
+var SUPPORTED_VERSIONS = '3.0.x';
 
 // restify.createServer
 function createServerWrap(createServer) {
@@ -98,8 +101,10 @@ function endRootSpanForRequest(rootContext, req, res) {
 }
 
 module.exports = {
-  patch: function(restify_, agent_) {
-    // TODO(mattloring): version check
+  patch: function(restify_, agent_, version_) {
+    if (!semver.satisfies(version_, SUPPORTED_VERSIONS)) {
+      return;
+    }
     if (!restify) {
       agent = agent_;
       restify = restify_;

--- a/test/hooks/test-hooks-index.js
+++ b/test/hooks/test-hooks-index.js
@@ -1,0 +1,39 @@
+/**
+ * Copyright 2015 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+
+var assert = require('assert');
+var Module = require('module');
+var findModuleVersion = require('../../lib/hooks/index.js').findModuleVersion;
+
+describe('findModuleVersion', function() {
+  it('should correctly find package.json for userspace packages', function() {
+    assert.equal(findModuleVersion('express', module, Module._load), '4.13.3');
+    assert.equal(findModuleVersion('hapi', module, Module._load), '8.8.1');
+    assert.equal(findModuleVersion('mongodb-core', module, Module._load), '1.2.14');
+    assert.equal(findModuleVersion('redis', module, Module._load), '0.12.1');
+    assert.equal(findModuleVersion('restify', module, Module._load), '3.0.3');
+  });
+
+  it('should not break for core packages', function() {
+    assert(!findModuleVersion('http', module, Module._load));
+  });
+
+  it('should work with namespaces', function() {
+    assert.equal(findModuleVersion(
+        '@google/cloud-diagnostics-common', module, Module._load), '0.2.0');
+  });
+});


### PR DESCRIPTION
This patch uses module internals to load the package.json file
associated with required modules and uses them to determine module
versions instead of checking for the presence of non-public facing
api functions.

Fixes #24.