### PR TITLE
Fix mongodb crash if project num isn't found

### DIFF
--- a/lib/hooks/core/hook-http.js
+++ b/lib/hooks/core/hook-http.js
@@ -24,7 +24,6 @@ var SpanData = require('../../span-data.js');
 var util = require('util');
 var url = require('url');
 var shimmer = require('shimmer');
-/** @type {TraceAgent} */
 var agent;
 
 // http.request
@@ -135,7 +134,7 @@ module.exports = function(version_, agent_) {
       },
       unpatch: function(http) {
         shimmer.unwrap(http, 'request');
-        agent = null;
+        agent_.logger.info('http: unpatched');
       }
     }
   };

--- a/lib/hooks/userspace/hook-express.js
+++ b/lib/hooks/userspace/hook-express.js
@@ -40,9 +40,7 @@ function applicationActionWrap(method) {
 function middleware(req, res, next) {
   var namespace = cls.getNamespace();
   if (!namespace) {
-    if (agent) {
-      agent.logger.info('Express: no namespace found, ignoring request');
-    }
+    agent.logger.info('Express: no namespace found, ignoring request');
     return next();
   }
   namespace.bindEmitter(req);
@@ -124,8 +122,7 @@ module.exports = function(version_, agent_) {
         patchedMethods.forEach(function(method) {
           shimmer.unwrap(express.application, method);
         });
-        agent.logger.info('Express: unpatched');
-        agent = null;
+        agent_.logger.info('Express: unpatched');
       }
     }
   };

--- a/lib/hooks/userspace/hook-hapi.js
+++ b/lib/hooks/userspace/hook-hapi.js
@@ -36,9 +36,7 @@ function connectionWrap(connection) {
 function middleware(request, reply) {
   var namespace = cls.getNamespace();
   if (!namespace) {
-    if (agent) {
-      agent.logger.info('Hapi: no namespace found, ignoring request');
-    }
+    agent.logger.info('Hapi: no namespace found, ignoring request');
     return reply.continue();
   }
   var req = request.raw.req;
@@ -119,8 +117,7 @@ module.exports = function(version_, agent_) {
       },
       unpatch: function(hapi) {
         shimmer.unwrap(hapi.Server.prototype, 'connection');
-        agent.logger.info('Hapi: unpatched');
-        agent = null;
+        agent_.logger.info('Hapi: unpatched');
       }
     }
   };

--- a/lib/hooks/userspace/hook-mongodb-core.js
+++ b/lib/hooks/userspace/hook-mongodb-core.js
@@ -88,7 +88,7 @@ module.exports = function(version_, agent_) {
       },
       unpatch: function(pool) {
         shimmer.unwrap(pool.prototype, 'once');
-        agent.logger.info('Mongo connection pool: unpatched');
+        agent_.logger.info('Mongo connection pool: unpatched');
       }
     },
     // An empty relative path here matches the root module being loaded.
@@ -107,8 +107,7 @@ module.exports = function(version_, agent_) {
         shimmer.unwrap(mongo.Server.prototype, 'update');
         shimmer.unwrap(mongo.Server.prototype, 'remove');
         shimmer.unwrap(mongo.Cursor.prototype, 'next');
-        agent.logger.info('Mongo: unpatched');
-        agent = null;
+        agent_.logger.info('Mongo: unpatched');
       }
     }
   };

--- a/lib/hooks/userspace/hook-mysql.js
+++ b/lib/hooks/userspace/hook-mysql.js
@@ -71,7 +71,7 @@ module.exports = function(version_, agent_) {
       },
       unpatch: function(Connection) {
         shimmer.unwrap(Connection, 'createQuery');
-        agent = null;
+        agent_.logger.info('Mysql: unpatched');
       }
     }
   };

--- a/lib/hooks/userspace/hook-redis.js
+++ b/lib/hooks/userspace/hook-redis.js
@@ -92,8 +92,7 @@ module.exports = function(version_, agent_) {
         shimmer.unwrap(redis.RedisClient.prototype, 'send_command');
         shimmer.unwrap(redis.RedisClient.prototype, 'install_stream_listeners');
         shimmer.unwrap(redis, 'createClient');
-        agent.logger.info('Redis: unpatched');
-        agent = null;
+        agent_.logger.info('Redis: unpatched');
       }
     }
   };

--- a/lib/hooks/userspace/hook-restify.js
+++ b/lib/hooks/userspace/hook-restify.js
@@ -37,9 +37,7 @@ function createServerWrap(createServer) {
 function middleware(req, res, next) {
   var namespace = cls.getNamespace();
   if (!namespace) {
-    if (agent) {
-      agent.logger.info('Restify: no namespace found, ignoring request');
-    }
+    agent.logger.info('Restify: no namespace found, ignoring request');
     return next();
   }
   namespace.bindEmitter(req);
@@ -117,8 +115,7 @@ module.exports = function(version_, agent_) {
       },
       unpatch: function(restify) {
         shimmer.unwrap(restify, 'createServer');
-        agent.logger.info('Restify: unpatched');
-        agent = null;
+        agent_.logger.info('Restify: unpatched');
       }
     }
   };

--- a/test/standalone/test-hooks-no-project-num.js
+++ b/test/standalone/test-hooks-no-project-num.js
@@ -1,0 +1,139 @@
+/**
+ * Copyright 2015 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+
+delete process.env.GCLOUD_PROJECT_NUM;
+
+var assert = require('assert');
+
+describe('should not break without project num', function() {
+  it('mongo', function(done) {
+    var agent = require('../..').start();
+    var mongoose = require('../hooks/fixtures/mongoose4');
+    var Simple = mongoose.model('Simple', new mongoose.Schema({
+      f1: String,
+      f2: Boolean,
+      f3: Number
+    }));
+    mongoose.connect('mongodb://localhost:27017/testdb', function(err) {
+      assert(!err, 'Skipping: error connecting to mongo at localhost:27017.');
+      Simple.find({}, function(err, results) {
+        mongoose.connection.close(function(err) {
+          agent.stop();
+          done();
+        });
+      });
+    });
+  });
+
+  it('redis', function(done) {
+    var agent = require('../..').start();
+    var redis = require('../hooks/fixtures/redis2');
+    var client = redis.createClient();
+    client.set('i', 1, function() {
+      client.quit(function() {
+        agent.stop();
+        done();
+      });
+    });
+  });
+
+  it('express', function(done) {
+    var http = require('http');
+    var agent = require('../..').start();
+    var express = require('../hooks/fixtures/express4');
+    var app = express();
+    var server;
+    app.get('/', function (req, res) {
+      res.send('hi');
+      server.close();
+      agent.stop();
+      done();
+    });
+    server = app.listen(8081, function() {
+      http.get({ port: 8081 });
+    });
+  });
+
+  it('restify', function(done) {
+    var http = require('http');
+    var agent = require('../..').start();
+    var restify = require('../hooks/fixtures/restify3');
+    var server = restify.createServer();
+    server.get('/', function (req, res, next) {
+      res.writeHead(200, {
+        'Content-Type': 'text/plain'
+      });
+      res.write('hi');
+      res.end();
+      server.close();
+      agent.stop();
+      done();
+    });
+    server.listen(8081, function() {
+      http.get({ port: 8081 });
+    });
+  });
+
+  it('hapi', function(done) {
+    var http = require('http');
+    var agent = require('../..').start();
+    var hapi = require('../hooks/fixtures/hapi8');
+    var server = new hapi.Server();
+    server.connection({ port: 8081 });
+    server.route({
+      method: 'GET',
+      path: '/',
+      handler: function(req, reply) {
+        reply('hi');
+        server.stop();
+        agent.stop();
+        done();
+      }
+    });
+    server.start(function() {
+      http.get({ port: 8081 });
+    });
+  });
+
+  it('http', function(done) {
+    var agent = require('../..').start();
+    var req = require('http').get({ port: 8081 });
+    req.on('error', function() {
+      agent.stop();
+      done();
+    });
+  });
+
+  it('mysql', function(done) {
+    var agent = require('../..').start();
+    var mysql = require('../hooks/fixtures/mysql2');
+    var pool = mysql.createPool({
+      host     : 'localhost',
+      user     : 'travis',
+      password : '',
+      database : 'test'
+    });
+    pool.getConnection(function(err, conn) {
+      assert(!err, 'Skipping: Failed to connect to mysql.');
+      conn.query('SHOW TABLES', function(err, result) {
+        conn.release();
+        agent.stop();
+        done();
+      });
+    });
+  });
+});


### PR DESCRIPTION
The crash is not reproducible for the other frameworks as those patches
do not persist on long lived objects and thus execute after hooks have
been disabled. This PR also fixes a race condition crash that could
occur if hooks were disabled between the start and end of a single span
(resulting in a null dereference of the agent).

Fixes #149