### PR TITLE
Add support for pre-release grpc v0.15

### DIFF
--- a/lib/hooks/userspace/hook-grpc.js
+++ b/lib/hooks/userspace/hook-grpc.js
@@ -21,7 +21,7 @@ var shimmer = require('shimmer');
 var semver = require('semver');
 var agent;
 
-var SUPPORTED_VERSIONS = '0.13 - 0.14';
+var SUPPORTED_VERSIONS = '0.13 - 0.15';
 
 function startBatchWrap(startBatch) {
   return function startBatchTrace(thing, callback) {


### PR DESCRIPTION
This was tested by:
1. Installing a new grpc fixture from grpc@master.
2. Updating `hook-grpc.js` to accept the version range `0.13 - 0.14 || 0.15.0-dev`.
3. Running `test/standalone/test-grpc-context.js` including this new fixture.
4. After passing tests, updating the accepted version range to `0.13 - 0.15`.