### PR TITLE
Fix incorrect modulesLoadedBeforeTrace check

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,10 +34,9 @@ var moduleRegex =
 for (var i = 0; i < filesLoadedBeforeTrace.length; i++) {
   var matches = moduleRegex.exec(filesLoadedBeforeTrace[i]);
   if (matches && matches.length > 1 &&
+      matches[1] !== '@google' &&
       modulesLoadedBeforeTrace.indexOf(matches[1]) === -1) {
-    if (matches[1] !== '@google') {
-      modulesLoadedBeforeTrace.push(matches[1]);
-    }
+    modulesLoadedBeforeTrace.push(matches[1]);
   }
 }
 

--- a/index.js
+++ b/index.js
@@ -29,12 +29,28 @@ var constants = require('./lib/constants.js');
 var path = require('path');
 
 var modulesLoadedBeforeTrace = [];
-var moduleRegex =
-  new RegExp('.*?node_modules\\' + path.sep + '([^\\' + path.sep + ']*).*');
+
+// Includes support for npm '@org/name' packages
+// Regex: .*?node_modules\/(@[^\/]*\/[^\/]*|[^\/]*).*
+// Tests: https://regex101.com/r/lW2bE3/4
+var moduleRegex = new RegExp(
+  '.*?node_modules'
+  + path.sep +
+  '(@[^'
+  + path.sep +
+  ']*'
+  + path.sep +
+  '[^'
+  + path.sep +
+  ']*|[^'
+  + path.sep +
+  ']*).*'
+);
+
 for (var i = 0; i < filesLoadedBeforeTrace.length; i++) {
   var matches = moduleRegex.exec(filesLoadedBeforeTrace[i]);
   if (matches && matches.length > 1 &&
-      matches[1] !== '@google' &&
+      matches[1] !== '@google/cloud-trace' &&
       modulesLoadedBeforeTrace.indexOf(matches[1]) === -1) {
     modulesLoadedBeforeTrace.push(matches[1]);
   }

--- a/index.js
+++ b/index.js
@@ -35,7 +35,7 @@ for (var i = 0; i < filesLoadedBeforeTrace.length; i++) {
   var matches = moduleRegex.exec(filesLoadedBeforeTrace[i]);
   if (matches && matches.length > 1 &&
       modulesLoadedBeforeTrace.indexOf(matches[1]) === -1) {
-    if (matches[1] !== '@google' && matches[1] !=='cloud-trace') {
+    if (matches[1] !== '@google') {
       modulesLoadedBeforeTrace.push(matches[1]);
     }
   }

--- a/index.js
+++ b/index.js
@@ -144,9 +144,9 @@ var publicAgent = {
     var headers = {};
     headers[constants.TRACE_AGENT_REQUEST_HEADER] = 1;
 
-    if (modulesLoadedBeforeTrace.length > 0) {
+    if (modulesLoadedBeforeTrace.length > 1) {
       logger.warn('Tracing might not work as the following modules ' +
-        ' were loaded before the trace agent was initialized: ' +
+        'were loaded before the trace agent was initialized: ' +
         JSON.stringify(modulesLoadedBeforeTrace));
     }
 

--- a/index.js
+++ b/index.js
@@ -34,16 +34,11 @@ var modulesLoadedBeforeTrace = [];
 // Regex: .*?node_modules\/(@[^\/]*\/[^\/]*|[^\/]*).*
 // Tests: https://regex101.com/r/lW2bE3/4
 var moduleRegex = new RegExp(
-  '.*?node_modules'
-  + path.sep +
-  '(@[^'
-  + path.sep +
-  ']*'
-  + path.sep +
-  '[^'
-  + path.sep +
-  ']*|[^'
-  + path.sep +
+  '.*?node_modules' + path.sep +
+  '(@[^' + path.sep +
+  ']*' + path.sep +
+  '[^' + path.sep +
+  ']*|[^' + path.sep +
   ']*).*'
 );
 

--- a/index.js
+++ b/index.js
@@ -35,7 +35,9 @@ for (var i = 0; i < filesLoadedBeforeTrace.length; i++) {
   var matches = moduleRegex.exec(filesLoadedBeforeTrace[i]);
   if (matches && matches.length > 1 &&
       modulesLoadedBeforeTrace.indexOf(matches[1]) === -1) {
-    modulesLoadedBeforeTrace.push(matches[1]);
+    if (matches[1] !== '@google' && matches[1] !=='cloud-trace') {
+      modulesLoadedBeforeTrace.push(matches[1]);
+    }
   }
 }
 
@@ -144,7 +146,7 @@ var publicAgent = {
     var headers = {};
     headers[constants.TRACE_AGENT_REQUEST_HEADER] = 1;
 
-    if (modulesLoadedBeforeTrace.length > 1) {
+    if (modulesLoadedBeforeTrace.length > 0) {
       logger.warn('Tracing might not work as the following modules ' +
         'were loaded before the trace agent was initialized: ' +
         JSON.stringify(modulesLoadedBeforeTrace));


### PR DESCRIPTION
The `modulesLoadedBeforeTrace` check is incorrect, should be greater than 1 as requiring this module itself counts as a "moduleLoadedBeforeTrace", so will always log warnings.

Also fixed the double spacing on the logging.

**Logs:**
```
WARN :@google/cloud-trace: Tracing might not work as the following modules  were loaded before the trace agent was initialized: ["@google"]
```

The regex is also borked on this for extracting package names in orgs, but that can be another PR. 👍 