### PR TITLE
Allow ignoring the requests Context header

### DIFF
--- a/config.js
+++ b/config.js
@@ -64,7 +64,7 @@ module.exports = {
 
     // Specifies the behavior of the trace agent in the case of an uncaught exception.
     // Possible values are:
-    //   `ignore`: Take no action. Note that the process may termiante before all the 
+    //   `ignore`: Take no action. Note that the process may termiante before all the
     //            traces currently buffered have been flushed to the network.
     //   `flush`: Handle the uncaught exception and attempt to publish the traces to
     //            the API. Note that if you have other uncaught exception handlers in your
@@ -79,6 +79,9 @@ module.exports = {
     //            a delay. Note that presence of other uncaught exception handlers may
     //            chose to terminate the application before the buffer has been flushed to
     //            the network.
-    onUncaughtException: 'ignore'
+    onUncaughtException: 'ignore',
+
+    // Allows to ignore the requests X-Cloud-Trace-Context -header if set
+    ignoreContextHeader: false
   }
 };

--- a/lib/trace-agent.js
+++ b/lib/trace-agent.js
@@ -231,6 +231,9 @@ TraceAgent.prototype.isTraceAgentRequest = function(options) {
  *         object with keys. null if there is a problem.
  */
 TraceAgent.prototype.parseContextFromHeader = function(str) {
+  if (this.config_.ignoreContextHeader) {
+    return null;
+  }
   if (!str) {
     return null;
   }

--- a/test/test-trace-agent.js
+++ b/test/test-trace-agent.js
@@ -163,11 +163,11 @@ describe('Trace Agent', function() {
 
     describe('when configured to ignore header', function() {
       it('should return expected value: null', function() {
-        var agent2 = agent;
-        agent2.config_.ignoreContextHeader = true;
-        var result = agent2.parseContextFromHeader(
+        agent.config_.ignoreContextHeader = true;
+        var result = agent.parseContextFromHeader(
           '123456/667;o=1');
         assert(!result);
+        agent.config_.ignoreContextHeader = false;
       });
     });
   });

--- a/test/test-trace-agent.js
+++ b/test/test-trace-agent.js
@@ -160,6 +160,16 @@ describe('Trace Agent', function() {
         });
       });
     });
+
+    describe('when configured to ignore header', function() {
+      it('should return expected value: null', function() {
+        var agent2 = agent;
+        agent2.config_.ignoreContextHeader = true;
+        var result = agent2.parseContextFromHeader(
+          '123456/667;o=1');
+        assert(!result);
+      });
+    });
   });
 
 });


### PR DESCRIPTION
Hi,

Short background: I've been debugging for a week an issue that started occurring last week in our GCP projects after the Google Load Balancers got an update.
The LB doesn't respect my already set "x-cloud-trace-context" -header and overwrites it.
This makes our Traces to disappear because of our complex infrastructural setup.

This simple patch allows us to continue the usage of this module without any problems.
This will help others also who have similar infrastructural setup (I can write a description of it, if necessary).

Hopefully this could be included in the main package, so I do not need to keep installing this with npm from my github.