### PR TITLE
Add support for pre-release grpc v1.1.0

### DIFF
--- a/lib/hooks/userspace/hook-grpc.js
+++ b/lib/hooks/userspace/hook-grpc.js
@@ -24,7 +24,7 @@ var findIndex = require('lodash.findindex');
 
 var agent;
 
-var SUPPORTED_VERSIONS = '0.13 - 0.15';
+var SUPPORTED_VERSIONS = '0.13 - 1';
 
 function makeClientMethod(method, name) {
   return function clientMethodTrace() {


### PR DESCRIPTION
This was tested by:
1. Installing a new grpc fixture from grpc@master.
2. Updating `hook-grpc.js` to accept the version range `0.13 - 0.15 || 1.1.0-dev`.
3. Running `test/standalone/test-grpc-context.js` including this new fixture.
4. Running `test/hooks/test-trace-grpc.js` including this new fixture.
5. After passing tests, updating the accepted version range to `0.13 - 1`.