### PR TITLE
load cls before all else

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,6 +16,10 @@
 
 'use strict';
 
+// Load continuation-local-storage first to ensure the core async APIs get
+// patched before any user-land modules get loaded.
+require('continuation-local-storage');
+
 var SpanData = require('./lib/span-data.js');
 var common = require('@google/cloud-diagnostics-common');
 var semver = require('semver');


### PR DESCRIPTION
This ensures that the code async APIs get patched befored anything use-space can
get loaded and interfere with tracing. This is a problem with `request` in
particular as it caches setImmediate.

Fixes: https://github.com/GoogleCloudPlatform/cloud-trace-nodejs/issues/182