### PR TITLE
Resolve all module scripts correctly

### DIFF
--- a/lib/hooks/index.js
+++ b/lib/hooks/index.js
@@ -88,7 +88,7 @@ var toInstrument = Object.create(null, {
 });
 
 function findModuleVersion(request, parent, load) {
-  var mainScriptDir = path.dirname(require.resolve(request));
+  var mainScriptDir = path.dirname(Module._resolveFilename(request, parent));
   var resolvedModule = Module._resolveLookupPaths(request, parent);
   var paths = resolvedModule[1];
   for (var i = 0, PL = paths.length; i < PL; i++) {


### PR DESCRIPTION
The module file finder is able to search with respect to a
provided parent module allowing us to find modules that are
not in the load path of the primary application module.

Fixes #82