### PR TITLE
Updated logging in a few places

### DIFF
--- a/lib/hooks/index.js
+++ b/lib/hooks/index.js
@@ -103,7 +103,7 @@ function activate(agent) {
     var regex = new RegExp('node_modules' + path.sep + moduleName + path.sep);
     for (var file in require.cache) {
       if (file.match(regex)) {
-        logger.warn(moduleName + ' tracing might not work as ' + file +
+        logger.error(moduleName + ' tracing might not work as ' + file +
             ' was loaded before the trace agent was initialized.');
         break;
       }

--- a/lib/trace-writer.js
+++ b/lib/trace-writer.js
@@ -153,7 +153,7 @@ TraceWriter.prototype.queueTrace_ = function(trace) {
 
     // Publish soon if the buffer is getting big
     if (that.buffer_.length >= that.config_.bufferSize) {
-      that.logger_.info('Flushing: performing periodic flush');
+      that.logger_.info('Flushing: trace buffer full');
       setImmediate(function() { that.flushBuffer_(project); });
     }
   });


### PR DESCRIPTION
Detecting modules loaded before the trace agent now causes an error to
be logged (up from warning). Message logged for full trace buffer now
states this as the cause.

Fixes #194