### PR TITLE
Warn about modules loaded before trace agent

### DIFF
--- a/test/fixtures/start-agent.js
+++ b/test/fixtures/start-agent.js
@@ -1,0 +1,20 @@
+/**
+ * Copyright 2015 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+
+process.env.GCLOUD_TRACE_LOGLEVEL = 4;
+require('glob'); // Load a module before agent
+require('../..').start();

--- a/test/standalone/test-modules-loaded-before-agent.js
+++ b/test/standalone/test-modules-loaded-before-agent.js
@@ -1,0 +1,29 @@
+/**
+ * Copyright 2015 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+var assert = require('assert');
+var cp = require('child_process');
+
+describe('modules loaded before agent', function() {
+  it('should log if modules were loaded before agent', function() {
+    var output =
+      cp.execSync('node test/fixtures/start-agent.js');
+    console.log(output.toString());
+    assert(output.toString().match(/Tracing might not work.*"glob".*/));
+  });
+});


### PR DESCRIPTION
Add additional logging to report any modules loaded before the trace
agent even if they are not modules that we patch directly.

Fixes #187.