### PR TITLE
Respect incoming trace enabled options

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,5 +1,5 @@
 {
-  "bitwise": true,
+  "bitwise": false,
   "curly": true,
   "eqeqeq": true,
   "esnext": true,

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -21,5 +21,8 @@ module.exports = {
   TRACE_CONTEXT_HEADER_NAME: 'x-cloud-trace-context',
 
   /** @const {string} header that is used to identify outgoing http made by the agent. */
-  TRACE_AGENT_REQUEST_HEADER: 'x-cloud-trace-agent-request'
+  TRACE_AGENT_REQUEST_HEADER: 'x-cloud-trace-agent-request',
+
+  /** @const {number} bitmask to determine whether trace is enabled in trace options. */
+  TRACE_OPTIONS_TRACE_ENABLED: 1 << 0
 };

--- a/lib/hooks/userspace/hook-express.js
+++ b/lib/hooks/userspace/hook-express.js
@@ -42,7 +42,9 @@ function middleware(req, res, next) {
     agent.logger.info('Express: no namespace found, ignoring request');
     return next();
   }
-  if (!agent.shouldTrace(req.originalUrl)) {
+  var traceHeader = agent.parseContextFromHeader(
+    req.get(constants.TRACE_CONTEXT_HEADER_NAME)) || {};
+  if (!agent.shouldTrace(req.originalUrl, traceHeader.options)) {
     return next();
   }
 
@@ -52,7 +54,7 @@ function middleware(req, res, next) {
   var originalEnd = res.end;
 
   namespace.run(function() {
-    var rootContext = startRootSpanForRequest(req);
+    var rootContext = startRootSpanForRequest(req, traceHeader);
 
     // wrap end
     res.end = function(chunk, encoding) {
@@ -70,14 +72,12 @@ function middleware(req, res, next) {
 /**
  * Creates and sets up a new root span for the given request.
  * @param {Object} req The request being processed.
+ * @param {Object} traceHeader The incoming trace header.
  * @returns {!SpanData} The new initialized trace span data instance.
  */
-function startRootSpanForRequest(req) {
-  var result = agent.parseContextFromHeader(
-    req.get(constants.TRACE_CONTEXT_HEADER_NAME)) || {};
-
-  var traceId = result.traceId;
-  var parentSpanId = result.spanId;
+function startRootSpanForRequest(req, traceHeader) {
+  var traceId = traceHeader.traceId;
+  var parentSpanId = traceHeader.spanId;
   var url = req.protocol + '://' + req.hostname + req.originalUrl;
 
   // we use the path part of the url as the span name and add the full

--- a/lib/hooks/userspace/hook-hapi.js
+++ b/lib/hooks/userspace/hook-hapi.js
@@ -41,7 +41,9 @@ function middleware(request, reply) {
   }
   var req = request.raw.req;
   var res = request.raw.res;
-  if (!agent.shouldTrace(req.url)) {
+  var traceHeader = agent.parseContextFromHeader(
+    req.headers[constants.TRACE_CONTEXT_HEADER_NAME]) || {};
+  if (!agent.shouldTrace(req.url, traceHeader.options)) {
     return reply.continue();
   }
 
@@ -51,7 +53,7 @@ function middleware(request, reply) {
   var originalEnd = res.end;
 
   namespace.run(function() {
-    var rootContext = startRootSpanForRequest(req);
+    var rootContext = startRootSpanForRequest(req, traceHeader);
 
     // wrap end
     res.end = function(chunk, encoding) {
@@ -69,14 +71,12 @@ function middleware(request, reply) {
 /**
  * Creates and sets up a new root span for the given request.
  * @param {Object} req The request being processed.
+ * @param {Object} traceHeader The incoming trace header.
  * @returns {!SpanData} The new initialized trace span data instance.
  */
-function startRootSpanForRequest(req) {
-  var result = agent.parseContextFromHeader(
-    req.headers[constants.TRACE_CONTEXT_HEADER_NAME]) || {};
-
-  var traceId = result.traceId;
-  var parentSpanId = result.spanId;
+function startRootSpanForRequest(req, traceHeader) {
+  var traceId = traceHeader.traceId;
+  var parentSpanId = traceHeader.spanId;
   var url = (req.headers['X-Forwarded-Proto'] || 'http') +
     '://' + req.headers.host + req.url;
 

--- a/lib/hooks/userspace/hook-koa.js
+++ b/lib/hooks/userspace/hook-koa.js
@@ -42,7 +42,9 @@ function* middleware(next) {
     agent.logger.info('Koa: no namespace found, ignoring request');
     return;
   }
-  if (!agent.shouldTrace(this.req.url)) {
+  const traceHeader = agent.parseContextFromHeader(
+    this.req.headers[constants.TRACE_CONTEXT_HEADER_NAME]) || {};
+  if (!agent.shouldTrace(this.req.url, traceHeader.options)) {
     return;
   }
   const req = this.req;
@@ -54,7 +56,7 @@ function* middleware(next) {
   const originalEnd = res.end;
 
   namespace.run(function() {
-    const rootContext = startRootSpanForRequest(req);
+    const rootContext = startRootSpanForRequest(req, traceHeader);
 
     // wrap end
     res.end = function(chunk, encoding) {
@@ -72,14 +74,12 @@ function* middleware(next) {
 /**
  * Creates and sets up a new root span for the given request.
  * @param {Object} req The request being processed.
+ * @param {Object} traceHeader The incoming trace header.
  * @returns {!SpanData} The new initialized trace span data instance.
  */
-function startRootSpanForRequest(req) {
-  const result = agent.parseContextFromHeader(
-    req.headers[constants.TRACE_CONTEXT_HEADER_NAME]) || {};
-
-  const traceId = result.traceId;
-  const parentSpanId = result.spanId;
+function startRootSpanForRequest(req, traceHeader) {
+  const traceId = traceHeader.traceId;
+  const parentSpanId = traceHeader.spanId;
   const url = (req.headers['X-Forwarded-Proto'] || 'http') +
     '://' + req.headers.host + req.url;
 

--- a/lib/hooks/userspace/hook-restify.js
+++ b/lib/hooks/userspace/hook-restify.js
@@ -40,7 +40,9 @@ function middleware(req, res, next) {
     agent.logger.info('Restify: no namespace found, ignoring request');
     return next();
   }
-  if (!agent.shouldTrace(req.url)) {
+  var traceHeader = agent.parseContextFromHeader(
+    req.header(constants.TRACE_CONTEXT_HEADER_NAME, null)) || {};
+  if (!agent.shouldTrace(req.url, traceHeader.options)) {
     return next();
   }
 
@@ -50,7 +52,7 @@ function middleware(req, res, next) {
   var originalEnd = res.end;
 
   namespace.run(function() {
-    var rootContext = startRootSpanForRequest(req);
+    var rootContext = startRootSpanForRequest(req, traceHeader);
 
     // wrap end
     res.end = function(chunk, encoding) {
@@ -68,14 +70,12 @@ function middleware(req, res, next) {
 /**
  * Creates and sets up a new root span for the given request.
  * @param {Object} req The request being processed.
+ * @param {Object} traceHeader The incoming trace header.
  * @returns {!SpanData} The new initialized trace span data instance.
  */
-function startRootSpanForRequest(req) {
-  var result = agent.parseContextFromHeader(
-    req.header(constants.TRACE_CONTEXT_HEADER_NAME, null)) || {};
-
-  var traceId = result.traceId;
-  var parentSpanId = result.spanId;
+function startRootSpanForRequest(req, traceHeader) {
+  var traceId = traceHeader.traceId;
+  var parentSpanId = traceHeader.spanId;
   var url = req.header('X-Forwarded-Proto', 'http') + '://' +
     req.header('host') + req.url;
 

--- a/lib/trace-agent.js
+++ b/lib/trace-agent.js
@@ -162,9 +162,15 @@ TraceAgent.prototype.addTransactionLabel = function(key, value) {
 /**
  * Determines whether a trace of the given name should be recorded based
  * on the current tracing policy.
+ *
+ * @param {string} name the url to trace
+ * @param {!number} options the trace header options
  */
-TraceAgent.prototype.shouldTrace = function(name) {
-  return this.policy.shouldTrace(Date.now(), name);
+TraceAgent.prototype.shouldTrace = function(name, options) {
+  if (isNaN(options)) {
+    return this.policy.shouldTrace(Date.now(), name);
+  }
+  return options & constants.TRACE_OPTIONS_TRACE_ENABLED;
 };
 
 /**
@@ -189,13 +195,14 @@ TraceAgent.prototype.isTraceAgentRequest = function(options) {
 
 /**
  * Parse a cookie-style header string to extract traceId, spandId and options
- * ex: '123456/667;o=something'
- * -> {traceId: '123456', spanId: '667', options: 'something'}
+ * ex: '123456/667;o=3'
+ * -> {traceId: '123456', spanId: '667', options: '3'}
  * note that we ignore trailing garbage if there is more than one '='
  * Returns null if traceId or spanId are could not be found.
  *
  * @param {string} str string representation of the trace headers
- * @return {?Object} object with keys. null if there is a problem.
+ * @return {?{traceId: string, spanId: string, options: number}}
+ *         object with keys. null if there is a problem.
  */
 TraceAgent.prototype.parseContextFromHeader = function(str) {
   if (!str) {
@@ -209,7 +216,7 @@ TraceAgent.prototype.parseContextFromHeader = function(str) {
   return {
     traceId: matches[1],
     spanId: matches[2],
-    options: matches[3]
+    options: Number(matches[3])
   };
 };
 

--- a/test/standalone/test-trace-options.js
+++ b/test/standalone/test-trace-options.js
@@ -1,0 +1,68 @@
+/**
+ * Copyright 2015 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+
+// Prereqs:
+// Start docker daemon
+//   ex) docker -d
+// Run a mongo image binding the mongo port
+//   ex) docker run -p 27017:27017 -d mongo
+require('../..').start({ samplingRate: 0 });
+
+var common = require('../hooks/common.js');
+
+var assert = require('assert');
+var express = require('../hooks/fixtures/express4');
+var http = require('http');
+
+describe('express + mongo with trace options header', function() {
+  it('should trace when enabled', function(done) {
+    var app = express();
+    app.get('/', function (req, res) {
+      setTimeout(function() {
+        res.send('Hello World');
+      }, 50);
+    });
+    var server = app.listen(common.serverPort, function() {
+      var shouldTraceOptions = [1,3,5,7];
+      var shouldNotTraceOptions = [0,2,4,6];
+      sendRequests(shouldTraceOptions, shouldTraceOptions.length, function() {
+        sendRequests(shouldNotTraceOptions, 0, function() {
+          server.close();
+          done();
+        });
+      });
+    });
+  });
+});
+
+function sendRequests(options, expectedTraceCount, done) {
+  var doneCount = 0;
+  options.forEach(function(option) {
+    var headers = {};
+    headers['x-cloud-trace-context'] = '42/1729;o=' + option;
+    http.get({port: common.serverPort, headers: headers}, function(res) {
+      res.on('data', function() {});
+      res.on('end', function() {
+        if (++doneCount === options.length) {
+          assert.equal(common.getTraces().length, expectedTraceCount);
+          common.cleanTraces();
+          done();
+        }
+      });
+    });
+  });
+}


### PR DESCRIPTION
Previously, if the app server decided to ignore a request that our sampling process decided to trace, the span would not be rendered in the UI because the parent span to the root reported by the trace agent was not present. Inversely, if the app server decided to trace a request that our sampling process decided to ignore, an empty root span would show up in the UI without any additional Node.js information.

To remedy these issues, we have adopted the following semantics:

If there is no trace context header; we use our sampling
If there is a trace context header, but no options or non-numeric options; we use our sampling
If there is a trace context header with options, and options is a number; we use that to decide.