### PR TITLE
Relaxed required version checks to major version only

### DIFF
--- a/lib/hooks/userspace/hook-express.js
+++ b/lib/hooks/userspace/hook-express.js
@@ -26,7 +26,7 @@ var constants = require('../../constants.js');
 var agent;
 var express;
 
-var SUPPORTED_VERSIONS = '4.13.x';
+var SUPPORTED_VERSIONS = '4.x';
 
 function applicationActionWrap(method) {
   return function expressActionTrace() {

--- a/lib/hooks/userspace/hook-hapi.js
+++ b/lib/hooks/userspace/hook-hapi.js
@@ -24,7 +24,7 @@ var constants = require('../../constants.js');
 var agent;
 var hapi;
 
-var SUPPORTED_VERSIONS = '8.8.x';
+var SUPPORTED_VERSIONS = '8.x';
 
 function connectionWrap(connection) {
   return function connectionTrace() {

--- a/lib/hooks/userspace/hook-mongodb-core.js
+++ b/lib/hooks/userspace/hook-mongodb-core.js
@@ -22,7 +22,7 @@ var semver = require('semver');
 var agent;
 var mongo;
 
-var SUPPORTED_VERSIONS = '1.2.x';
+var SUPPORTED_VERSIONS = '1.x';
 
 function nextWrap(next) {
   return function next_trace(cb) {

--- a/lib/hooks/userspace/hook-restify.js
+++ b/lib/hooks/userspace/hook-restify.js
@@ -24,7 +24,7 @@ var constants = require('../../constants.js');
 var agent;
 var restify;
 
-var SUPPORTED_VERSIONS = '3.0.x';
+var SUPPORTED_VERSIONS = '3.x';
 
 // restify.createServer
 function createServerWrap(createServer) {


### PR DESCRIPTION
Since Redis is still in 0.x, I'm leaving minor version requirement there as there could be breaking changes on minor differences.