### PR TITLE
Possible to omit all traces at specified urls

### DIFF
--- a/config.js
+++ b/config.js
@@ -34,6 +34,14 @@ module.exports = {
   // See `bufferSize`.
   flushDelaySeconds: 30,
 
+  // If paths are present in this array, then these paths will be ignored before
+  // `samplingRate` based decisions are made. Paths must include a leading
+  // forward slash and be of the form:
+  //   /componentOne/componentTwo/...
+  // Paths can additionally be classified by regex in which case any path matching
+  // any provided regex will be ignored.
+  ignoreUrls: [],
+
   // An upper bound on the number of traces to gather each second. If set to
   // -1, all traces will be reported. Sampling rates greater than 1000 are not
   // supported and will result in at most 1000 samples per second.

--- a/lib/trace-agent.js
+++ b/lib/trace-agent.js
@@ -162,7 +162,7 @@ TraceAgent.prototype.addTransactionLabel = function(key, value) {
  */
 TraceAgent.prototype.createRootSpanData = function(name, traceId, parentId) {
   var spanStart = new Date();
-  if (!this.policy.shouldTrace(spanStart.getTime())) {
+  if (!this.policy.shouldTrace(spanStart.getTime(), name)) {
     return SpanData.nullSpan();
   }
   traceId = traceId || (uuid.v4().split('-').join(''));

--- a/lib/tracing-policy.js
+++ b/lib/tracing-policy.js
@@ -35,16 +35,47 @@ RateLimiterPolicy.prototype.shouldTrace = function(dateMillis) {
   return true;
 };
 
+function FilterPolicy(basePolicy, filterUrls) {
+  this.basePolicy = basePolicy;
+  this.filterUrls = filterUrls;
+}
+
+FilterPolicy.prototype.matches = function(url) {
+  for (var i = 0; i < this.filterUrls.length; i++) {
+    var candidate = this.filterUrls[i];
+    if (typeof candidate === 'string') {
+      if (candidate === url) {
+        return true;
+      }
+    } else {
+      if (url.match(candidate)) {
+        return true;
+      }
+    }
+  }
+  return false;
+};
+
+FilterPolicy.prototype.shouldTrace = function(dataMillis, url) {
+  return !this.matches(url) && this.basePolicy.shouldTrace(dataMillis, url);
+};
+
 function TraceAllPolicy() {}
 
 TraceAllPolicy.prototype.shouldTrace = function() { return true; };
 
 module.exports = {
   createTracePolicy: function(config) {
+    var basePolicy;
     if (config.samplingRate < 0) {
-      return new TraceAllPolicy();
+      basePolicy = new TraceAllPolicy();
     } else {
-      return new RateLimiterPolicy(config.samplingRate);
+      basePolicy = new RateLimiterPolicy(config.samplingRate);
+    }
+    if (config.ignoreUrls && config.ignoreUrls.length > 0) {
+      return new FilterPolicy(basePolicy, config.ignoreUrls);
+    } else {
+      return basePolicy;
     }
   }
 };

--- a/test/test-trace-policy.js
+++ b/test/test-trace-policy.js
@@ -19,6 +19,21 @@
 var assert = require('assert');
 var tracingPolicy = require('../lib/tracing-policy.js');
 
+describe('FilterPolicy', function() {
+  it('should not allow filtered urls', function() {
+    var policy = tracingPolicy.createTracePolicy({samplingRate: -1,
+      ignoreUrls: ['/_ah/health', /\/book*/]});
+    assert(!policy.shouldTrace(null, '/_ah/health'));
+    assert(!policy.shouldTrace(null, '/book/test'));
+  });
+
+  it('should allow non-filtered urls', function() {
+    var policy = tracingPolicy.createTracePolicy({samplingRate: -1,
+      ignoreUrls: ['/_ah/health']});
+    assert(policy.shouldTrace(null, '/_ah/background'));
+  });
+});
+
 describe('RateLimiterPolicy', function() {
   var tracesPerSecond = [10, 50, 150, 200, 500, 1000];
   tracesPerSecond.forEach(function(traceCount) {


### PR DESCRIPTION
Introduced a new tracing policy that ignores all traces occuring at
designated paths before sampling occurs to prevent ignored urls from
being sampled.

Fixes #103.