### PR TITLE
Enforce sampling policy regardless of headers

### DIFF
--- a/config.js
+++ b/config.js
@@ -55,7 +55,7 @@ module.exports = {
     // An upper bound on the number of traces to gather each second. If set to 0,
     // sampling is disabled and all traces are recorded. Sampling rates greater
     // than 1000 are not supported and will result in at most 1000 samples per
-    // second. Some Google Cloud environments may override this rate.
+    // second. Some Google Cloud environments may further limit this rate.
     samplingRate: 10,
 
     // The number of transactions we buffer before we publish to the Cloud Trace

--- a/lib/trace-agent.js
+++ b/lib/trace-agent.js
@@ -170,10 +170,11 @@ TraceAgent.prototype.addTransactionLabel = function(key, value) {
  * @param {!number} options the trace header options
  */
 TraceAgent.prototype.shouldTrace = function(name, options) {
-  if (isNaN(options)) {
-    return this.policy.shouldTrace(Date.now(), name);
-  }
-  return options & constants.TRACE_OPTIONS_TRACE_ENABLED;
+  var locallyAllowed = this.policy.shouldTrace(Date.now(), name);
+  // Note: remotelyDisallowed is false if no trace options are present.
+  var remotelyDisallowed = !(isNaN(options) ||
+    (options & constants.TRACE_OPTIONS_TRACE_ENABLED));
+  return locallyAllowed && !remotelyDisallowed;
 };
 
 /**

--- a/test/standalone/test-trace-options-sampling.js
+++ b/test/standalone/test-trace-options-sampling.js
@@ -1,0 +1,60 @@
+/**
+ * Copyright 2015 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+
+// Prereqs:
+// Start docker daemon
+//   ex) docker -d
+// Run a mongo image binding the mongo port
+//   ex) docker run -p 27017:27017 -d mongo
+require('../..').start({ samplingRate: 1 });
+
+var common = require('../hooks/common.js');
+
+var assert = require('assert');
+var express = require('../hooks/fixtures/express4');
+var http = require('http');
+
+describe('express + mongo with trace options header + sampling', function() {
+  it('should trace when enabled', function(done) {
+    var app = express();
+    app.get('/', function (req, res) {
+      setTimeout(function() {
+        res.send('Hello World');
+      }, 50);
+    });
+    var server = app.listen(common.serverPort, function() {
+      var headers = {};
+      headers['x-cloud-trace-context'] = '42/1729;o=1';
+      var doneCount = 0;
+      var cb = function(res) {
+        res.on('data', function() {});
+        res.on('end', function() {
+          if (++doneCount === 5) {
+            // Only one trace should be sampled even though all have enabled header.
+            assert.equal(common.getTraces().length, 1);
+            common.cleanTraces();
+            server.close();
+            done();
+          }
+        });
+      };
+      for (var i = 0; i < 5; i++) {
+        http.get({port: common.serverPort, headers: headers}, cb);
+      }
+    });
+  });
+});


### PR DESCRIPTION
This will lead to some empty root spans appearing in the UI if the app
server decides to trace an incoming request but the agent decides not to
sample it. This is deemed preferable to always accepting incoming trace
headers as we cannot always trust their origin.

Fixes #234