### PR TITLE
Set outgoing trace enabled header always

### DIFF
--- a/lib/hooks/core/hook-http.js
+++ b/lib/hooks/core/hook-http.js
@@ -65,7 +65,7 @@ function requestWrap(request) {
     var span = agent.startSpan(uri, labels);
     // Adding context to the headers lets us trace the request
     // as it makes it through other layers of the Google infrastructure
-    agent.addContextToHeaders(span, options.headers);
+    agent.addContextToHeaders(span, options.headers, true);
 
     var returned = request.call(this, options, function(res) {
       namespace.bindEmitter(res);

--- a/lib/trace-agent.js
+++ b/lib/trace-agent.js
@@ -254,15 +254,17 @@ TraceAgent.prototype.parseContextFromHeader = function(str) {
  * @param {SpanData} spanData The span to be added to headers.
  * @param {Object} headers The http headers associated with the
  *   current request.
+ * @param {boolean} traced Whether this request was traced by the agent.
  */
-TraceAgent.prototype.addContextToHeaders = function(spanData, headers) {
+TraceAgent.prototype.addContextToHeaders = function(spanData, headers, traced) {
   if (spanData === SpanData.nullSpan) {
     return;
   }
   var header = spanData.trace.traceId + '/' + spanData.span.spanId;
-  if (spanData.options) {
-    header += (';o=' + spanData.options);
-  }
+  var options = traced ?
+    spanData.options | constants.TRACE_OPTIONS_TRACE_ENABLED :
+    spanData.options;
+  header += (';o=' + options);
   headers[constants.TRACE_CONTEXT_HEADER_NAME] = header;
 };
 

--- a/test/standalone/test-trace-header-context.js
+++ b/test/standalone/test-trace-header-context.js
@@ -94,6 +94,9 @@ describe('test-trace-header-context', function() {
       assert.equal(
         req.headers[constants.TRACE_CONTEXT_HEADER_NAME].slice(0, 6),
         context.slice(0, 6));
+      assert.equal(
+        req.headers[constants.TRACE_CONTEXT_HEADER_NAME].slice(8),
+        ';o=1');
       res.send(common.serverRes);
       var traces = common.getTraces();
       assert.equal(traces.length, 2);

--- a/test/test-trace-agent.js
+++ b/test/test-trace-agent.js
@@ -60,7 +60,7 @@ describe('Trace Agent', function() {
         var options = {
           headers: {}
         };
-        agent.addContextToHeaders(spanData, options.headers);
+        agent.addContextToHeaders(spanData, options.headers, true);
         var parsed = agent.parseContextFromHeader(
             options.headers[constants.TRACE_CONTEXT_HEADER_NAME]);
         assert.equal(parsed.traceId, 1);
@@ -70,13 +70,43 @@ describe('Trace Agent', function() {
       });
     });
 
+    it('sets trace enabled bit when traced', function() {
+      cls.getNamespace().run(function() {
+        var spanData = agent.createRootSpanData('name', 1, 2);
+        spanData.options = 2;
+        var options = {
+          headers: {}
+        };
+        agent.addContextToHeaders(spanData, options.headers, true);
+        var parsed = agent.parseContextFromHeader(
+            options.headers[constants.TRACE_CONTEXT_HEADER_NAME]);
+        assert.equal(parsed.options, 3);
+      });
+    });
+
+    it('leaves options alone when untraced', function() {
+      cls.getNamespace().run(function() {
+        var spanData = agent.createRootSpanData('name', 1, 2);
+        spanData.options = 2;
+        var options = {
+          headers: {}
+        };
+        agent.addContextToHeaders(spanData, options.headers, false);
+        var parsed = agent.parseContextFromHeader(
+            options.headers[constants.TRACE_CONTEXT_HEADER_NAME]);
+        assert.equal(parsed.options, 2);
+      });
+    });
+
     it('noop on nullSpan', function() {
       cls.getNamespace().run(function() {
         var options = {
           headers: {}
         };
         agent.addContextToHeaders(SpanData.nullSpan, options.headers);
-        assert.equal(options.headers[constants.TRACE_CONTEXT_HEADER_NAME], undefined);
+        assert.equal(
+          options.headers[constants.TRACE_CONTEXT_HEADER_NAME],
+          undefined, true);
       });
     });
   });


### PR DESCRIPTION
We currently only emit a trace header on the requests that we sample. This change causes all such outgoing traced requests to set the trace enabled bit.