### PR TITLE
Patch the mongo connection pool

### DIFF
--- a/lib/hooks/core/hook-http.js
+++ b/lib/hooks/core/hook-http.js
@@ -24,7 +24,6 @@ var url = require('url');
 var shimmer = require('shimmer');
 /** @type {TraceAgent} */
 var agent;
-var http;
 
 // http.request
 function requestWrap(request) {
@@ -114,23 +113,17 @@ function uriFromOptions(options) {
   return uri;
 }
 
-module.exports = {
-  /**
-   * @param {object} http_ Node.js core http module
-   * @param {TraceAgent} agent_
-   */
-  patch: function(http_, agent_) {
-    if (!http) {
-      agent = agent_;
-      http = http_;
-      shimmer.wrap(http, 'request', requestWrap);
+module.exports = function(version_, agent_) {
+  return {
+    'http': {
+      patch: function(http) {
+        agent = agent_;
+        shimmer.wrap(http, 'request', requestWrap);
+      },
+      unpatch: function(http) {
+        shimmer.unwrap(http, 'request');
+        agent = null;
+      }
     }
-  },
-  unpatch: function() {
-    if (http) {
-      shimmer.unwrap(http, 'request');
-      http = null;
-      agent = null;
-    }
-  }
+  };
 };

--- a/lib/hooks/index.js
+++ b/lib/hooks/index.js
@@ -17,7 +17,6 @@
 
 var Module = require('module');
 var shimmer = require('shimmer');
-var assert = require('assert');
 var path = require('path');
 
 //
@@ -29,67 +28,38 @@ var path = require('path');
 //   These are done on-demand via our Module._load wrapper
 // Install a tracer in the global scope.
 
-
+// Patches is a map from module load path to { filename1: { patchFunction: ...,
+// unpatchFunction: ..., module: ..., active: ... }, filename2: ... }
+// Each filename key represents a relative path which will be appended to the
+// absolute path to the root of the module. Leaving this relative path blank
+// will result in the module itself being patched.
+// Note: the order in which filenames are defined in the hooks determines the
+// order in which they are loaded.
 var toInstrument = Object.create(null, {
-  'express': {
-    enumerable: true,
-    value: {
-      file: './userspace/hook-express.js',
-      module: null,
-      hook: null,
-      version: null
-    }
-  },
-  'hapi': {
-    enumerable: true,
-    value: {
-      file: './userspace/hook-hapi.js',
-      module: null,
-      hook: null,
-      version: null
-    }
-  },
-  'http': {
-    enumerable: true,
-    value: {
-      file: './core/hook-http.js',
-      module: null,
-      hook: null,
-      version: null
-    }
-  },
-  'mongodb-core': {
-    enumerable: true,
-    value: {
-      file: './userspace/hook-mongodb-core.js',
-      module: null,
-      hook: null,
-      version: null
-    }
-  },
-  'redis': {
-    enumerable: true,
-    value: {
-      file: './userspace/hook-redis.js',
-      module: null,
-      hook: null,
-      version: null
-    }
-  },
-  'restify': {
-    enumerable: true,
-    value: {
-      file: './userspace/hook-restify.js',
-      module: null,
-      hook: null,
-      version: null
-    }
-  }
+  'express': { enumerable: true, value: { file: './userspace/hook-express.js',
+      patches: {} } },
+  'hapi': { enumerable: true, value: { file: './userspace/hook-hapi.js',
+      patches: {} } },
+  'http': { enumerable: true, value: { file: './core/hook-http.js',
+      patches: {} } },
+  'mongodb-core': { enumerable: true, value: { file: './userspace/hook-mongodb-core.js',
+      patches: {} } },
+  'redis': { enumerable: true, value: { file: './userspace/hook-redis.js',
+      patches: {} } },
+  'restify': { enumerable: true, value: { file: './userspace/hook-restify.js',
+      patches: {} } }
 });
 
 var logger;
 
-function findModuleVersion(request, parent, load) {
+/**
+ * Determines the path at which the requested module will be loaded given
+ * the provided parent module.
+ *
+ * @param {string} request The name of the module to be loaded.
+ * @param {object} parent The module into which the requested module will be loaded.
+ */
+function findModulePath(request, parent) {
   var mainScriptDir = path.dirname(Module._resolveFilename(request, parent));
   var resolvedModule = Module._resolveLookupPaths(request, parent);
   var paths = resolvedModule[1];
@@ -97,25 +67,51 @@ function findModuleVersion(request, parent, load) {
     if (mainScriptDir.indexOf(paths[i]) === 0) {
       // This is unsafe on windows if request contains a namespace
       // TODO: convert path separators in request
-      var pjson = load(path.join(paths[i], request, 'package.json'));
-      return pjson.version;
+      return path.join(paths[i], request);
     }
   }
   return null;
+}
+
+/**
+ * Determines the version of the module located at `modulePath`.
+ *
+ * @param {?string} modulePath The absolute path to the root directory of the
+ *    module being loaded. This may be null if we are loading an internal module
+ *    such as http.
+ */
+function findModuleVersion(modulePath, load) {
+  return modulePath ? load(path.join(modulePath, 'package.json')).version :
+    process.version;
 }
 
 function activate(agent) {
 
   logger = agent.logger;
 
-  function loadHookAndPatch(loadFn, instrumentation) {
-    assert(instrumentation.module);
-    assert(!instrumentation.hook);
+  function loadHookAndPatch(loadFn, instrumentation, moduleRoot, version) {
+    var modulePatch = instrumentation.patches[moduleRoot];
+    if (!modulePatch) {
+      // Load the hook. This file, i.e. index.js, becomes the parent module.
+      var moduleHook = loadFn(instrumentation.file, module, false);
+      modulePatch = moduleHook(version, agent);
+    }
+    Object.keys(modulePatch).forEach(function(file) {
+      if (!modulePatch[file].module) {
+        var loadPath = moduleRoot ? path.join(moduleRoot, file) : file;
+        modulePatch[file].module = loadFn(loadPath, module, false);
+      }
+      modulePatch[file].patch(modulePatch[file].module);
+      modulePatch[file].active = true;
+    });
+    instrumentation.patches[moduleRoot] = modulePatch;
+  }
 
-    // Load the hook. This file, i.e. index.js, becomes the parent module.
-    var moduleHook = loadFn(instrumentation.file, module, false);
-    instrumentation.hook = moduleHook;
-    moduleHook.patch(instrumentation.module, agent, instrumentation.version);
+  function moduleAlreadyPatched(instrumentation, moduleRoot) {
+    var modulePatch = instrumentation.patches[moduleRoot];
+    return modulePatch && Object.keys(modulePatch).every(function(curr) {
+      return modulePatch[curr].active;
+    }, true);
   }
 
   for (var moduleName in toInstrument) {
@@ -136,33 +132,33 @@ function activate(agent) {
     // time that we need to go and patch pro-actively.
     for (var moduleName in toInstrument) {
       var instrumentation = toInstrument[moduleName];
-      if (instrumentation.module) {
-        loadHookAndPatch(originalModuleLoad, instrumentation);
+      for (var moduleRoot in instrumentation.patches) {
+        var modulePatch = instrumentation.patches[moduleRoot];
+        if (modulePatch) {
+          loadHookAndPatch(originalModuleLoad, instrumentation, moduleRoot, null);
+        }
       }
     }
 
     // Future requires get patched as they get loaded.
     return function Module_load() {
       var request = arguments[0];
-      var loaded = originalModuleLoad.apply(this, arguments);
+      var instrumentation = toInstrument[request];
 
-      if (typeof request === 'string') {
-        var instrumentation = toInstrument[request];
-
-        if (instrumentation && agent.config().excludedHooks &&
-            agent.config().excludedHooks.indexOf(request) === -1 &&
-            !instrumentation.hook) { // not already patched.
-          instrumentation.version = findModuleVersion(request, arguments[1],
-              originalModuleLoad);
-          logger.info('Patching ' + request + ' at version ' +
-              instrumentation.version);
-          instrumentation.module = loaded;
-          loadHookAndPatch(originalModuleLoad, instrumentation);
+      if (instrumentation &&
+          agent.config().excludedHooks.indexOf(request) === -1) {
+        var moduleRoot = findModulePath(request, arguments[1]);
+        if (moduleAlreadyPatched(instrumentation, moduleRoot)) {
+          return originalModuleLoad.apply(this, arguments);
         }
+        var moduleVersion = findModuleVersion(moduleRoot, originalModuleLoad);
+        logger.info('Patching ' + request + ' at version ' + moduleVersion);
+        loadHookAndPatch(originalModuleLoad, instrumentation, moduleRoot,
+          moduleVersion);
       }
 
       // no hooks installed. return the original module as-is.
-      return loaded;
+      return originalModuleLoad.apply(this, arguments);
     };
   });
 }
@@ -170,10 +166,14 @@ function activate(agent) {
 function deactivate() {
   for (var moduleName in toInstrument) {
     var instrumentation = toInstrument[moduleName];
-    if (instrumentation.hook) {
-      logger.info('Attempting to unpatch ' + moduleName);
-      instrumentation.hook.unpatch();
-      instrumentation.hook = null;
+    for (var moduleRoot in instrumentation.patches) {
+      var modulePatch = instrumentation.patches[moduleRoot];
+      for (var patchedFile in modulePatch) {
+        var hook = modulePatch[patchedFile];
+        logger.info('Attempting to unpatch ' + moduleName);
+        hook.unpatch(hook.module);
+        hook.active = false;
+      }
     }
   }
 
@@ -184,6 +184,7 @@ function deactivate() {
 module.exports = {
   activate: activate,
   deactivate: deactivate,
+  findModulePath: findModulePath,
   findModuleVersion: findModuleVersion
 };
 

--- a/lib/hooks/userspace/hook-express.js
+++ b/lib/hooks/userspace/hook-express.js
@@ -24,7 +24,6 @@ var patchedMethods = require('methods');
 patchedMethods.push('use', 'route', 'param', 'all');
 var constants = require('../../constants.js');
 var agent;
-var express;
 
 var SUPPORTED_VERSIONS = '4.x';
 
@@ -106,28 +105,27 @@ function endRootSpanForRequest(rootContext, req, res) {
   rootContext.close();
 }
 
-module.exports = {
-  patch: function(express_, agent_, version_) {
-    if (!semver.satisfies(version_, SUPPORTED_VERSIONS)) {
-      agent_.logger.info('Express: unsupported version ' + version_ + ' loaded');
-      return;
-    }
-    if (!express) {
-      agent = agent_;
-      express = express_;
-      patchedMethods.forEach(function(method) {
-        shimmer.wrap(express.application, method, applicationActionWrap);
-      });
-    }
-  },
-  unpatch: function() {
-    if (express) {
-      patchedMethods.forEach(function(method) {
-        shimmer.unwrap(express.application, method);
-      });
-      agent.logger.info('Express: unpatched');
-      express = null;
-      agent = null;
-    }
+module.exports = function(version_, agent_) {
+  if (!semver.satisfies(version_, SUPPORTED_VERSIONS)) {
+    agent_.logger.info('Express: unsupported version ' + version_ + ' loaded');
+    return {};
   }
+  return {
+    // An empty relative path here matches the root module being loaded.
+    '': {
+      patch: function(express) {
+        agent = agent_;
+        patchedMethods.forEach(function(method) {
+          shimmer.wrap(express.application, method, applicationActionWrap);
+        });
+      },
+      unpatch: function(express) {
+        patchedMethods.forEach(function(method) {
+          shimmer.unwrap(express.application, method);
+        });
+        agent.logger.info('Express: unpatched');
+        agent = null;
+      }
+    }
+  };
 };

--- a/lib/hooks/userspace/hook-hapi.js
+++ b/lib/hooks/userspace/hook-hapi.js
@@ -22,7 +22,6 @@ var shimmer = require('shimmer');
 var semver = require('semver');
 var constants = require('../../constants.js');
 var agent;
-var hapi;
 
 var SUPPORTED_VERSIONS = '8.x';
 
@@ -105,24 +104,23 @@ function endRootSpanForRequest(rootContext, req, res) {
   rootContext.close();
 }
 
-module.exports = {
-  patch: function(hapi_, agent_, version_) {
-    if (!semver.satisfies(version_, SUPPORTED_VERSIONS)) {
-      agent_.logger.info('Hapi: unsupported version ' + version_ + ' loaded');
-      return;
-    }
-    if (!hapi) {
-      agent = agent_;
-      hapi = hapi_;
-      shimmer.wrap(hapi.Server.prototype, 'connection', connectionWrap);
-    }
-  },
-  unpatch: function() {
-    if (hapi) {
-      shimmer.unwrap(hapi.Server.prototype, 'connection');
-      agent.logger.info('Hapi: unpatched');
-      hapi = null;
-      agent = null;
-    }
+module.exports = function(version_, agent_) {
+  if (!semver.satisfies(version_, SUPPORTED_VERSIONS)) {
+    agent_.logger.info('Hapi: unsupported version ' + version_ + ' loaded');
+    return {};
   }
+  return {
+    // An empty relative path here matches the root module being loaded.
+    '': {
+      patch: function(hapi) {
+        agent = agent_;
+        shimmer.wrap(hapi.Server.prototype, 'connection', connectionWrap);
+      },
+      unpatch: function(hapi) {
+        shimmer.unwrap(hapi.Server.prototype, 'connection');
+        agent.logger.info('Hapi: unpatched');
+        agent = null;
+      }
+    }
+  };
 };

--- a/lib/hooks/userspace/hook-mongodb-core.js
+++ b/lib/hooks/userspace/hook-mongodb-core.js
@@ -20,7 +20,6 @@ var cls = require('../../cls.js');
 var shimmer = require('shimmer');
 var semver = require('semver');
 var agent;
-var mongo;
 
 var SUPPORTED_VERSIONS = '1.x';
 
@@ -66,32 +65,46 @@ function wrapCallback(span, done) {
   return cls.getNamespace().bind(fn);
 }
 
-module.exports = {
-  patch: function(mongo_, agent_, version_) {
-    if (!semver.satisfies(version_, SUPPORTED_VERSIONS)) {
-      agent_.logger.info('Mongo: unsupported version ' + version_ + ' loaded');
-      return;
-    }
-    if (!mongo) {
-      agent = agent_;
-      mongo = mongo_;
-      shimmer.wrap(mongo.Server.prototype, 'command', wrapWithLabel('mongo-command'));
-      shimmer.wrap(mongo.Server.prototype, 'insert', wrapWithLabel('mongo-insert'));
-      shimmer.wrap(mongo.Server.prototype, 'update', wrapWithLabel('mongo-update'));
-      shimmer.wrap(mongo.Server.prototype, 'remove', wrapWithLabel('mongo-remove'));
-      shimmer.wrap(mongo.Cursor.prototype, 'next', nextWrap);
-    }
-  },
-  unpatch: function() {
-    if (mongo) {
-      shimmer.unwrap(mongo.Server.prototype, 'command');
-      shimmer.unwrap(mongo.Server.prototype, 'insert');
-      shimmer.unwrap(mongo.Server.prototype, 'update');
-      shimmer.unwrap(mongo.Server.prototype, 'remove');
-      shimmer.unwrap(mongo.Cursor.prototype, 'next');
-      agent.logger.info('Mongo: unpatched');
-      mongo = null;
-      agent = null;
-    }
+function onceWrap(once) {
+  return function once_trace(event, cb) {
+    return once.call(this, event, cls.getNamespace().bind(cb));
+  };
+}
+
+module.exports = function(version_, agent_) {
+  if (!semver.satisfies(version_, SUPPORTED_VERSIONS)) {
+    agent_.logger.info('Mongo: unsupported version ' + version_ + ' loaded');
+    return {};
   }
+  return {
+    'lib/connection/pool.js': {
+      patch: function(pool) {
+        shimmer.wrap(pool.prototype, 'once', onceWrap);
+      },
+      unpatch: function(pool) {
+        shimmer.unwrap(pool.prototype, 'once');
+        agent.logger.info('Mongo connection pool: unpatched');
+      }
+    },
+    // An empty relative path here matches the root module being loaded.
+    '': {
+      patch: function(mongo) {
+        agent = agent_;
+        shimmer.wrap(mongo.Server.prototype, 'command', wrapWithLabel('mongo-command'));
+        shimmer.wrap(mongo.Server.prototype, 'insert', wrapWithLabel('mongo-insert'));
+        shimmer.wrap(mongo.Server.prototype, 'update', wrapWithLabel('mongo-update'));
+        shimmer.wrap(mongo.Server.prototype, 'remove', wrapWithLabel('mongo-remove'));
+        shimmer.wrap(mongo.Cursor.prototype, 'next', nextWrap);
+      },
+      unpatch: function(mongo) {
+        shimmer.unwrap(mongo.Server.prototype, 'command');
+        shimmer.unwrap(mongo.Server.prototype, 'insert');
+        shimmer.unwrap(mongo.Server.prototype, 'update');
+        shimmer.unwrap(mongo.Server.prototype, 'remove');
+        shimmer.unwrap(mongo.Cursor.prototype, 'next');
+        agent.logger.info('Mongo: unpatched');
+        agent = null;
+      }
+    }
+  };
 };

--- a/lib/hooks/userspace/hook-redis.js
+++ b/lib/hooks/userspace/hook-redis.js
@@ -20,7 +20,6 @@ var cls = require('../../cls.js');
 var shimmer = require('shimmer');
 var semver = require('semver');
 var agent;
-var redis;
 
 var SUPPORTED_VERSIONS = '0.12.x';
 
@@ -64,26 +63,25 @@ function wrapCallback(span, done) {
   return cls.getNamespace().bind(fn);
 }
 
-module.exports = {
-  patch: function(redis_, agent_, version_) {
-    if (!semver.satisfies(version_, SUPPORTED_VERSIONS)) {
-      agent_.logger.info('Redis: unsupported version ' + version_ + ' loaded');
-      return;
-    }
-    if (!redis) {
-      agent = agent_;
-      redis = redis_;
-      shimmer.wrap(redis.RedisClient.prototype, 'send_command', sendCommandWrap);
-      shimmer.wrap(redis, 'createClient', createClientWrap);
-    }
-  },
-  unpatch: function() {
-    if (redis) {
-      shimmer.unwrap(redis.RedisClient.prototype, 'send_command');
-      shimmer.unwrap(redis, 'createClient');
-      agent.logger.info('Redis: unpatched');
-      redis = null;
-      agent = null;
-    }
+module.exports = function(version_, agent_) {
+  if (!semver.satisfies(version_, SUPPORTED_VERSIONS)) {
+    agent_.logger.info('Redis: unsupported version ' + version_ + ' loaded');
+    return {};
   }
+  return {
+    // An empty relative path here matches the root module being loaded.
+    '': {
+      patch: function(redis) {
+        agent = agent_;
+        shimmer.wrap(redis.RedisClient.prototype, 'send_command', sendCommandWrap);
+        shimmer.wrap(redis, 'createClient', createClientWrap);
+      },
+      unpatch: function(redis) {
+        shimmer.unwrap(redis.RedisClient.prototype, 'send_command');
+        shimmer.unwrap(redis, 'createClient');
+        agent.logger.info('Redis: unpatched');
+        agent = null;
+      }
+    }
+  };
 };

--- a/lib/hooks/userspace/hook-restify.js
+++ b/lib/hooks/userspace/hook-restify.js
@@ -22,7 +22,6 @@ var shimmer = require('shimmer');
 var semver = require('semver');
 var constants = require('../../constants.js');
 var agent;
-var restify;
 
 var SUPPORTED_VERSIONS = '3.x';
 
@@ -103,24 +102,23 @@ function endRootSpanForRequest(rootContext, req, res) {
   rootContext.close();
 }
 
-module.exports = {
-  patch: function(restify_, agent_, version_) {
-    if (!semver.satisfies(version_, SUPPORTED_VERSIONS)) {
-      agent_.logger.info('Restify: unsupported version ' + version_ + ' loaded');
-      return;
-    }
-    if (!restify) {
-      agent = agent_;
-      restify = restify_;
-      shimmer.wrap(restify, 'createServer', createServerWrap);
-    }
-  },
-  unpatch: function() {
-    if (restify) {
-      shimmer.unwrap(restify, 'createServer');
-      agent.logger.info('Restify: unpatched');
-      restify = null;
-      agent = null;
-    }
+module.exports = function(version_, agent_) {
+  if (!semver.satisfies(version_, SUPPORTED_VERSIONS)) {
+    agent_.logger.info('Restify: unsupported version ' + version_ + ' loaded');
+    return {};
   }
+  return {
+    // An empty relative path here matches the root module being loaded.
+    '': {
+      patch: function(restify) {
+        agent = agent_;
+        shimmer.wrap(restify, 'createServer', createServerWrap);
+      },
+      unpatch: function(restify) {
+        shimmer.unwrap(restify, 'createServer');
+        agent.logger.info('Restify: unpatched');
+        agent = null;
+      }
+    }
+  };
 };

--- a/test/hooks/test-hooks-index.js
+++ b/test/hooks/test-hooks-index.js
@@ -18,21 +18,25 @@
 var assert = require('assert');
 var Module = require('module');
 var semver = require('semver');
-var findModuleVersion = require('../../lib/hooks/index.js').findModuleVersion;
+var index = require('../../lib/hooks/index.js');
+var findModulePath = index.findModulePath;
+var findModuleVersion = index.findModuleVersion;
 
 describe('findModuleVersion', function() {
   it('should correctly find package.json for userspace packages', function() {
     var pjson = require('../../package.json');
-    assert(semver.satisfies(findModuleVersion('glob', module, Module._load),
+    var modulePath = findModulePath('glob', module);
+    assert(semver.satisfies(findModuleVersion(modulePath, Module._load),
         pjson.devDependencies.glob));
   });
 
   it('should not break for core packages', function() {
-    assert(!findModuleVersion('http', module, Module._load));
+    var modulePath = findModulePath('http', module);
+    assert.equal(findModuleVersion(modulePath, Module._load), process.version);
   });
 
   it('should work with namespaces', function() {
-    assert.equal(findModuleVersion(
-        '@google/cloud-diagnostics-common', module, Module._load), '0.2.0');
+    var modulePath = findModulePath('@google/cloud-diagnostics-common', module);
+    assert.equal(findModuleVersion(modulePath, Module._load), '0.2.0');
   });
 });

--- a/test/hooks/test-hooks-interop-mongo-express.js
+++ b/test/hooks/test-hooks-interop-mongo-express.js
@@ -1,0 +1,58 @@
+/**
+ * Copyright 2015 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+
+// Prereqs:
+// Start docker daemon
+//   ex) docker -d
+// Run a mongo image binding the mongo port
+//   ex) docker run -p 27017:27017 -d mongo
+var common = require('./common.js');
+
+var assert = require('assert');
+var express = require('./fixtures/express4');
+var http = require('http');
+var mongoose = require('./fixtures/mongoose4');
+var agent = require('../..').get().private_();
+var oldWarn = agent.logger.warn;
+agent.logger.warn = function(error) {
+  assert(error.indexOf('mongo') === -1, error);
+};
+
+var server;
+
+describe('mongodb + express', function() {
+  it('should not lose context on startup', function(done) {
+    var app = express();
+    app.get('/', function (req, res) {
+      mongoose.connect('mongodb://localhost:27017/testdb', function(err) {
+        assert(!err, 'Skipping: no mongo server found at localhost:27017.');
+        mongoose.connection.close(function(err) {
+          assert(!err);
+          res.sendStatus(200);
+        });
+      });
+    });
+    server = app.listen(common.serverPort, function() {
+      http.get({port: common.serverPort}, function(res) {
+        server.close();
+        common.cleanTraces();
+        agent.logger.warn = oldWarn;
+        done();
+      });
+    });
+  });
+});


### PR DESCRIPTION
ismaster checks occuring on behalf of incoming requests were escaping. By binding listeners on the connection pool event emitter to the current cls context, we can correctly attribute the work that they do.

Fixes #96