### PR TITLE
fix GAE_MODULE fall-back to local hostname

### DIFF
--- a/lib/trace-writer.js
+++ b/lib/trace-writer.js
@@ -62,7 +62,7 @@ function TraceWriter(logger, config) {
     that.getInstanceId(function(instanceId) {
       var labels = {};
       labels[traceLabels.AGENT_DATA] = 'node ' + pjson.version;
-      labels[traceLabels.GCE_HOSTNAME] = hostname || require('os').hostname();
+      labels[traceLabels.GCE_HOSTNAME] = hostname;
       if (instanceId) {
         labels[traceLabels.GCE_INSTANCE_ID] = instanceId;
       }
@@ -95,7 +95,7 @@ TraceWriter.prototype.getHostname = function(cb) {
       // We are running on GCP.
       that.logger_.warn('Unable to retrieve GCE hostname.', err);
     }
-    cb(hostname);
+    cb(hostname || require('os').hostname());
   });
 };
 


### PR DESCRIPTION
We were sending undefined as the GAE_MODULE label.

@matthewloring ptal.