### PR TITLE
restrict redis support to <= 2.3.x

### DIFF
--- a/lib/hooks/userspace/hook-redis.js
+++ b/lib/hooks/userspace/hook-redis.js
@@ -22,7 +22,7 @@ var semver = require('semver');
 var SpanData = require('../../span-data.js');
 var agent;
 
-var SUPPORTED_VERSIONS = '<=2.x';
+var SUPPORTED_VERSIONS = '<=2.3.x';
 
 function createClientWrap(createClient) {
   return function createClientTrace() {

--- a/test/hooks/fixtures/redis2-hiredis0.4/package.json
+++ b/test/hooks/fixtures/redis2-hiredis0.4/package.json
@@ -4,6 +4,6 @@
   "main": "index.js",
   "dependencies": {
     "hiredis": "^0.4.1",
-    "redis": "^2.2.5"
+    "redis": "~2.3.x"
   }
 }

--- a/test/hooks/fixtures/redis2/package.json
+++ b/test/hooks/fixtures/redis2/package.json
@@ -3,6 +3,6 @@
   "version": "1.0.0",
   "main": "index.js",
   "dependencies": {
-    "redis": "^2.2.5"
+    "redis": "~2.3.x"
   }
 }


### PR DESCRIPTION
This is a work-arounds a change is redis 2.4 that breaks our tracing.