### PR TITLE
Change config format to support multiple agents

### DIFF
--- a/index.js
+++ b/index.js
@@ -53,8 +53,11 @@ var initConfig = function(projectConfig) {
   var config = {};
   util._extend(config, require('./config.js'));
   util._extend(config, projectConfig);
-  if (process.env.hasOwnProperty('GCLOUD_TRACE_CONFIG')) {
-    util._extend(config, require(path.resolve(process.env.GCLOUD_TRACE_CONFIG)));
+  if (process.env.hasOwnProperty('GCLOUD_DIAGNOSTICS_CONFIG')) {
+    var c = require(path.resolve(process.env.GCLOUD_DIAGNOSTICS_CONFIG));
+    if (c) {
+      util._extend(config, c.trace);
+    }
   }
   if (process.env.hasOwnProperty('GCLOUD_TRACE_LOGLEVEL')) {
     config.logLevel = process.env.GCLOUD_TRACE_LOGLEVEL;

--- a/test/fixtures/test-config.js
+++ b/test/fixtures/test-config.js
@@ -16,11 +16,10 @@
 'use strict';
 
 module.exports = {
-  logLevel: 4,
-
-  stackTraceLimit: 1,
-
-  flushDelaySeconds: 31
-
+  trace: {
+    logLevel: 4,
+    stackTraceLimit: 1,
+    flushDelaySeconds: 31
+  }
 };
 

--- a/test/fixtures/test-config.json
+++ b/test/fixtures/test-config.json
@@ -1,8 +1,7 @@
 {
-  "logLevel": 4,
-
-  "stackTraceLimit": 1,
-
-  "flushDelaySeconds": 31
+  "trace": {
+    "logLevel": 4,
+    "stackTraceLimit": 1,
+    "flushDelaySeconds": 31
+  }
 }
-

--- a/test/standalone/test-config-json.js
+++ b/test/standalone/test-config-json.js
@@ -23,7 +23,8 @@ var assert = require('assert');
 
 // Fixtures configuration:
 // { logLevel: 4, stackTraceLimit: 1 };
-process.env.GCLOUD_TRACE_CONFIG = path.join('test', 'fixtures', 'test-config.json');
+process.env.GCLOUD_DIAGNOSTICS_CONFIG =
+  path.join('test', 'fixtures', 'test-config.json');
 
 var agent = require('../..').start();
 

--- a/test/standalone/test-config-priority.js
+++ b/test/standalone/test-config-priority.js
@@ -23,7 +23,7 @@ var assert = require('assert');
 
 // Fixtures configuration:
 // { logLevel: 4, stackTraceLimit: 1 };
-process.env.GCLOUD_TRACE_CONFIG =
+process.env.GCLOUD_DIAGNOSTICS_CONFIG =
   path.join(__dirname, '..', 'fixtures', 'test-config.js');
 
 process.env.GCLOUD_TRACE_LOGLEVEL = 2;

--- a/test/standalone/test-config-relative-path.js
+++ b/test/standalone/test-config-relative-path.js
@@ -23,7 +23,7 @@ var assert = require('assert');
 
 // Fixtures configuration:
 // { logLevel: 4, stackTraceLimit: 1 };
-process.env.GCLOUD_TRACE_CONFIG = path.join('fixtures', 'test-config.js');
+process.env.GCLOUD_DIAGNOSTICS_CONFIG = path.join('fixtures', 'test-config.js');
 
 process.chdir('test');
 


### PR DESCRIPTION
The environment variable name for the config file has been updated to
the more general GCLOUD_CONFIG. The config file is also now structured
to support separate configs for each of the profile, debug, and trace
agents.