### PR TITLE
Identify root spans with inherited context

### DIFF
--- a/lib/hooks/core/hook-http.js
+++ b/lib/hooks/core/hook-http.js
@@ -21,6 +21,7 @@ var httpAgent = require('_http_agent');
 var cls = require('../../cls.js');
 var TraceLabels = require('../../trace-labels.js');
 var SpanData = require('../../span-data.js');
+var util = require('util');
 var url = require('url');
 var shimmer = require('shimmer');
 /** @type {TraceAgent} */
@@ -33,14 +34,12 @@ function requestWrap(request) {
       return request.apply(this, arguments);
     }
 
-    var localOptions = (typeof options === 'string') ?
-      url.parse(options) : options;
-
     // Don't trace ourselves lest we get into infinite loops
     // Note: this would not be a problem if we guarantee buffering
     // of trace api calls. If there is no buffering then each trace is
     // an http call which will get a trace which will be an http call
-    if (agent.isTraceAgentRequest(localOptions)) {
+    if (typeof options === 'object' &&
+        agent.isTraceAgentRequest(options)) {
       return request.apply(this, arguments);
     }
 
@@ -54,17 +53,19 @@ function requestWrap(request) {
       return request.apply(this, arguments);
     }
 
+    options = (typeof options === 'string') ?
+      url.parse(options) : clone(options);
+    options.headers = options.headers || {};
+
     var namespace = cls.getNamespace();
     var uri = uriFromOptions(options);
     var labels = {};
     labels[TraceLabels.HTTP_METHOD_LABEL_KEY] = options.method;
     labels[TraceLabels.HTTP_URL_LABEL_KEY] = uri;
     var span = agent.startSpan(uri, labels);
-    if (options.headers) {
-      // Adding context to the headers lets us trace the request
-      // as it makes it through other layers of the Google infrastructure
-      agent.addContextToHeaders(span, options.headers);
-    }
+    // Adding context to the headers lets us trace the request
+    // as it makes it through other layers of the Google infrastructure
+    agent.addContextToHeaders(span, options.headers);
 
     var returned = request.call(this, options, function(res) {
       namespace.bindEmitter(res);
@@ -99,6 +100,12 @@ function requestWrap(request) {
   };
 }
 
+function clone(o) {
+  var r = {};
+  util._extend(r, o);
+  return r;
+}
+
 function uriFromOptions(options) {
   var uri;
   if (typeof options === 'string') {
@@ -112,8 +119,9 @@ function uriFromOptions(options) {
     var defaultAgent = options._defaultAgent || httpAgent.globalAgent;
     var protocol = options.protocol || defaultAgent.protocol;
     var host = options.hostname || options.host || 'localhost';
+    var port = options.port ? (':' + options.port) : '';
     var path = options.path || options.pathname || '/';
-    uri = protocol + '//' + host + path;
+    uri = protocol + '//' + host + port + path;
   }
   return uri;
 }

--- a/lib/span-data.js
+++ b/lib/span-data.js
@@ -27,14 +27,16 @@ var uid = 1;
  * @param {Trace} trace The object holding the spans comprising this trace.
  * @param {string} name The name of the span.
  * @param {number} parentSpanId The id of the parent span, 0 for root spans.
+ * @param {boolean} isRoot Whether this is a root span.
  * @param {number=} time The time when the associated TraceSpan begins.
  * @constructor
  */
-function SpanData(agent, trace, name, parentSpanId, time) {
+function SpanData(agent, trace, name, parentSpanId, isRoot, time) {
   var spanId = uid++;
   this.agent = agent;
   this.span = new TraceSpan(name, spanId, parentSpanId, time);
   this.trace = trace;
+  this.isRoot = isRoot;
   trace.spans.push(this.span);
   if (agent.config().stackTraceLimit > 0) {
     // This is a mechanism to get the structured stack trace out of V8.
@@ -79,7 +81,7 @@ function SpanData(agent, trace, name, parentSpanId, time) {
  * @returns {SpanData} The new child trace span data.
  */
 SpanData.prototype.createChildSpanData = function(name) {
-  return new SpanData(this.agent, this.trace, name, this.span.spanId);
+  return new SpanData(this.agent, this.trace, name, this.span.spanId, false);
 };
 
 SpanData.prototype.addLabel = function(key, value) {
@@ -91,7 +93,7 @@ SpanData.prototype.addLabel = function(key, value) {
  */
 SpanData.prototype.close = function() {
   this.span.close();
-  if (this.span.parentSpanId === 0) {
+  if (this.isRoot) {
     this.agent.logger.info('Writing root span');
     this.agent.traceWriter.writeSpan(this);
   }

--- a/lib/trace-agent.js
+++ b/lib/trace-agent.js
@@ -169,7 +169,7 @@ TraceAgent.prototype.createRootSpanData = function(name, traceId, parentId) {
   traceId = traceId || (uuid.v4().split('-').join(''));
   parentId = parentId || 0;
   var trace = new Trace(0, traceId); // project number added later
-  var spanData = new SpanData(this, trace, name, parentId, spanStart);
+  var spanData = new SpanData(this, trace, name, parentId, true, spanStart);
   cls.setRootContext(spanData);
   return spanData;
 };

--- a/test/standalone/test-trace-header-context.js
+++ b/test/standalone/test-trace-header-context.js
@@ -1,0 +1,76 @@
+/**
+ * Copyright 2015 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+
+var common = require('../hooks/common.js');
+var http = require('http');
+var assert = require('assert');
+var express = require('../hooks/fixtures/express4');
+var constants = require('../../lib/constants.js');
+
+describe('test-trace-header-context', function() {
+  it('should work with string url', function(done) {
+    var app = express();
+    var server;
+    app.get('/', function (req, res) {
+      http.get('http://localhost:' + common.serverPort + '/self');
+      res.send(common.serverRes);
+    });
+    app.get('/self', function(req, res) {
+      assert(req.headers[constants.TRACE_CONTEXT_HEADER_NAME.toLowerCase()]);
+      res.send(common.serverRes);
+      var traces = common.getTraces();
+      assert.equal(traces.length, 2);
+      assert.equal(traces[0].spans.length, 2);
+      assert.equal(traces[1].spans.length, 1);
+      assert.equal(traces[0].spans[0].name, '/');
+      assert.equal(traces[0].spans[1].name, 'http://localhost:9042/self');
+      assert.equal(traces[1].spans[0].name, '/self');
+      common.cleanTraces();
+      server.close();
+      done();
+    });
+    server = app.listen(common.serverPort, function() {
+      http.get({ port: common.serverPort });
+    });
+  });
+
+  it('should work with options object url', function(done) {
+    var app = express();
+    var server;
+    app.get('/', function (req, res) {
+      http.get({ port: common.serverPort, path: '/self'});
+      res.send(common.serverRes);
+    });
+    app.get('/self', function(req, res) {
+      assert(req.headers[constants.TRACE_CONTEXT_HEADER_NAME.toLowerCase()]);
+      res.send(common.serverRes);
+      var traces = common.getTraces();
+      assert.equal(traces.length, 2);
+      assert.equal(traces[0].spans.length, 2);
+      assert.equal(traces[1].spans.length, 1);
+      assert.equal(traces[0].spans[0].name, '/');
+      assert.equal(traces[0].spans[1].name, 'http://localhost:9042/self');
+      assert.equal(traces[1].spans[0].name, '/self');
+      common.cleanTraces();
+      server.close();
+      done();
+    });
+    server = app.listen(common.serverPort, function() {
+      http.get({ port: common.serverPort });
+    });
+  });
+});


### PR DESCRIPTION
Root spans that inherit their trace context from incoming headers are
now properly identified as root spans and logged. Independently this
fixes and tests a bug where outgoing contexts were not attached to all
requests.

Fixes #152.