### PR TITLE
Fix mongoose promise deprecation

### DIFF
--- a/test/hooks/test-trace-mongoose.js
+++ b/test/hooks/test-trace-mongoose.js
@@ -25,6 +25,7 @@ var traceLabels = require('../../lib/trace-labels.js');
 
 var assert = require('assert');
 var mongoose = require('./fixtures/mongoose4');
+mongoose.Promise = global.Promise;
 var Schema = mongoose.Schema;
 
 var simpleSchema = new Schema({


### PR DESCRIPTION
Mongoose updated and dropped support for its own promise library
mpromise. The test will now rely on builtin promises.