### PR TITLE
Begin using test all versions for hooks

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -33,7 +33,10 @@ before_test:
 # Post-install test scripts.
 test_script:
   # run tests
-  - ps: node_modules/.bin/mocha test test\hooks --timeout 4000 --R
+  - ps: node_modules/.bin/mocha test test\hooks\test-hooks-index.js test\hooks\test-hooks-interop-mongo-express.js test\hooks\test-trace-grpc.js test\hooks\test-trace-hapi.js test\hooks\test-trace-http.js test\hooks\test-trace-mongodb.js test\hooks\test-trace-redis.js --timeout 4000 --R
+  - ps: node_modules/.bin/tav express "4.14.0" node_modules\.bin\mocha test\hooks\test-trace-express.js
+  - ps: node_modules/.bin/tav mysql "2.11.1" node_modules\.bin\mocha test\hooks\test-trace-mysql.js
+  - ps: node_modules/.bin/tav restify "3.0.3 || 4.1.1" node_modules\.bin\mocha test\hooks\test-trace-restify.js
   - ps: ForEach ($test in Get-ChildItem test/standalone/test-*.js) { if ($test -notmatch 'grpc*') { node_modules/.bin/mocha $test --timeout 4000 --R; if ($lastexitcode -ne 0) { exit 1 } } }
 
 # Don't actually build using MSBuild

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "nock": "^8.0.0",
     "proxyquire": "^1.4.0",
     "request": "^2.61.0",
+    "test-all-versions": "^1.2.1",
     "timekeeper": "0.0.5",
     "tmp": "0.0.28"
   },

--- a/test/hooks/test-trace-express.js
+++ b/test/hooks/test-trace-express.js
@@ -19,7 +19,7 @@ var traceLabels = require('../../lib/trace-labels.js');
 var http = require('http');
 var assert = require('assert');
 var common = require('./common.js');
-var express = require('./fixtures/express4');
+var express = require('express');
 
 var server;
 var write;

--- a/test/hooks/test-trace-mysql.js
+++ b/test/hooks/test-trace-mysql.js
@@ -19,7 +19,7 @@ var common = require('./common.js');
 var traceLabels = require('../../lib/trace-labels.js');
 require('../..').private_().config_.enhancedDatabaseReporting = true;
 var assert = require('assert');
-var mysql = require('./fixtures/mysql2');
+var mysql = require('mysql');
 
 var pool = mysql.createPool({
   host     : 'localhost',

--- a/test/hooks/test-trace-restify.js
+++ b/test/hooks/test-trace-restify.js
@@ -19,170 +19,163 @@ var traceLabels = require('../../lib/trace-labels.js');
 var http = require('http');
 var assert = require('assert');
 var common = require('./common.js');
-var versions = {
-  restify3: require('./fixtures/restify3'),
-  restify4: require('./fixtures/restify4')
-};
+var restify = require('restify');
 
 var server;
 var write;
 
-Object.keys(versions).forEach(function(version) {
-  var restify = versions[version];
+describe('restify', function() {
+  before(function() {
+    // Mute stderr to satiate appveyor
+    write = process.stderr.write;
+    process.stderr.write = function(c, e, cb) {
+      assert(c.indexOf('DeprecationWarning') !== -1);
+      if (cb) {
+        cb();
+      }
+    };
+  });
+  after(function() {
+    process.stderr.write = write;
+  });
+  afterEach(function() {
+    common.cleanTraces();
+    server.close();
+  });
 
-  describe(version, function() {
-    before(function() {
-      // Mute stderr to satiate appveyor
-      write = process.stderr.write;
-      process.stderr.write = function(c, e, cb) {
-        assert(c.indexOf('DeprecationWarning') !== -1);
-        if (cb) {
-          cb();
-        }
-      };
-    });
-    after(function() {
-      process.stderr.write = write;
-    });
-    afterEach(function() {
-      common.cleanTraces();
-      server.close();
-    });
-
-    it('should accurately measure get time, get', function(done) {
-      server = restify.createServer();
-      server.get('/', function (req, res, next) {
-        setTimeout(function() {
-          res.writeHead(200, {
-            'Content-Type': 'text/plain'
-          });
-          res.write(common.serverRes);
-          res.end();
-          return next();
-        }, common.serverWait);
-      });
-      server.listen(common.serverPort, function(){
-        common.doRequest('GET', done, restifyPredicate);
-      });
-    });
-
-    it('should accurately measure get time, post', function(done) {
-      server = restify.createServer();
-      server.post('/', function (req, res, next) {
-        setTimeout(function() {
-          res.writeHead(200, {
-            'Content-Type': 'text/plain'
-          });
-          res.write(common.serverRes);
-          res.end();
-          return next();
-        }, common.serverWait);
-      });
-      server.listen(common.serverPort, function(){
-        common.doRequest('POST', done, restifyPredicate);
-      });
-    });
-
-    it('should accurately measure get time, multiple handlers', function(done) {
-      server = restify.createServer();
-      server.get('/', function (req, res, next) {
-        setTimeout(function() {
-          return next();
-        }, common.serverWait / 2);
-      }, function (req, res, next) {
-        setTimeout(function() {
-          res.writeHead(200, {
-            'Content-Type': 'text/plain'
-          });
-          res.write(common.serverRes);
-          res.end();
-          return next();
-        }, common.serverWait / 2);
-      });
-      server.listen(common.serverPort, function(){
-        common.doRequest('GET', done, restifyPredicate);
-      });
-    });
-
-    it('should accurately measure get time, regex path', function(done) {
-      server = restify.createServer();
-      server.get(/\/([^&=?]*)/, function (req, res, next) {
-        setTimeout(function() {
-          res.writeHead(200, {
-            'Content-Type': 'text/plain'
-          });
-          res.write(common.serverRes);
-          res.end();
-          return next();
-        }, common.serverWait);
-      });
-      server.listen(common.serverPort, function(){
-        common.doRequest('GET', done, restifyPredicate);
-      });
-    });
-
-    it('should accurately measure get time, use and get', function(done) {
-      server = restify.createServer();
-      server.use(function (req, res, next) {
-        setTimeout(function() {
-          return next();
-        }, common.serverWait / 2);
-      });
-      server.get('/', function (req, res, next) {
-        setTimeout(function() {
-          res.writeHead(200, {
-            'Content-Type': 'text/plain'
-          });
-          res.write(common.serverRes);
-          res.end();
-          return next();
-        }, common.serverWait / 2);
-      });
-      server.listen(common.serverPort, function(){
-        common.doRequest('GET', done, restifyPredicate);
-      });
-    });
-
-    it('should have proper labels', function(done) {
-      server = restify.createServer();
-      server.get('/', function (req, res, next) {
+  it('should accurately measure get time, get', function(done) {
+    server = restify.createServer();
+    server.get('/', function (req, res, next) {
+      setTimeout(function() {
         res.writeHead(200, {
           'Content-Type': 'text/plain'
         });
         res.write(common.serverRes);
         res.end();
         return next();
-      });
-      server.listen(common.serverPort, function(){
-        http.get({port: common.serverPort}, function(res) {
-          var labels = common.getMatchingSpan(restifyPredicate).labels;
-          assert.equal(labels[traceLabels.HTTP_RESPONSE_CODE_LABEL_KEY], '200');
-          assert.equal(labels[traceLabels.HTTP_METHOD_LABEL_KEY], 'GET');
-          assert.equal(labels[traceLabels.HTTP_URL_LABEL_KEY], 'http://localhost:9042/');
-          assert(labels[traceLabels.HTTP_SOURCE_IP]);
-          done();
-        });
-      });
+      }, common.serverWait);
     });
+    server.listen(common.serverPort, function(){
+      common.doRequest('GET', done, restifyPredicate);
+    });
+  });
 
-    it('should remove trace frames from stack', function(done) {
-      server = restify.createServer();
-      server.get('/', function (req, res, next) {
+  it('should accurately measure get time, post', function(done) {
+    server = restify.createServer();
+    server.post('/', function (req, res, next) {
+      setTimeout(function() {
         res.writeHead(200, {
           'Content-Type': 'text/plain'
         });
         res.write(common.serverRes);
         res.end();
         return next();
-      });
-      server.listen(common.serverPort, function() {
-        http.get({port: common.serverPort}, function(res) {
-          var labels = common.getMatchingSpan(restifyPredicate).labels;
-          var stackTrace = JSON.parse(labels[traceLabels.STACK_TRACE_DETAILS_KEY]);
-          // Ensure that our middleware is on top of the stack
-          assert.equal(stackTrace.stack_frame[0].method_name, 'middleware');
-          done();
+      }, common.serverWait);
+    });
+    server.listen(common.serverPort, function(){
+      common.doRequest('POST', done, restifyPredicate);
+    });
+  });
+
+  it('should accurately measure get time, multiple handlers', function(done) {
+    server = restify.createServer();
+    server.get('/', function (req, res, next) {
+      setTimeout(function() {
+        return next();
+      }, common.serverWait / 2);
+    }, function (req, res, next) {
+      setTimeout(function() {
+        res.writeHead(200, {
+          'Content-Type': 'text/plain'
         });
+        res.write(common.serverRes);
+        res.end();
+        return next();
+      }, common.serverWait / 2);
+    });
+    server.listen(common.serverPort, function(){
+      common.doRequest('GET', done, restifyPredicate);
+    });
+  });
+
+  it('should accurately measure get time, regex path', function(done) {
+    server = restify.createServer();
+    server.get(/\/([^&=?]*)/, function (req, res, next) {
+      setTimeout(function() {
+        res.writeHead(200, {
+          'Content-Type': 'text/plain'
+        });
+        res.write(common.serverRes);
+        res.end();
+        return next();
+      }, common.serverWait);
+    });
+    server.listen(common.serverPort, function(){
+      common.doRequest('GET', done, restifyPredicate);
+    });
+  });
+
+  it('should accurately measure get time, use and get', function(done) {
+    server = restify.createServer();
+    server.use(function (req, res, next) {
+      setTimeout(function() {
+        return next();
+      }, common.serverWait / 2);
+    });
+    server.get('/', function (req, res, next) {
+      setTimeout(function() {
+        res.writeHead(200, {
+          'Content-Type': 'text/plain'
+        });
+        res.write(common.serverRes);
+        res.end();
+        return next();
+      }, common.serverWait / 2);
+    });
+    server.listen(common.serverPort, function(){
+      common.doRequest('GET', done, restifyPredicate);
+    });
+  });
+
+  it('should have proper labels', function(done) {
+    server = restify.createServer();
+    server.get('/', function (req, res, next) {
+      res.writeHead(200, {
+        'Content-Type': 'text/plain'
+      });
+      res.write(common.serverRes);
+      res.end();
+      return next();
+    });
+    server.listen(common.serverPort, function(){
+      http.get({port: common.serverPort}, function(res) {
+        var labels = common.getMatchingSpan(restifyPredicate).labels;
+        assert.equal(labels[traceLabels.HTTP_RESPONSE_CODE_LABEL_KEY], '200');
+        assert.equal(labels[traceLabels.HTTP_METHOD_LABEL_KEY], 'GET');
+        assert.equal(labels[traceLabels.HTTP_URL_LABEL_KEY], 'http://localhost:9042/');
+        assert(labels[traceLabels.HTTP_SOURCE_IP]);
+        done();
+      });
+    });
+  });
+
+  it('should remove trace frames from stack', function(done) {
+    server = restify.createServer();
+    server.get('/', function (req, res, next) {
+      res.writeHead(200, {
+        'Content-Type': 'text/plain'
+      });
+      res.write(common.serverRes);
+      res.end();
+      return next();
+    });
+    server.listen(common.serverPort, function() {
+      http.get({port: common.serverPort}, function(res) {
+        var labels = common.getMatchingSpan(restifyPredicate).labels;
+        var stackTrace = JSON.parse(labels[traceLabels.STACK_TRACE_DETAILS_KEY]);
+        // Ensure that our middleware is on top of the stack
+        assert.equal(stackTrace.stack_frame[0].method_name, 'middleware');
+        done();
       });
     });
   });


### PR DESCRIPTION
This change moves express, mysql, and restify over to use
test-all-versions as opposed to committed fixtures.