### PR TITLE
attach GAE labels when available

### DIFF
--- a/index.js
+++ b/index.js
@@ -159,6 +159,13 @@ var publicAgent = {
       return this;
     }
 
+    if (process.env.GAE_MODULE_NAME) {
+      config.gae_module_name = process.env.GAE_MODULE_NAME;
+    }
+    if (process.env.GAE_MODULE_VERSION) {
+      config.gae_module_version = process.env.GAE_MODULE_VERSION;
+    }
+
     agent = require('./lib/trace-agent.js').get(config, logger);
     return this; // for chaining
   },

--- a/lib/trace-labels.js
+++ b/lib/trace-labels.js
@@ -65,6 +65,16 @@ TraceLabels.ERROR_DETAILS_NAME = 'trace.cloud.google.com/error/name';
 TraceLabels.ERROR_DETAILS_MESSAGE = 'trace.cloud.google.com/error/message';
 
 /**
+ * @type {string} The well-known label for the module name on AppEngine.
+ */
+TraceLabels.GAE_MODULE_NAME = 'trace.cloud.google.com/gae/app/module';
+
+/**
+ * @type {string} The well-known label for the module version on AppEngine.
+ */
+TraceLabels.GAE_MODULE_VERSION = 'trace.cloud.google.com/gae/app/module_version';
+
+/**
  * @type {string} The label for GCE instance id. This is not a label
  *   recognized by the trace API.
  */

--- a/lib/trace-writer.js
+++ b/lib/trace-writer.js
@@ -74,6 +74,15 @@ TraceWriter.prototype.writeSpan = function(spanData) {
   if (this.config_.instanceId) {
     spanData.addLabel(traceLabels.GCE_INSTANCE_ID, this.config_.instanceId);
   }
+
+  var moduleName = this.config_.gae_module_name || this.config_.hostname;
+  if (moduleName) {
+    spanData.addLabel(traceLabels.GAE_MODULE_NAME, moduleName);
+  }
+  if (this.config_.gae_module_version) {
+    spanData.addLabel(traceLabels.GAE_MODULE_VERSION,
+      this.config_.gae_module_version);
+  }
   spanData.addLabel(traceLabels.AGENT_DATA, 'node ' + pjson.version);
   this.queueTrace_(spanData.trace);
 };


### PR DESCRIPTION
Module and version drop down boxes in the Trace UI use these labels to allow
filtering by module and version. For GCE, GKE we use the hostname as the module
to allow the same functionality in the UI.

Fixes: #169