### PR TITLE
Enable trace throttling

### DIFF
--- a/config.js
+++ b/config.js
@@ -34,6 +34,12 @@ module.exports = {
   // See `bufferSize`.
   flushDelaySeconds: 30,
 
+  // If false, traces will be published as soon as `bufferSize` traces have
+  // been collected if this occurs before `flushDelaySeconds`.
+  // If true, traces will flush every `flushDelaySeconds` and additional
+  // traces beyond `bufferSize` will be dropped.
+  samplingEnabled: false,
+
   // The number of transactions we buffer before we publish to the Cloud Trace
   // API, unless we hit `flushDelaySeconds` first.
   bufferSize: 1000

--- a/lib/trace-writer.js
+++ b/lib/trace-writer.js
@@ -86,12 +86,16 @@ TraceWriter.prototype.queueTrace_ = function(trace) {
     }
 
     trace.projectId = project;
-    var length = that.buffer_.push(JSON.stringify(trace));
 
-    that.logger_.info('queued trace. new size:', length);
+    if (that.buffer_.length <= that.config_.bufferSize) {
+      that.buffer_.push(JSON.stringify(trace));
+      that.logger_.debug('queued trace. new size:', that.buffer_.length);
+    }
 
-    // Publish soon if the buffer is getting big
-    if (length >= that.config_.bufferLimit) {
+    // Publish soon if the buffer is getting big and
+    // samplingEnabled is not set
+    if (that.buffer_.length >= that.config_.bufferSize &&
+        !that.config_.samplingEnabled) {
       that.logger_.info('Flushing: buffer full');
       setImmediate(function() { that.flushBuffer_(project); });
     }

--- a/test/standalone/test-trace-writer.js
+++ b/test/standalone/test-trace-writer.js
@@ -51,7 +51,7 @@ describe('tracewriter publishing', function() {
           assert.equal(JSON.stringify(body), JSON.stringify(parsedOriginal));
           return true;
         }).reply(200);
-    var privateAgent = agent.start({bufferLimit: 2}).private_();
+    var privateAgent = agent.start({bufferSize: 2}).private_();
     privateAgent.traceWriter.request_ = request; // Avoid authing
     cls.getNamespace().run(function() {
       queueSpans(2, privateAgent);
@@ -93,7 +93,7 @@ describe('tracewriter publishing', function() {
           assert.equal(JSON.stringify(body), JSON.stringify(parsedOriginal));
           return true;
         }).replyWithError('Simulated Network Error');
-    var privateAgent = agent.start({bufferLimit: 2}).private_();
+    var privateAgent = agent.start({bufferSize: 2}).private_();
     privateAgent.traceWriter.request_ = request; // Avoid authing
     cls.getNamespace().run(function() {
       queueSpans(2, privateAgent);


### PR DESCRIPTION
This also fixes a bug where we were ignoring `bufferSize` in config due to a typo. Arrggg.