### PR TITLE
ignore /_ah/health by default

### DIFF
--- a/.jshintignore
+++ b/.jshintignore
@@ -2,3 +2,4 @@ node_modules
 test/debug/e2e/node_modules
 test/debug/fixtures/coffee
 test/trace/examples/node_modules
+test/hooks/fixtures

--- a/config.js
+++ b/config.js
@@ -40,7 +40,8 @@ module.exports = {
   //   /componentOne/componentTwo/...
   // Paths can additionally be classified by regex in which case any path matching
   // any provided regex will be ignored.
-  ignoreUrls: [],
+  // We ignore the health checker probes (/_ah/health) by default.
+  ignoreUrls: [ '/_ah/health' ],
 
   // An upper bound on the number of traces to gather each second. If set to 0,
   // sampling is disabled and all traces are recorded. Sampling rates greater

--- a/test/standalone/test-default-ignore-ah-health.js
+++ b/test/standalone/test-default-ignore-ah-health.js
@@ -15,24 +15,24 @@
  */
 'use strict';
 
-var agent = require('../..').start({ignoreUrls: ['/test'], samplingRate: -1});
+var agent = require('../..').start({samplingRate: -1});
 
 var assert = require('assert');
 var http = require('http');
 var express = require('../hooks/fixtures/express4');
 
-describe('test-ignore-urls', function() {
-  it('should not trace ignored urls', function(done) {
+describe('test-default-ignore-ah-health', function() {
+  it('should ignore /_ah/health traces by default', function(done) {
     var app = express();
-    app.get('/test', function (req, res) {
-      res.send('hi');
+    app.get('/_ah/health', function (req, res) {
+      res.send('🏥');
     });
     var server = app.listen(9042, function() {
-      http.get({port: 9042, path: '/test'}, function(res) {
+      http.get({port: 9042, path: '/_ah/health'}, function(res) {
         var result = '';
         res.on('data', function(data) { result += data; });
         res.on('end', function() {
-          assert.equal(result, 'hi');
+          assert.equal(result, '🏥');
           assert.equal(agent.private_().traceWriter.buffer_.length, 0);
           server.close();
           done();


### PR DESCRIPTION
A few other minor issues also fixed at the same time
* BSD `sed` on a mac requires an argument for `-i`.
* Don't run jshint on test/hooks/fixtures