### PR TITLE
No more warnings when root spans are sampled

### DIFF
--- a/lib/cls.js
+++ b/lib/cls.js
@@ -46,16 +46,14 @@ module.exports = {
     // patched closures escaped before the agent was stopped and the
     // namespace was destroyed. There should be a cleaner way to
     // avoid this (only collect traces once we have a project num)
-    if (getNamespace() && getNamespace().get('spanStack')) {
-      return getNamespace().get('spanStack')[0];
+    if (getNamespace() && getNamespace().get('root')) {
+      return getNamespace().get('root');
     }
     return null;
   },
 
   setRootContext: function setRootContext(rootContext) {
-    var stack = [];
-    stack.push(rootContext);
-    getNamespace().set('spanStack', stack);
+    getNamespace().set('root', rootContext);
   }
 };
 

--- a/lib/hooks/core/hook-http.js
+++ b/lib/hooks/core/hook-http.js
@@ -20,6 +20,7 @@
 var httpAgent = require('_http_agent');
 var cls = require('../../cls.js');
 var TraceLabels = require('../../trace-labels.js');
+var SpanData = require('../../span-data.js');
 var url = require('url');
 var shimmer = require('shimmer');
 /** @type {TraceAgent} */
@@ -43,9 +44,13 @@ function requestWrap(request) {
       return request.apply(this, arguments);
     }
 
-    if (!cls.getRootContext()) {
+    var root = cls.getRootContext();
+
+    if (!root) {
       agent.logger.warn(
         'Cannot trace outbound http requests outside of a supported http framework.');
+      return request.apply(this, arguments);
+    } else if (root === SpanData.nullSpan) {
       return request.apply(this, arguments);
     }
 

--- a/lib/hooks/userspace/hook-mongodb-core.js
+++ b/lib/hooks/userspace/hook-mongodb-core.js
@@ -19,6 +19,7 @@
 var cls = require('../../cls.js');
 var shimmer = require('shimmer');
 var semver = require('semver');
+var SpanData = require('../../span-data.js');
 var agent;
 
 var SUPPORTED_VERSIONS = '1.x';
@@ -28,6 +29,8 @@ function nextWrap(next) {
     var root = cls.getRootContext();
     if (!root) {
       agent.logger.warn('Cannot trace mongo outside of a supported framework.');
+      return next.apply(this, arguments);
+    } else if (root === SpanData.nullSpan) {
       return next.apply(this, arguments);
     }
     var span = agent.startSpan('mongo-cursor', { db: this.ns });
@@ -41,6 +44,8 @@ function wrapWithLabel(label) {
       var root = cls.getRootContext();
       if (!root) {
         agent.logger.warn('Cannot trace mongo outside of a supported framework.');
+        return original.apply(this, arguments);
+      } else if (root === SpanData.nullSpan) {
         return original.apply(this, arguments);
       }
       var span = agent.startSpan(label, { db: ns });

--- a/lib/hooks/userspace/hook-redis.js
+++ b/lib/hooks/userspace/hook-redis.js
@@ -19,6 +19,7 @@
 var cls = require('../../cls.js');
 var shimmer = require('shimmer');
 var semver = require('semver');
+var SpanData = require('../../span-data.js');
 var agent;
 
 var SUPPORTED_VERSIONS = '<=2.x';
@@ -31,11 +32,20 @@ function createClientWrap(createClient) {
   };
 }
 
+function streamListenersWrap(install_stream_listeners) {
+  return function install_stream_listeners_trace() {
+    cls.getNamespace().bindEmitter(this.stream);
+    return install_stream_listeners.apply(this, arguments);
+  };
+}
+
 function sendCommandWrap(send_command) {
   return function send_command_trace(cmd, args, cb) {
     var root = cls.getRootContext();
     if (!root) {
       agent.logger.warn('Cannot trace redis outside of a supported framework.');
+      return send_command.call(this, cmd, args, cb);
+    } else if (root === SpanData.nullSpan) {
       return send_command.call(this, cmd, args, cb);
     }
     if (!cmd || !args || typeof cmd !== 'string' || !Array.isArray(args) ||
@@ -74,10 +84,13 @@ module.exports = function(version_, agent_) {
       patch: function(redis) {
         agent = agent_;
         shimmer.wrap(redis.RedisClient.prototype, 'send_command', sendCommandWrap);
+        shimmer.wrap(redis.RedisClient.prototype, 'install_stream_listeners',
+          streamListenersWrap);
         shimmer.wrap(redis, 'createClient', createClientWrap);
       },
       unpatch: function(redis) {
         shimmer.unwrap(redis.RedisClient.prototype, 'send_command');
+        shimmer.wrap(redis.RedisClient.prototype, 'install_stream_listeners');
         shimmer.unwrap(redis, 'createClient');
         agent.logger.info('Redis: unpatched');
         agent = null;

--- a/lib/trace-agent.js
+++ b/lib/trace-agent.js
@@ -163,6 +163,7 @@ TraceAgent.prototype.addTransactionLabel = function(key, value) {
 TraceAgent.prototype.createRootSpanData = function(name, traceId, parentId) {
   var spanStart = new Date();
   if (!this.policy.shouldTrace(spanStart.getTime(), name)) {
+    cls.setRootContext(SpanData.nullSpan);
     return SpanData.nullSpan;
   }
   traceId = traceId || (uuid.v4().split('-').join(''));

--- a/test/standalone/test-hooks-sample-warning.js
+++ b/test/standalone/test-hooks-sample-warning.js
@@ -1,0 +1,112 @@
+/**
+ * Copyright 2015 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+
+// Prereqs:
+// Start docker daemon
+//   ex) docker -d
+// Run a mongo image binding the mongo port
+//   ex) docker run -p 27017:27017 -d mongo
+var agent = require('../..').start({ samplingRate: 1 }).private_();
+
+var common = require('../hooks/common.js');
+
+var assert = require('assert');
+var express = require('../hooks/fixtures/express4');
+var http = require('http');
+var mongoose = require('../hooks/fixtures/mongoose4');
+var redis = require('../hooks/fixtures/redis2');
+var warnCount = 0;
+var oldWarn = agent.logger.warn;
+var newWarn = function(error) {
+  if (error.indexOf('redis') !== -1 || error.indexOf('mongo') !== -1 ||
+      error.indexOf('http') !== -1) {
+    warnCount++;
+  }
+};
+
+describe('express + dbs', function() {
+  beforeEach(function() {
+    agent.logger.warn = newWarn;
+  });
+
+  afterEach(function() {
+    agent.logger.warn = oldWarn;
+    warnCount = 0;
+  });
+
+  it('mongo should not warn', function(done) {
+    var app = express();
+    app.get('/', function (req, res) {
+      mongoose.connect('mongodb://localhost:27017/testdb', function(err) {
+        assert(!err, 'Skipping: no mongo server found at localhost:27017.');
+        mongoose.connection.close(function(err) {
+          assert(!err);
+          res.sendStatus(200);
+        });
+      });
+    });
+    var server = app.listen(common.serverPort, function() {
+      http.get({port: common.serverPort}, function(res) {
+        http.get({port: common.serverPort}, function(res) {
+          server.close();
+          common.cleanTraces();
+          assert.equal(warnCount, 2);
+          done();
+        });
+      });
+    });
+  });
+
+  it('redis should not warn', function(done) {
+    var app = express();
+    app.get('/', function (req, res) {
+      var client = redis.createClient();
+      client.quit(function() {
+        res.sendStatus(200);
+      });
+    });
+    var server = app.listen(common.serverPort + 1, function() {
+      http.get({port: common.serverPort + 1}, function(res) {
+        http.get({port: common.serverPort + 1}, function(res) {
+          server.close();
+          common.cleanTraces();
+          assert.equal(warnCount, 2);
+          done();
+        });
+      });
+    });
+  });
+
+  it('http should not warn', function(done) {
+    var app = express();
+    app.get('/', function (req, res) {
+      http.get('http://www.google.com/', function() {
+        res.sendStatus(200);
+      });
+    });
+    var server = app.listen(common.serverPort + 2, function() {
+      http.get({port: common.serverPort + 2}, function(res) {
+        http.get({port: common.serverPort + 2}, function(res) {
+          server.close();
+          common.cleanTraces();
+          assert.equal(warnCount, 2);
+          done();
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
Mongo and redis no longer warn that tracing happened outside of a
supported framework when root spans are sampled.

Fixes #137.