### PR TITLE
Run redis v2 against unit tests

### DIFF
--- a/lib/hooks/userspace/hook-redis.js
+++ b/lib/hooks/userspace/hook-redis.js
@@ -21,7 +21,7 @@ var shimmer = require('shimmer');
 var semver = require('semver');
 var agent;
 
-var SUPPORTED_VERSIONS = '0.12.x';
+var SUPPORTED_VERSIONS = '<=2.2.x';
 
 function createClientWrap(createClient) {
   return function createClientTrace() {

--- a/test/hooks/fixtures/redis2/index.js
+++ b/test/hooks/fixtures/redis2/index.js
@@ -1,0 +1,1 @@
+module.exports = require('redis');

--- a/test/hooks/fixtures/redis2/package.json
+++ b/test/hooks/fixtures/redis2/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "redis2",
+  "version": "1.0.0",
+  "main": "index.js",
+  "dependencies": {
+    "redis": "^2.2.5"
+  }
+}

--- a/test/hooks/test-hooks-index.js
+++ b/test/hooks/test-hooks-index.js
@@ -37,6 +37,8 @@ describe('findModuleVersion', function() {
 
   it('should work with namespaces', function() {
     var modulePath = findModulePath('@google/cloud-diagnostics-common', module);
-    assert.equal(findModuleVersion(modulePath, Module._load), '0.2.1');
+    var truePackage =
+      require('../../node_modules/@google/cloud-diagnostics-common/package.json');
+    assert.equal(findModuleVersion(modulePath, Module._load), truePackage.version);
   });
 });


### PR DESCRIPTION
This also tests the patching of multiple versions of a module
simultaneously. Also, removed a test that was not testing
agent functionality (just a property of redis).

Fixes #92.