### PR TITLE
Document using just the trace.append scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ If you are using [Google App Engine flexible environment](https://cloud.google.c
 
 ### Google Compute Engine
 
-Your VM instances need to be created with `cloud-platform` scope if created via [gcloud](https://cloud.google.com/sdk) or the 'Allow API access' checkbox selected if created via the [console][cloud-console] (see screenshot).
+Your VM instances need to be created with the `https://www.googleapis.com/auth/trace.append` or `cloud-platform` scope if created via the [gcloud](https://cloud.google.com/sdk) CLI or the Google Cloud Platform API, or with the 'Allow API access' checkbox selected if created via the [console][cloud-console] (see screenshot).
 
 ![GCE API](doc/images/gce.png?raw=true)
 


### PR DESCRIPTION
As far as I've tested today, it work fine to just use `https://www.googleapis.com/auth/trace.append` instead of the whole `cloud-platform` scope.

Ref #248