### PR TITLE
Support for Redis 2.3

### DIFF
--- a/lib/hooks/index.js
+++ b/lib/hooks/index.js
@@ -116,7 +116,6 @@ function activate(agent) {
         var moduleHook = originalModuleLoad(instrumentation.file, module, false);
         modulePatch = moduleHook(version, agent);
       }
-      var loadedModule; // The final module loaded.
       Object.keys(modulePatch).forEach(function(file) {
         if (!modulePatch[file].module) {
           var loadPath = moduleRoot ? path.join(moduleRoot, file) : file;
@@ -124,10 +123,8 @@ function activate(agent) {
         }
         modulePatch[file].patch(modulePatch[file].module);
         modulePatch[file].active = true;
-        loadedModule = modulePatch[file].module;
       });
       instrumentation.patches[moduleRoot] = modulePatch;
-      return loadedModule;
     }
 
     function moduleAlreadyPatched(instrumentation, moduleRoot) {
@@ -161,7 +158,7 @@ function activate(agent) {
         }
         var moduleVersion = findModuleVersion(moduleRoot, originalModuleLoad);
         logger.info('Patching ' + request + ' at version ' + moduleVersion);
-        return loadAndPatch(instrumentation, moduleRoot,
+        loadAndPatch(instrumentation, moduleRoot,
           moduleVersion);
       }
 

--- a/lib/hooks/userspace/hook-redis.js
+++ b/lib/hooks/userspace/hook-redis.js
@@ -21,7 +21,7 @@ var shimmer = require('shimmer');
 var semver = require('semver');
 var agent;
 
-var SUPPORTED_VERSIONS = '<=2.2.x';
+var SUPPORTED_VERSIONS = '<=2.x';
 
 function createClientWrap(createClient) {
   return function createClientTrace() {

--- a/test/hooks/fixtures/redis2/package.json
+++ b/test/hooks/fixtures/redis2/package.json
@@ -3,6 +3,6 @@
   "version": "1.0.0",
   "main": "index.js",
   "dependencies": {
-    "redis": "2.2.5"
+    "redis": "^2.2.5"
   }
 }


### PR DESCRIPTION
This fix should allow us to pick up future versions of redis on the 2.x
line.

Fixes #123