### PR TITLE
Implement gRPC Server Tracing

### DIFF
--- a/lib/hooks/userspace/hook-grpc.js
+++ b/lib/hooks/userspace/hook-grpc.js
@@ -17,6 +17,7 @@
 'use strict';
 
 var cls = require('../../cls.js');
+var TraceLabels = require('../../trace-labels.js');
 var shimmer = require('shimmer');
 var semver = require('semver');
 var SpanData = require('../../span-data.js');
@@ -176,7 +177,7 @@ function wrapBidi(namespace, handlerSet, requestName) {
       var endSpan = function () {
         if (!spanEnded) {
           spanEnded = true;
-          endRootSpanForRequest(rootContext, requestName);
+          endRootSpanForRequest(rootContext);
         }
       };
       stream.on('finish', function () {
@@ -227,7 +228,7 @@ function wrapServerStream(namespace, handlerSet, requestName) {
       var endSpan = function () {
         if (!spanEnded) {
           spanEnded = true;
-          endRootSpanForRequest(rootContext, requestName);
+          endRootSpanForRequest(rootContext);
         }
       };
       call.on('finish', function () {
@@ -273,8 +274,7 @@ function wrapClientStream(namespace, handlerSet, requestName) {
         if (agent.config_.enhancedDatabaseReporting) {
           if (err) {
             rootContext.addLabel('error', err);
-          }
-          else {
+          } else {
             rootContext.addLabel('result', JSON.stringify(result));
           }
           if (trailer) {
@@ -284,7 +284,7 @@ function wrapClientStream(namespace, handlerSet, requestName) {
         if (err) {
           // If there is an error, then no result will be serialized to
           // be sent back to the client. So end the root span here.
-          endRootSpanForRequest(rootContext, requestName);
+          endRootSpanForRequest(rootContext);
         }
         return callback(err, result);
       };
@@ -294,7 +294,7 @@ function wrapClientStream(namespace, handlerSet, requestName) {
   shimmer.wrap(handlerSet, 'serialize', function (serialize) {
     return function serializeTrace(result) {
       var serializeResult = serialize.apply(this, arguments);
-      endRootSpanForRequest(rootContext, requestName);
+      endRootSpanForRequest(rootContext);
       return serializeResult;
     };
   });
@@ -336,8 +336,7 @@ function wrapUnary(namespace, handlerSet, requestName) {
         if (agent.config_.enhancedDatabaseReporting) {
           if (err) {
             rootContext.addLabel('error', err);
-          }
-          else {
+          } else {
             rootContext.addLabel('result', JSON.stringify(result));
           }
           if (trailer) {
@@ -347,7 +346,7 @@ function wrapUnary(namespace, handlerSet, requestName) {
         if (err) {
           // If there is an error, then no result will be serialized to
           // be sent back to the client. So end the root span here.
-          endRootSpanForRequest(rootContext, requestName);
+          endRootSpanForRequest(rootContext);
         }
         return callback(err, result);
       };
@@ -357,7 +356,7 @@ function wrapUnary(namespace, handlerSet, requestName) {
   shimmer.wrap(handlerSet, 'serialize', function (serialize) {
     return function serializeTrace() {
       var serializeResult = serialize.apply(this, arguments);
-      endRootSpanForRequest(rootContext, requestName);
+      endRootSpanForRequest(rootContext);
       return serializeResult;
     };
   });
@@ -391,8 +390,10 @@ function serverRegisterWrap(register) {
       wrapServerStream(namespace, handlerSet, requestName);
     } else if (method_type === 'client_stream') {
       wrapClientStream(namespace, handlerSet, requestName);
-    } else { // method_type === 'unary'
+    } else if (method_type === 'unary') {
       wrapUnary(namespace, handlerSet, requestName);
+    } else {
+      agent.logger.warn('gRPC Server: Unrecognized method_type ' + method_type);
     }
     return result;
   };
@@ -405,7 +406,6 @@ function serverRegisterWrap(register) {
  */
 function startRootSpanForRequest(req) {
   var rootContext = agent.createRootSpanData(req, null, null, 1);
-  rootContext.span.kind = 'RPC_SERVER';
   return rootContext;
 }
 
@@ -413,9 +413,9 @@ function startRootSpanForRequest(req) {
 /**
  * Ends the root span for the given request.
  * @param {!SpanData} rootContext The span to close out.
- * @param {Object} req The request being processed.
  */
-function endRootSpanForRequest(rootContext, req) {
+function endRootSpanForRequest(rootContext) {
+  rootContext.addLabel(TraceLabels.HTTP_METHOD_LABEL_KEY, 'POST');
   rootContext.close();
 }
 

--- a/lib/hooks/userspace/hook-grpc.js
+++ b/lib/hooks/userspace/hook-grpc.js
@@ -74,27 +74,28 @@ function makeClientMethod(method) {
     // The user might need the current context in listeners to this stream.
     cls.getNamespace().bindEmitter(call);
     if (method.responseStream) {
-      // It is possible that gRPC emits simply 'error', or simply 'status',
-      // or both 'status' and 'error'. We need to make sure we do not end
-      // the span twice in the last case.
       var spanEnded = false;
-      call.on('error', function(err) {
+      var endSpan = function () {
         if (!spanEnded) {
-          if (agent.config_.enhancedDatabaseReporting) {
-            span.addLabel('error', err);
-          }
-          agent.endSpan(span);
           spanEnded = true;
+          agent.endSpan(span);
         }
+      }
+      call.on('error', function(err) {
+        if (agent.config_.enhancedDatabaseReporting) {
+          span.addLabel('error', err);
+        }
+        // By scheduling the call to end the span at the next tick,
+        // we can guarantee that if both status and error events were fired
+        // in the same frame, labels from both events will show up in the
+        // resulting trace span.
+        process.nextTick(endSpan);
       });
       call.on('status', function(status) {
-        if (!spanEnded) {
-          if (agent.config_.enhancedDatabaseReporting) {
-            span.addLabel('status', JSON.stringify(status));
-          }
-          agent.endSpan(span);
-          spanEnded = true;
+        if (agent.config_.enhancedDatabaseReporting) {
+          span.addLabel('status', JSON.stringify(status));
         }
+        process.nextTick(endSpan);
       });
     }
     return call;
@@ -133,8 +134,8 @@ function makeClientConstructorWrap(makeClientConstructor) {
 
 // # Server
 
-function sendMetadataWrapperFactory(rootContext) {
-  return function sendMetadataWrapper(sendMetadata) {
+function sendMetadataWrapper(rootContext) {
+  return function (sendMetadata) {
     return function sendMetadataTrace(responseMetadata) {
       if (rootContext) {
         rootContext.addLabel('metadata', JSON.stringify(responseMetadata.getMap()));
@@ -172,16 +173,23 @@ function serverRegisterWrap(register) {
         return namespace.bind(function funcTrace(call) {
           rootContext = startRootSpanForRequest(requestName);
           if (agent.config_.enhancedDatabaseReporting) {
-            shimmer.wrap(call, 'sendMetadata', sendMetadataWrapperFactory(rootContext));
+            shimmer.wrap(call, 'sendMetadata', sendMetadataWrapper(rootContext));
           }
+          var spanEnded = false;
+          var endSpan = function () {
+            if (!spanEnded) {
+              spanEnded = true;
+              endRootSpanForRequest(rootContext, requestName);
+            }
+          };
           call.on('finish', function () {
-            endRootSpanForRequest(rootContext, requestName);
+            process.nextTick(endSpan);
           });
           call.on('error', function (err) {
             if (agent.config_.enhancedDatabaseReporting) {
               rootContext.addLabel('error', err);
             }
-            endRootSpanForRequest(rootContext, requestName);
+            process.nextTick(endSpan);
           });
           return func.apply(this, arguments);
         }, context);
@@ -198,22 +206,28 @@ function serverRegisterWrap(register) {
       shimmer.wrap(handlerSet, 'func', function (func) {
         return namespace.bind(function funcTrace(call) {
           if (agent.config_.enhancedDatabaseReporting) {
-            shimmer.wrap(call, 'sendMetadata', sendMetadataWrapperFactory(rootContext));
+            shimmer.wrap(call, 'sendMetadata', sendMetadataWrapper(rootContext));
           }
           if (agent.config_.enhancedDatabaseReporting) {
             rootContext.addLabel('argument', JSON.stringify(call.request));
           }
-          var result = func.apply(this, arguments);
+          var spanEnded = false;
+          var endSpan = function () {
+            if (!spanEnded) {
+              spanEnded = true;
+              endRootSpanForRequest(rootContext, requestName);
+            }
+          };
           call.on('finish', function () {
-            endRootSpanForRequest(rootContext, requestName);
+            process.nextTick(endSpan);
           });
           call.on('error', function (err) {
             if (agent.config_.enhancedDatabaseReporting) {
               rootContext.addLabel('error', err);
             }
-            endRootSpanForRequest(rootContext, requestName);
+            process.nextTick(endSpan);
           });
-          return result;
+          return func.apply(this, arguments);
         }, context);
       });
     } else if (method_type === 'client_stream') {
@@ -223,7 +237,7 @@ function serverRegisterWrap(register) {
         return namespace.bind(function funcTrace(call, callback) {
           rootContext = startRootSpanForRequest(requestName);
           if (agent.config_.enhancedDatabaseReporting) {
-            shimmer.wrap(call, 'sendMetadata', sendMetadataWrapperFactory(rootContext));
+            shimmer.wrap(call, 'sendMetadata', sendMetadataWrapper(rootContext));
           }
           // arguments[1] is the callback
           arguments[1] = function (err, result, trailer) {
@@ -271,7 +285,7 @@ function serverRegisterWrap(register) {
       shimmer.wrap(handlerSet, 'func', function (func) {
         return namespace.bind(function funcTrace(call, callback) {
           if (agent.config_.enhancedDatabaseReporting) {
-            shimmer.wrap(call, 'sendMetadata', sendMetadataWrapperFactory(rootContext));
+            shimmer.wrap(call, 'sendMetadata', sendMetadataWrapper(rootContext));
           }
           if (agent.config_.enhancedDatabaseReporting) {
             rootContext.addLabel('argument', JSON.stringify(call.request));
@@ -317,7 +331,7 @@ function serverRegisterWrap(register) {
  * @returns {!SpanData} The new initialized trace span data instance.
  */
 function startRootSpanForRequest(req) {
-  var rootContext = agent.createRootSpanData(req, null, null, 3);
+  var rootContext = agent.createRootSpanData(req, null, null, 1);
   rootContext.span.kind = "RPC_SERVER";
   return rootContext;
 }

--- a/lib/hooks/userspace/hook-grpc.js
+++ b/lib/hooks/userspace/hook-grpc.js
@@ -147,8 +147,8 @@ function sendMetadataWrapper(rootContext) {
         agent.logger.info('gRPC: No root context found in sendMetadata');
       }
       return sendMetadata.apply(this, arguments);
-    }
-  }
+    };
+  };
 }
 
 /**
@@ -378,10 +378,7 @@ function serverRegisterWrap(register) {
     }
     var result = register.apply(this, arguments);
     var handlerSet = this.handlers[name];
-    var requestName = "grpc:" + name;
-    var rootContext;
-    // CLS context object
-    var context = {};
+    var requestName = 'grpc:' + name;
     // Proceed to wrap methods that are invoked when a gRPC service call is made.
     // In every case, the function 'func' is the user-implemented handling function.
     if (method_type === 'bidi') {
@@ -394,7 +391,7 @@ function serverRegisterWrap(register) {
       wrapUnary(namespace, handlerSet, requestName);
     }
     return result;
-  }
+  };
 }
 
 /**
@@ -404,7 +401,7 @@ function serverRegisterWrap(register) {
  */
 function startRootSpanForRequest(req) {
   var rootContext = agent.createRootSpanData(req, null, null, 1);
-  rootContext.span.kind = "RPC_SERVER";
+  rootContext.span.kind = 'RPC_SERVER';
   return rootContext;
 }
 

--- a/lib/hooks/userspace/hook-grpc.js
+++ b/lib/hooks/userspace/hook-grpc.js
@@ -135,6 +135,10 @@ function makeClientConstructorWrap(makeClientConstructor) {
 
 function serverRegisterWrap(register) {
   return function registerTrace(name, handler, serialize, deserialize, method_type) {
+    // register(n, h, s, d, m) is called in addService once for each service method.
+    // Its role is to assign the serialize, deserialize, and user logic handlers
+    // for each exposed service method. Here, we wrap these functions depending on the
+    // method type.
     var namespace = cls.getNamespace();
     if (!namespace) {
       agent.logger.info('gRPC: no namespace found, ignoring request');
@@ -142,46 +146,106 @@ function serverRegisterWrap(register) {
     }
     var result = register.apply(this, arguments);
     var handlerSet = this.handlers[name];
+    var requestName = "grpc:" + name;
     var rootContext;
-    if (method_type == 'bidi' || method_type == 'client_stream') {
-      // Streaming Client: Start the root span right before the gRPC function is invoked.
+    // CLS context object
+    var context = {};
+    // Proceed to wrap methods that are invoked when a gRPC service call is made.
+    // In every case, the function 'func' is the user-implemented handling function.
+    if (method_type == 'bidi') {
+      // Start right before call to function
+      // End right after output stream 'finish' event
       shimmer.wrap(handlerSet, 'func', function (func) {
-        return namespace.bind(function funcTrace() {
-          rootContext = startRootSpanForRequest(name);
+        return namespace.bind(function funcTrace(call) {
+          rootContext = startRootSpanForRequest(requestName);
+          call.on('finish', function () {
+            endRootSpanForRequest(rootContext, requestName);
+          });
           return func.apply(this, arguments);
-        });
+        }, context);
       });
-    } else {
-      // Single Client Request: Start the root span right before deserializing the request.
+    } else if (method_type == 'server_stream') {
+      // Start right before deserialization (which precedes call to function)
+      // End right after output stream 'finish' event
       shimmer.wrap(handlerSet, 'deserialize', function (deserialize) {
         return namespace.bind(function deserializeTrace() {
-          rootContext = startRootSpanForRequest(name);
-          // We still need to bind the gRPC function to our namespace.
-          shimmer.wrap(handlerSet, 'func', function (func) {
-            return namespace.bind(function () {
-              func.apply(this, arguments);
-            });
-          });
+          rootContext = startRootSpanForRequest(requestName);
           return deserialize.apply(this, arguments);
-        });
+        }, context);
       });
-    }
-    if (method_type == 'bidi' || method_type == 'server_stream') {
-      // Streaming Server: End the root span once the server closes the response stream.
       shimmer.wrap(handlerSet, 'func', function (func) {
-        return function endStreamTrace(stream) {
-          stream.on('finish', function () {
-            endRootSpanForRequest(rootContext, name);
+        return namespace.bind(function funcTrace(call) {
+          if (agent.config_.enhancedDatabaseReporting) {
+            rootContext.addLabel('argument', JSON.stringify(call.request));
+          }
+          var result = func.apply(this, arguments);
+          call.on('finish', function () {
+            endRootSpanForRequest(rootContext, requestName);
           });
+          return result;
+        }, context);
+      });
+    } else if (method_type == 'client_stream') {
+      // Start right before call to function
+      // End right after serialization (which is done in the callback)
+      shimmer.wrap(handlerSet, 'func', function (func) {
+        return namespace.bind(function funcTrace(call, callback) {
+          rootContext = startRootSpanForRequest(requestName);
+          if (agent.config_.enhancedDatabaseReporting) {
+            // arguments[1] is the callback
+            arguments[1] = function (err, result) {
+              if (err) {
+                rootContext.addLabel('error', err);
+              } else {
+                rootContext.addLabel('result', JSON.stringify(result));
+              }
+              return callback(err, result);
+            }
+          }
           return func.apply(this, arguments);
+        }, context);
+      });
+      shimmer.wrap(handlerSet, 'serialize', function (serialize) {
+        return function serializeTrace(result) {
+          var serializeResult = serialize.apply(this, arguments);
+          endRootSpanForRequest(rootContext, requestName);
+          return serializeResult;
         };
       });
     } else {
-      // Single Server Response: End the root span right after serializing the response.
+      // Start right before deserialization
+      // End right after serialization
+      shimmer.wrap(handlerSet, 'deserialize', function (deserialize) {
+        return namespace.bind(function deserializeTrace() {
+          rootContext = startRootSpanForRequest(requestName);
+          return deserialize.apply(this, arguments);
+        }, context);
+      });
+      // Even though our root span doesn't start or end here,
+      // we need to wrap 'func' so that:
+      // (1) child spans have the correct context, and
+      // (2) we can get additional labels as needed
+      shimmer.wrap(handlerSet, 'func', function (func) {
+        return namespace.bind(function funcTrace(call, callback) {
+          if (agent.config_.enhancedDatabaseReporting) {
+            rootContext.addLabel('argument', JSON.stringify(call.request));
+            // arguments[1] is the callback
+            arguments[1] = function (err, result) {
+              if (err) {
+                rootContext.addLabel('error', err);
+              } else {
+                rootContext.addLabel('result', JSON.stringify(result));
+              }
+              return callback(err, result);
+            }
+          }
+          return func.apply(this, arguments);
+        }, context);
+      });
       shimmer.wrap(handlerSet, 'serialize', function (serialize) {
         return function serializeTrace() {
           var serializeResult = serialize.apply(this, arguments);
-          endRootSpanForRequest(rootContext, name);
+          endRootSpanForRequest(rootContext, requestName);
           return serializeResult;
         };
       });

--- a/lib/hooks/userspace/hook-grpc.js
+++ b/lib/hooks/userspace/hook-grpc.js
@@ -165,11 +165,13 @@ function wrapBidi(namespace, handlerSet, requestName) {
   // Start right before call to function
   // End right after output stream 'finish' event
   shimmer.wrap(handlerSet, 'func', function (func) {
-    return namespace.bind(function funcTrace(call) {
+    return namespace.bind(function funcTrace(stream) {
       rootContext = startRootSpanForRequest(requestName);
       if (agent.config_.enhancedDatabaseReporting) {
-        shimmer.wrap(call, 'sendMetadata', sendMetadataWrapper(rootContext));
+        shimmer.wrap(stream, 'sendMetadata', sendMetadataWrapper(rootContext));
       }
+      // Preserve context in stream event handlers.
+      namespace.bindEmitter(stream);
       var spanEnded = false;
       var endSpan = function () {
         if (!spanEnded) {
@@ -177,13 +179,13 @@ function wrapBidi(namespace, handlerSet, requestName) {
           endRootSpanForRequest(rootContext, requestName);
         }
       };
-      call.on('finish', function () {
+      stream.on('finish', function () {
         // End the span unless there is an error.
-        if (call.status.code === 0) {
+        if (stream.status.code === 0) {
           endSpan();
         }
       });
-      call.on('error', function (err) {
+      stream.on('error', function (err) {
         if (agent.config_.enhancedDatabaseReporting) {
           rootContext.addLabel('error', err);
         }
@@ -259,11 +261,13 @@ function wrapClientStream(namespace, handlerSet, requestName) {
   // Start right before call to function
   // End right after serialization (which is done in the callback)
   shimmer.wrap(handlerSet, 'func', function (func) {
-    return namespace.bind(function funcTrace(call, callback) {
+    return namespace.bind(function funcTrace(stream, callback) {
       rootContext = startRootSpanForRequest(requestName);
       if (agent.config_.enhancedDatabaseReporting) {
-        shimmer.wrap(call, 'sendMetadata', sendMetadataWrapper(rootContext));
+        shimmer.wrap(stream, 'sendMetadata', sendMetadataWrapper(rootContext));
       }
+      // Preserve context in stream event handlers.
+      namespace.bindEmitter(stream);
       // arguments[1] is the callback
       arguments[1] = function (err, result, trailer) {
         if (agent.config_.enhancedDatabaseReporting) {

--- a/lib/hooks/userspace/hook-grpc.js
+++ b/lib/hooks/userspace/hook-grpc.js
@@ -153,47 +153,66 @@ function sendMetadataWrapper(rootContext) {
 }
 
 /**
- * Wraps a bidirectional streaming function in order to record trace spans.
+ * Wraps a unary function in order to record trace spans.
  * @param {cls.Namespace} namespace The CLS namespace.
  * @param {Object} handlerSet An object containing references to the function handle,
  * as well as serialize and deserialize handles.
  * @param {string} requestName The human-friendly name of the request.
  */
-function wrapBidi(namespace, handlerSet, requestName) {
+function wrapUnary(namespace, handlerSet, requestName) {
   var rootContext;
-  // CLS context object
+  // CLS context object. Because a root span is started outside of the unary function
+  // handle, we use this object to explicitly ensure that any client trace spans
+  // have the same context available to them.
   var context = {};
-  // Start right before call to function
-  // End right after output stream 'finish' event
-  shimmer.wrap(handlerSet, 'func', function (func) {
-    return namespace.bind(function funcTrace(stream) {
+  // Start right before deserialization
+  // End right after serialization
+  shimmer.wrap(handlerSet, 'deserialize', function (deserialize) {
+    return namespace.bind(function deserializeTrace() {
       rootContext = startRootSpanForRequest(requestName);
+      return deserialize.apply(this, arguments);
+    }, context);
+  });
+  // Even though our root span doesn't start or end here,
+  // we need to wrap 'func' so that:
+  // (1) child spans have the correct context, and
+  // (2) we can get additional labels as needed
+  shimmer.wrap(handlerSet, 'func', function (func) {
+    return namespace.bind(function funcTrace(call, callback) {
       if (agent.config_.enhancedDatabaseReporting) {
-        shimmer.wrap(stream, 'sendMetadata', sendMetadataWrapper(rootContext));
+        shimmer.wrap(call, 'sendMetadata', sendMetadataWrapper(rootContext));
       }
-      // Preserve context in stream event handlers.
-      namespace.bindEmitter(stream);
-      var spanEnded = false;
-      var endSpan = function () {
-        if (!spanEnded) {
-          spanEnded = true;
+      if (agent.config_.enhancedDatabaseReporting) {
+        rootContext.addLabel('argument', JSON.stringify(call.request));
+      }
+      // arguments[1] is the callback
+      arguments[1] = function (err, result, trailer, flags) {
+        if (agent.config_.enhancedDatabaseReporting) {
+          if (err) {
+            rootContext.addLabel('error', err);
+          } else {
+            rootContext.addLabel('result', JSON.stringify(result));
+          }
+          if (trailer) {
+            rootContext.addLabel('trailing_metadata', JSON.stringify(trailer.getMap()));
+          }
+        }
+        if (err) {
+          // If there is an error, then no result will be serialized to
+          // be sent back to the client. So end the root span here.
           endRootSpanForRequest(rootContext);
         }
+        return callback(err, result, trailer, flags);
       };
-      stream.on('finish', function () {
-        // End the span unless there is an error.
-        if (stream.status.code === 0) {
-          endSpan();
-        }
-      });
-      stream.on('error', function (err) {
-        if (agent.config_.enhancedDatabaseReporting) {
-          rootContext.addLabel('error', err);
-        }
-        endSpan();
-      });
       return func.apply(this, arguments);
     }, context);
+  });
+  shimmer.wrap(handlerSet, 'serialize', function (serialize) {
+    return function serializeTrace() {
+      var serializeResult = serialize.apply(this, arguments);
+      endRootSpanForRequest(rootContext);
+      return serializeResult;
+    };
   });
 }
 
@@ -206,7 +225,7 @@ function wrapBidi(namespace, handlerSet, requestName) {
  */
 function wrapServerStream(namespace, handlerSet, requestName) {
   var rootContext;
-  // CLS context object
+  // CLS context object.
   var context = {};
   // Start right before deserialization (which precedes call to function)
   // End right after output stream 'finish' event
@@ -270,7 +289,7 @@ function wrapClientStream(namespace, handlerSet, requestName) {
       // Preserve context in stream event handlers.
       namespace.bindEmitter(stream);
       // arguments[1] is the callback
-      arguments[1] = function (err, result, trailer) {
+      arguments[1] = function (err, result, trailer, flags) {
         if (agent.config_.enhancedDatabaseReporting) {
           if (err) {
             rootContext.addLabel('error', err);
@@ -286,7 +305,7 @@ function wrapClientStream(namespace, handlerSet, requestName) {
           // be sent back to the client. So end the root span here.
           endRootSpanForRequest(rootContext);
         }
-        return callback(err, result);
+        return callback(err, result, trailer, flags);
       };
       return func.apply(this, arguments);
     }, context);
@@ -301,64 +320,47 @@ function wrapClientStream(namespace, handlerSet, requestName) {
 }
 
 /**
- * Wraps a unary function in order to record trace spans.
+ * Wraps a bidirectional streaming function in order to record trace spans.
  * @param {cls.Namespace} namespace The CLS namespace.
  * @param {Object} handlerSet An object containing references to the function handle,
  * as well as serialize and deserialize handles.
  * @param {string} requestName The human-friendly name of the request.
  */
-function wrapUnary(namespace, handlerSet, requestName) {
+function wrapBidi(namespace, handlerSet, requestName) {
   var rootContext;
   // CLS context object
   var context = {};
-  // Start right before deserialization
-  // End right after serialization
-  shimmer.wrap(handlerSet, 'deserialize', function (deserialize) {
-    return namespace.bind(function deserializeTrace() {
-      rootContext = startRootSpanForRequest(requestName);
-      return deserialize.apply(this, arguments);
-    }, context);
-  });
-  // Even though our root span doesn't start or end here,
-  // we need to wrap 'func' so that:
-  // (1) child spans have the correct context, and
-  // (2) we can get additional labels as needed
+  // Start right before call to function
+  // End right after output stream 'finish' event
   shimmer.wrap(handlerSet, 'func', function (func) {
-    return namespace.bind(function funcTrace(call, callback) {
+    return namespace.bind(function funcTrace(stream) {
+      rootContext = startRootSpanForRequest(requestName);
       if (agent.config_.enhancedDatabaseReporting) {
-        shimmer.wrap(call, 'sendMetadata', sendMetadataWrapper(rootContext));
+        shimmer.wrap(stream, 'sendMetadata', sendMetadataWrapper(rootContext));
       }
-      if (agent.config_.enhancedDatabaseReporting) {
-        rootContext.addLabel('argument', JSON.stringify(call.request));
-      }
-      // arguments[1] is the callback
-      arguments[1] = function (err, result, trailer) {
-        if (agent.config_.enhancedDatabaseReporting) {
-          if (err) {
-            rootContext.addLabel('error', err);
-          } else {
-            rootContext.addLabel('result', JSON.stringify(result));
-          }
-          if (trailer) {
-            rootContext.addLabel('trailing_metadata', JSON.stringify(trailer.getMap()));
-          }
-        }
-        if (err) {
-          // If there is an error, then no result will be serialized to
-          // be sent back to the client. So end the root span here.
+      // Preserve context in stream event handlers.
+      namespace.bindEmitter(stream);
+      var spanEnded = false;
+      var endSpan = function () {
+        if (!spanEnded) {
+          spanEnded = true;
           endRootSpanForRequest(rootContext);
         }
-        return callback(err, result);
       };
+      stream.on('finish', function () {
+        // End the span unless there is an error.
+        if (stream.status.code === 0) {
+          endSpan();
+        }
+      });
+      stream.on('error', function (err) {
+        if (agent.config_.enhancedDatabaseReporting) {
+          rootContext.addLabel('error', err);
+        }
+        endSpan();
+      });
       return func.apply(this, arguments);
     }, context);
-  });
-  shimmer.wrap(handlerSet, 'serialize', function (serialize) {
-    return function serializeTrace() {
-      var serializeResult = serialize.apply(this, arguments);
-      endRootSpanForRequest(rootContext);
-      return serializeResult;
-    };
   });
 }
 
@@ -384,14 +386,14 @@ function serverRegisterWrap(register) {
     var requestName = 'grpc:' + name;
     // Proceed to wrap methods that are invoked when a gRPC service call is made.
     // In every case, the function 'func' is the user-implemented handling function.
-    if (method_type === 'bidi') {
-      wrapBidi(namespace, handlerSet, requestName);
+    if (method_type === 'unary') {
+      wrapUnary(namespace, handlerSet, requestName);
     } else if (method_type === 'server_stream') {
       wrapServerStream(namespace, handlerSet, requestName);
     } else if (method_type === 'client_stream') {
       wrapClientStream(namespace, handlerSet, requestName);
-    } else if (method_type === 'unary') {
-      wrapUnary(namespace, handlerSet, requestName);
+    } else if (method_type === 'bidi') {
+      wrapBidi(namespace, handlerSet, requestName);
     } else {
       agent.logger.warn('gRPC Server: Unrecognized method_type ' + method_type);
     }

--- a/lib/hooks/userspace/hook-grpc.js
+++ b/lib/hooks/userspace/hook-grpc.js
@@ -87,7 +87,7 @@ function makeClientMethod(method) {
         }
         // By scheduling the call to end the span at the next tick,
         // we can guarantee that if both status and error events were fired
-        // in the same frame, labels from both events will show up in the
+        // in the same frame, so labels from both events will show up in the
         // resulting trace span.
         process.nextTick(endSpan);
       });
@@ -134,6 +134,14 @@ function makeClientConstructorWrap(makeClientConstructor) {
 
 // # Server
 
+/**
+ * A helper function to record metadata in a trace span. The return value of this
+ * function can be used as the 'wrapper' argument to wrap sendMetadata.
+ * sendMetadata is a member of each of ServerUnaryCall, ServerWriteableStream,
+ * ServerReadableStream, and ServerDuplexStream.
+ * @param rootContext The span object to which the metadata should be added.
+ * @returns {Function} A function that returns a wrapped form of sendMetadata.
+ */
 function sendMetadataWrapper(rootContext) {
   return function (sendMetadata) {
     return function sendMetadataTrace(responseMetadata) {
@@ -147,6 +155,12 @@ function sendMetadataWrapper(rootContext) {
   }
 }
 
+/**
+ * Returns a function that wraps the gRPC server register function in order
+ * to create trace spans for gRPC service methods.
+ * @param {Function(*)} register The function Server.prototype.register
+ * @returns {Function(*)} registerTrace The new wrapper function.
+ */
 function serverRegisterWrap(register) {
   return function registerTrace(name, handler, serialize, deserialize, method_type) {
     // register(n, h, s, d, m) is called in addService once for each service method.

--- a/lib/hooks/userspace/hook-grpc.js
+++ b/lib/hooks/userspace/hook-grpc.js
@@ -26,7 +26,9 @@ var agent;
 
 var SUPPORTED_VERSIONS = '0.13 - 1';
 
-function makeClientMethod(method, name) {
+// # Client
+
+function makeClientMethod(method) {
   return function clientMethodTrace() {
     var root = cls.getRootContext();
     if (!root) {
@@ -59,7 +61,7 @@ function makeClientMethod(method, name) {
       // but this is an extremely rare case.
       var metaIndex = findIndex(arguments, function(arg) {
         return arg && typeof arg === 'object' && arg._internal_repr &&
-            typeof arg.getMap === 'function';
+          typeof arg.getMap === 'function';
       });
       if (metaIndex !== -1) {
         var metadata = arguments[metaIndex];
@@ -129,6 +131,89 @@ function makeClientConstructorWrap(makeClientConstructor) {
   };
 }
 
+// # Server
+
+function serverRegisterWrap(register) {
+  return function registerTrace(name, handler, serialize, deserialize, method_type) {
+    var namespace = cls.getNamespace();
+    if (!namespace) {
+      agent.logger.info('gRPC: no namespace found, ignoring request');
+      return register.apply(this, arguments);
+    }
+    var result = register.apply(this, arguments);
+    var handler = this.handlers[name];
+    var rootContext;
+    if (method_type == 'bidi' || method_type == 'client_stream') {
+      // Streaming Client: Start the root span right before the gRPC function is invoked.
+      shimmer.wrap(handler, 'func', function (func) {
+        return namespace.bind(function funcTrace() {
+          rootContext = startRootSpanForRequest(name);
+          return func.apply(this, arguments);
+        });
+      });
+    } else {
+      // Single Client Request: Start the root span right before deserializing the request.
+      shimmer.wrap(handler, 'deserialize', function (deserialize) {
+        return namespace.bind(function deserializeTrace() {
+          rootContext = startRootSpanForRequest(name);
+          // We still need to bind the gRPC function to our namespace.
+          shimmer.wrap(handler, 'func', function (func) {
+            return namespace.bind(function () {
+              func.apply(this, arguments);
+            });
+          })
+          return deserialize.apply(this, arguments);
+        });
+      });
+    }
+    if (method_type == 'bidi' || method_type == 'server_stream') {
+      // Streaming Server: End the root span once the server closes the response stream.
+      shimmer.wrap(handler, 'func', function (func) {
+        return function endStreamTrace(stream) {
+          stream.on('finish', function () {
+            endRootSpanForRequest(rootContext, name);
+          });
+          return func.apply(this, arguments);
+        };
+      });
+    } else {
+      // Single Server Response: End the root span right after serializing the response.
+      shimmer.wrap(handler, 'serialize', function (serialize) {
+        return function serializeTrace() {
+          var serializeResult = serialize.apply(this, arguments);
+          endRootSpanForRequest(rootContext, name);
+          return serializeResult;
+        };
+      });
+    }
+    return result;
+  }
+}
+
+/**
+ * Creates and sets up a new root span for the given request.
+ * @param {Object} req The request being processed.
+ * @param {Object} traceHeader The incoming trace header.
+ * @returns {!SpanData} The new initialized trace span data instance.
+ */
+function startRootSpanForRequest(req) {
+  var rootContext = agent.createRootSpanData(req, null, null, 3);
+  return rootContext;
+}
+
+
+/**
+ * Ends the root span for the given request.
+ * @param {!SpanData} rootContext The span to close out.
+ * @param {Object} req The request being processed.
+ * @param {Object} res The response being processed.
+ */
+function endRootSpanForRequest(rootContext, req) {
+  rootContext.close();
+}
+
+// # Exports
+
 module.exports = function(version_, agent_) {
   if (!semver.satisfies(version_, SUPPORTED_VERSIONS)) {
     agent_.logger.info('grpc: unsupported version ' + version_ + ' loaded');
@@ -139,7 +224,7 @@ module.exports = function(version_, agent_) {
       patch: function(client) {
         agent = agent_;
         shimmer.wrap(client, 'makeClientConstructor',
-            makeClientConstructorWrap);
+          makeClientConstructorWrap);
       },
       unpatch: function(client) {
         // Only the Client constructor is unwrapped, so that future grpc.load's
@@ -147,6 +232,15 @@ module.exports = function(version_, agent_) {
         // objects with wrapped prototype methods will continue tracing.
         shimmer.unwrap(client, 'makeClientConstructor');
         agent_.logger.info('gRPC makeClientConstructor: unpatched');
+      }
+    },
+    'src/node/src/server.js': {
+      patch: function(server) {
+        shimmer.wrap(server.Server.prototype, 'register', serverRegisterWrap);
+      },
+      unpatch: function(server) {
+        shimmer.unwrap(server.Server.prototype, 'register');
+        agent_.logger.info('gRPC Server: unpatched');
       }
     }
   };

--- a/lib/hooks/userspace/hook-grpc.js
+++ b/lib/hooks/userspace/hook-grpc.js
@@ -152,6 +152,214 @@ function sendMetadataWrapper(rootContext) {
 }
 
 /**
+ * Wraps a bidirectional streaming function in order to record trace spans.
+ * @param {cls.Namespace} namespace The CLS namespace.
+ * @param {Object} handlerSet An object containing references to the function handle,
+ * as well as serialize and deserialize handles.
+ * @param {string} requestName The human-friendly name of the request.
+ */
+function wrapBidi(namespace, handlerSet, requestName) {
+  var rootContext;
+  // CLS context object
+  var context = {};
+  // Start right before call to function
+  // End right after output stream 'finish' event
+  shimmer.wrap(handlerSet, 'func', function (func) {
+    return namespace.bind(function funcTrace(call) {
+      rootContext = startRootSpanForRequest(requestName);
+      if (agent.config_.enhancedDatabaseReporting) {
+        shimmer.wrap(call, 'sendMetadata', sendMetadataWrapper(rootContext));
+      }
+      var spanEnded = false;
+      var endSpan = function () {
+        if (!spanEnded) {
+          spanEnded = true;
+          endRootSpanForRequest(rootContext, requestName);
+        }
+      };
+      call.on('finish', function () {
+        // End the span unless there is an error.
+        if (call.status.code === 0) {
+          endSpan();
+        }
+      });
+      call.on('error', function (err) {
+        if (agent.config_.enhancedDatabaseReporting) {
+          rootContext.addLabel('error', err);
+        }
+        endSpan();
+      });
+      return func.apply(this, arguments);
+    }, context);
+  });
+}
+
+/**
+ * Wraps a server streaming function in order to record trace spans.
+ * @param {cls.Namespace} namespace The CLS namespace.
+ * @param {Object} handlerSet An object containing references to the function handle,
+ * as well as serialize and deserialize handles.
+ * @param {string} requestName The human-friendly name of the request.
+ */
+function wrapServerStream(namespace, handlerSet, requestName) {
+  var rootContext;
+  // CLS context object
+  var context = {};
+  // Start right before deserialization (which precedes call to function)
+  // End right after output stream 'finish' event
+  shimmer.wrap(handlerSet, 'deserialize', function (deserialize) {
+    return namespace.bind(function deserializeTrace() {
+      rootContext = startRootSpanForRequest(requestName);
+      return deserialize.apply(this, arguments);
+    }, context);
+  });
+  shimmer.wrap(handlerSet, 'func', function (func) {
+    return namespace.bind(function funcTrace(call) {
+      if (agent.config_.enhancedDatabaseReporting) {
+        shimmer.wrap(call, 'sendMetadata', sendMetadataWrapper(rootContext));
+      }
+      if (agent.config_.enhancedDatabaseReporting) {
+        rootContext.addLabel('argument', JSON.stringify(call.request));
+      }
+      var spanEnded = false;
+      var endSpan = function () {
+        if (!spanEnded) {
+          spanEnded = true;
+          endRootSpanForRequest(rootContext, requestName);
+        }
+      };
+      call.on('finish', function () {
+        // End the span unless there is an error.
+        if (call.status.code === 0) {
+          endSpan();
+        }
+      });
+      call.on('error', function (err) {
+        if (agent.config_.enhancedDatabaseReporting) {
+          rootContext.addLabel('error', err);
+        }
+        endSpan();
+      });
+      return func.apply(this, arguments);
+    }, context);
+  });
+}
+
+/**
+ * Wraps a client streaming function in order to record trace spans.
+ * @param {cls.Namespace} namespace The CLS namespace.
+ * @param {Object} handlerSet An object containing references to the function handle,
+ * as well as serialize and deserialize handles.
+ * @param {string} requestName The human-friendly name of the request.
+ */
+function wrapClientStream(namespace, handlerSet, requestName) {
+  var rootContext;
+  // CLS context object
+  var context = {};
+  // Start right before call to function
+  // End right after serialization (which is done in the callback)
+  shimmer.wrap(handlerSet, 'func', function (func) {
+    return namespace.bind(function funcTrace(call, callback) {
+      rootContext = startRootSpanForRequest(requestName);
+      if (agent.config_.enhancedDatabaseReporting) {
+        shimmer.wrap(call, 'sendMetadata', sendMetadataWrapper(rootContext));
+      }
+      // arguments[1] is the callback
+      arguments[1] = function (err, result, trailer) {
+        if (agent.config_.enhancedDatabaseReporting) {
+          if (err) {
+            rootContext.addLabel('error', err);
+          }
+          else {
+            rootContext.addLabel('result', JSON.stringify(result));
+          }
+          if (trailer) {
+            rootContext.addLabel('trailing_metadata', JSON.stringify(trailer.getMap()));
+          }
+        }
+        if (err) {
+          // If there is an error, then no result will be serialized to
+          // be sent back to the client. So end the root span here.
+          endRootSpanForRequest(rootContext, requestName);
+        }
+        return callback(err, result);
+      };
+      return func.apply(this, arguments);
+    }, context);
+  });
+  shimmer.wrap(handlerSet, 'serialize', function (serialize) {
+    return function serializeTrace(result) {
+      var serializeResult = serialize.apply(this, arguments);
+      endRootSpanForRequest(rootContext, requestName);
+      return serializeResult;
+    };
+  });
+}
+
+/**
+ * Wraps a unary function in order to record trace spans.
+ * @param {cls.Namespace} namespace The CLS namespace.
+ * @param {Object} handlerSet An object containing references to the function handle,
+ * as well as serialize and deserialize handles.
+ * @param {string} requestName The human-friendly name of the request.
+ */
+function wrapUnary(namespace, handlerSet, requestName) {
+  var rootContext;
+  // CLS context object
+  var context = {};
+  // Start right before deserialization
+  // End right after serialization
+  shimmer.wrap(handlerSet, 'deserialize', function (deserialize) {
+    return namespace.bind(function deserializeTrace() {
+      rootContext = startRootSpanForRequest(requestName);
+      return deserialize.apply(this, arguments);
+    }, context);
+  });
+  // Even though our root span doesn't start or end here,
+  // we need to wrap 'func' so that:
+  // (1) child spans have the correct context, and
+  // (2) we can get additional labels as needed
+  shimmer.wrap(handlerSet, 'func', function (func) {
+    return namespace.bind(function funcTrace(call, callback) {
+      if (agent.config_.enhancedDatabaseReporting) {
+        shimmer.wrap(call, 'sendMetadata', sendMetadataWrapper(rootContext));
+      }
+      if (agent.config_.enhancedDatabaseReporting) {
+        rootContext.addLabel('argument', JSON.stringify(call.request));
+      }
+      // arguments[1] is the callback
+      arguments[1] = function (err, result, trailer) {
+        if (agent.config_.enhancedDatabaseReporting) {
+          if (err) {
+            rootContext.addLabel('error', err);
+          }
+          else {
+            rootContext.addLabel('result', JSON.stringify(result));
+          }
+          if (trailer) {
+            rootContext.addLabel('trailing_metadata', JSON.stringify(trailer.getMap()));
+          }
+        }
+        if (err) {
+          // If there is an error, then no result will be serialized to
+          // be sent back to the client. So end the root span here.
+          endRootSpanForRequest(rootContext, requestName);
+        }
+        return callback(err, result);
+      };
+      return func.apply(this, arguments);
+    }, context);
+  });
+  shimmer.wrap(handlerSet, 'serialize', function (serialize) {
+    return function serializeTrace() {
+      var serializeResult = serialize.apply(this, arguments);
+      endRootSpanForRequest(rootContext, requestName);
+      return serializeResult;
+    };
+  });
+}
+
+/**
  * Returns a function that wraps the gRPC server register function in order
  * to create trace spans for gRPC service methods.
  * @param {Function} register The function Server.prototype.register
@@ -177,165 +385,13 @@ function serverRegisterWrap(register) {
     // Proceed to wrap methods that are invoked when a gRPC service call is made.
     // In every case, the function 'func' is the user-implemented handling function.
     if (method_type === 'bidi') {
-      // Start right before call to function
-      // End right after output stream 'finish' event
-      shimmer.wrap(handlerSet, 'func', function (func) {
-        return namespace.bind(function funcTrace(call) {
-          rootContext = startRootSpanForRequest(requestName);
-          if (agent.config_.enhancedDatabaseReporting) {
-            shimmer.wrap(call, 'sendMetadata', sendMetadataWrapper(rootContext));
-          }
-          var spanEnded = false;
-          var endSpan = function () {
-            if (!spanEnded) {
-              spanEnded = true;
-              endRootSpanForRequest(rootContext, requestName);
-            }
-          };
-          call.on('finish', function () {
-            // End the span unless there is an error.
-            if (call.status.code === 0) {
-              endSpan();
-            }
-          });
-          call.on('error', function (err) {
-            if (agent.config_.enhancedDatabaseReporting) {
-              rootContext.addLabel('error', err);
-            }
-            endSpan();
-          });
-          return func.apply(this, arguments);
-        }, context);
-      });
+      wrapBidi(namespace, handlerSet, requestName);
     } else if (method_type === 'server_stream') {
-      // Start right before deserialization (which precedes call to function)
-      // End right after output stream 'finish' event
-      shimmer.wrap(handlerSet, 'deserialize', function (deserialize) {
-        return namespace.bind(function deserializeTrace() {
-          rootContext = startRootSpanForRequest(requestName);
-          return deserialize.apply(this, arguments);
-        }, context);
-      });
-      shimmer.wrap(handlerSet, 'func', function (func) {
-        return namespace.bind(function funcTrace(call) {
-          if (agent.config_.enhancedDatabaseReporting) {
-            shimmer.wrap(call, 'sendMetadata', sendMetadataWrapper(rootContext));
-          }
-          if (agent.config_.enhancedDatabaseReporting) {
-            rootContext.addLabel('argument', JSON.stringify(call.request));
-          }
-          var spanEnded = false;
-          var endSpan = function () {
-            if (!spanEnded) {
-              spanEnded = true;
-              endRootSpanForRequest(rootContext, requestName);
-            }
-          };
-          call.on('finish', function () {
-            // End the span unless there is an error.
-            if (call.status.code === 0) {
-              endSpan();
-            }
-          });
-          call.on('error', function (err) {
-            if (agent.config_.enhancedDatabaseReporting) {
-              rootContext.addLabel('error', err);
-            }
-            endSpan();
-          });
-          return func.apply(this, arguments);
-        }, context);
-      });
+      wrapServerStream(namespace, handlerSet, requestName);
     } else if (method_type === 'client_stream') {
-      // Start right before call to function
-      // End right after serialization (which is done in the callback)
-      shimmer.wrap(handlerSet, 'func', function (func) {
-        return namespace.bind(function funcTrace(call, callback) {
-          rootContext = startRootSpanForRequest(requestName);
-          if (agent.config_.enhancedDatabaseReporting) {
-            shimmer.wrap(call, 'sendMetadata', sendMetadataWrapper(rootContext));
-          }
-          // arguments[1] is the callback
-          arguments[1] = function (err, result, trailer) {
-            if (agent.config_.enhancedDatabaseReporting) {
-              if (err) {
-                rootContext.addLabel('error', err);
-              }
-              else {
-                rootContext.addLabel('result', JSON.stringify(result));
-              }
-              if (trailer) {
-                rootContext.addLabel('trailing_metadata', JSON.stringify(trailer.getMap()));
-              }
-            }
-            if (err) {
-              // If there is an error, then no result will be serialized to
-              // be sent back to the client. So end the root span here.
-              endRootSpanForRequest(rootContext, requestName);
-            }
-            return callback(err, result);
-          };
-          return func.apply(this, arguments);
-        }, context);
-      });
-      shimmer.wrap(handlerSet, 'serialize', function (serialize) {
-        return function serializeTrace(result) {
-          var serializeResult = serialize.apply(this, arguments);
-          endRootSpanForRequest(rootContext, requestName);
-          return serializeResult;
-        };
-      });
+      wrapClientStream(namespace, handlerSet, requestName);
     } else { // method_type === 'unary'
-      // Start right before deserialization
-      // End right after serialization
-      shimmer.wrap(handlerSet, 'deserialize', function (deserialize) {
-        return namespace.bind(function deserializeTrace() {
-          rootContext = startRootSpanForRequest(requestName);
-          return deserialize.apply(this, arguments);
-        }, context);
-      });
-      // Even though our root span doesn't start or end here,
-      // we need to wrap 'func' so that:
-      // (1) child spans have the correct context, and
-      // (2) we can get additional labels as needed
-      shimmer.wrap(handlerSet, 'func', function (func) {
-        return namespace.bind(function funcTrace(call, callback) {
-          if (agent.config_.enhancedDatabaseReporting) {
-            shimmer.wrap(call, 'sendMetadata', sendMetadataWrapper(rootContext));
-          }
-          if (agent.config_.enhancedDatabaseReporting) {
-            rootContext.addLabel('argument', JSON.stringify(call.request));
-          }
-          // arguments[1] is the callback
-          arguments[1] = function (err, result, trailer) {
-            if (agent.config_.enhancedDatabaseReporting) {
-              if (err) {
-                rootContext.addLabel('error', err);
-              }
-              else {
-                rootContext.addLabel('result', JSON.stringify(result));
-              }
-              if (trailer) {
-                rootContext.addLabel('trailing_metadata', JSON.stringify(trailer.getMap()));
-              }
-            }
-            if (err) {
-              // If there is an error, then no result will be serialized to
-              // be sent back to the client. So end the root span here.
-              endRootSpanForRequest(rootContext, requestName);
-            }
-            return callback(err, result);
-          };
-          return func.apply(this, arguments);
-        }, context);
-      });
-      shimmer.wrap(handlerSet, 'serialize', function (serialize) {
-        return function serializeTrace() {
-          var serializeResult = serialize.apply(this, arguments);
-          endRootSpanForRequest(rootContext, requestName);
-          return serializeResult;
-        };
-      });
+      wrapUnary(namespace, handlerSet, requestName);
     }
     return result;
   }

--- a/lib/hooks/userspace/hook-grpc.js
+++ b/lib/hooks/userspace/hook-grpc.js
@@ -75,27 +75,23 @@ function makeClientMethod(method) {
     cls.getNamespace().bindEmitter(call);
     if (method.responseStream) {
       var spanEnded = false;
-      var endSpan = function () {
-        if (!spanEnded) {
-          spanEnded = true;
-          agent.endSpan(span);
-        }
-      }
       call.on('error', function(err) {
         if (agent.config_.enhancedDatabaseReporting) {
           span.addLabel('error', err);
         }
-        // By scheduling the call to end the span at the next tick,
-        // we can guarantee that if both status and error events were fired
-        // in the same frame, so labels from both events will show up in the
-        // resulting trace span.
-        process.nextTick(endSpan);
+        if (!spanEnded) {
+          spanEnded = true;
+          agent.endSpan(span);
+        }
       });
       call.on('status', function(status) {
         if (agent.config_.enhancedDatabaseReporting) {
           span.addLabel('status', JSON.stringify(status));
         }
-        process.nextTick(endSpan);
+        if (!spanEnded) {
+          spanEnded = true;
+          agent.endSpan(span);
+        }
       });
     }
     return call;
@@ -158,8 +154,8 @@ function sendMetadataWrapper(rootContext) {
 /**
  * Returns a function that wraps the gRPC server register function in order
  * to create trace spans for gRPC service methods.
- * @param {Function(*)} register The function Server.prototype.register
- * @returns {Function(*)} registerTrace The new wrapper function.
+ * @param {Function} register The function Server.prototype.register
+ * @returns {Function} registerTrace The new wrapper function.
  */
 function serverRegisterWrap(register) {
   return function registerTrace(name, handler, serialize, deserialize, method_type) {
@@ -197,13 +193,16 @@ function serverRegisterWrap(register) {
             }
           };
           call.on('finish', function () {
-            process.nextTick(endSpan);
+            // End the span unless there is an error.
+            if (call.status.code === 0) {
+              endSpan();
+            }
           });
           call.on('error', function (err) {
             if (agent.config_.enhancedDatabaseReporting) {
               rootContext.addLabel('error', err);
             }
-            process.nextTick(endSpan);
+            endSpan();
           });
           return func.apply(this, arguments);
         }, context);
@@ -233,13 +232,16 @@ function serverRegisterWrap(register) {
             }
           };
           call.on('finish', function () {
-            process.nextTick(endSpan);
+            // End the span unless there is an error.
+            if (call.status.code === 0) {
+              endSpan();
+            }
           });
           call.on('error', function (err) {
             if (agent.config_.enhancedDatabaseReporting) {
               rootContext.addLabel('error', err);
             }
-            process.nextTick(endSpan);
+            endSpan();
           });
           return func.apply(this, arguments);
         }, context);

--- a/lib/hooks/userspace/hook-grpc.js
+++ b/lib/hooks/userspace/hook-grpc.js
@@ -61,7 +61,7 @@ function makeClientMethod(method) {
       // but this is an extremely rare case.
       var metaIndex = findIndex(arguments, function(arg) {
         return arg && typeof arg === 'object' && arg._internal_repr &&
-          typeof arg.getMap === 'function';
+            typeof arg.getMap === 'function';
       });
       if (metaIndex !== -1) {
         var metadata = arguments[metaIndex];
@@ -141,11 +141,11 @@ function serverRegisterWrap(register) {
       return register.apply(this, arguments);
     }
     var result = register.apply(this, arguments);
-    var handler = this.handlers[name];
+    var handlerSet = this.handlers[name];
     var rootContext;
     if (method_type == 'bidi' || method_type == 'client_stream') {
       // Streaming Client: Start the root span right before the gRPC function is invoked.
-      shimmer.wrap(handler, 'func', function (func) {
+      shimmer.wrap(handlerSet, 'func', function (func) {
         return namespace.bind(function funcTrace() {
           rootContext = startRootSpanForRequest(name);
           return func.apply(this, arguments);
@@ -153,22 +153,22 @@ function serverRegisterWrap(register) {
       });
     } else {
       // Single Client Request: Start the root span right before deserializing the request.
-      shimmer.wrap(handler, 'deserialize', function (deserialize) {
+      shimmer.wrap(handlerSet, 'deserialize', function (deserialize) {
         return namespace.bind(function deserializeTrace() {
           rootContext = startRootSpanForRequest(name);
           // We still need to bind the gRPC function to our namespace.
-          shimmer.wrap(handler, 'func', function (func) {
+          shimmer.wrap(handlerSet, 'func', function (func) {
             return namespace.bind(function () {
               func.apply(this, arguments);
             });
-          })
+          });
           return deserialize.apply(this, arguments);
         });
       });
     }
     if (method_type == 'bidi' || method_type == 'server_stream') {
       // Streaming Server: End the root span once the server closes the response stream.
-      shimmer.wrap(handler, 'func', function (func) {
+      shimmer.wrap(handlerSet, 'func', function (func) {
         return function endStreamTrace(stream) {
           stream.on('finish', function () {
             endRootSpanForRequest(rootContext, name);
@@ -178,7 +178,7 @@ function serverRegisterWrap(register) {
       });
     } else {
       // Single Server Response: End the root span right after serializing the response.
-      shimmer.wrap(handler, 'serialize', function (serialize) {
+      shimmer.wrap(handlerSet, 'serialize', function (serialize) {
         return function serializeTrace() {
           var serializeResult = serialize.apply(this, arguments);
           endRootSpanForRequest(rootContext, name);
@@ -193,11 +193,11 @@ function serverRegisterWrap(register) {
 /**
  * Creates and sets up a new root span for the given request.
  * @param {Object} req The request being processed.
- * @param {Object} traceHeader The incoming trace header.
  * @returns {!SpanData} The new initialized trace span data instance.
  */
 function startRootSpanForRequest(req) {
   var rootContext = agent.createRootSpanData(req, null, null, 3);
+  rootContext.span.kind = "RPC_SERVER";
   return rootContext;
 }
 
@@ -206,7 +206,6 @@ function startRootSpanForRequest(req) {
  * Ends the root span for the given request.
  * @param {!SpanData} rootContext The span to close out.
  * @param {Object} req The request being processed.
- * @param {Object} res The response being processed.
  */
 function endRootSpanForRequest(rootContext, req) {
   rootContext.close();
@@ -224,7 +223,7 @@ module.exports = function(version_, agent_) {
       patch: function(client) {
         agent = agent_;
         shimmer.wrap(client, 'makeClientConstructor',
-          makeClientConstructorWrap);
+            makeClientConstructorWrap);
       },
       unpatch: function(client) {
         // Only the Client constructor is unwrapped, so that future grpc.load's

--- a/lib/hooks/userspace/hook-grpc.js
+++ b/lib/hooks/userspace/hook-grpc.js
@@ -133,6 +133,19 @@ function makeClientConstructorWrap(makeClientConstructor) {
 
 // # Server
 
+function sendMetadataWrapperFactory(rootContext) {
+  return function sendMetadataWrapper(sendMetadata) {
+    return function sendMetadataTrace(responseMetadata) {
+      if (rootContext) {
+        rootContext.addLabel('metadata', JSON.stringify(responseMetadata.getMap()));
+      } else {
+        agent.logger.info('gRPC: No root context found in sendMetadata');
+      }
+      return sendMetadata.apply(this, arguments);
+    }
+  }
+}
+
 function serverRegisterWrap(register) {
   return function registerTrace(name, handler, serialize, deserialize, method_type) {
     // register(n, h, s, d, m) is called in addService once for each service method.
@@ -152,19 +165,28 @@ function serverRegisterWrap(register) {
     var context = {};
     // Proceed to wrap methods that are invoked when a gRPC service call is made.
     // In every case, the function 'func' is the user-implemented handling function.
-    if (method_type == 'bidi') {
+    if (method_type === 'bidi') {
       // Start right before call to function
       // End right after output stream 'finish' event
       shimmer.wrap(handlerSet, 'func', function (func) {
         return namespace.bind(function funcTrace(call) {
           rootContext = startRootSpanForRequest(requestName);
+          if (agent.config_.enhancedDatabaseReporting) {
+            shimmer.wrap(call, 'sendMetadata', sendMetadataWrapperFactory(rootContext));
+          }
           call.on('finish', function () {
+            endRootSpanForRequest(rootContext, requestName);
+          });
+          call.on('error', function (err) {
+            if (agent.config_.enhancedDatabaseReporting) {
+              rootContext.addLabel('error', err);
+            }
             endRootSpanForRequest(rootContext, requestName);
           });
           return func.apply(this, arguments);
         }, context);
       });
-    } else if (method_type == 'server_stream') {
+    } else if (method_type === 'server_stream') {
       // Start right before deserialization (which precedes call to function)
       // End right after output stream 'finish' event
       shimmer.wrap(handlerSet, 'deserialize', function (deserialize) {
@@ -176,32 +198,53 @@ function serverRegisterWrap(register) {
       shimmer.wrap(handlerSet, 'func', function (func) {
         return namespace.bind(function funcTrace(call) {
           if (agent.config_.enhancedDatabaseReporting) {
+            shimmer.wrap(call, 'sendMetadata', sendMetadataWrapperFactory(rootContext));
+          }
+          if (agent.config_.enhancedDatabaseReporting) {
             rootContext.addLabel('argument', JSON.stringify(call.request));
           }
           var result = func.apply(this, arguments);
           call.on('finish', function () {
             endRootSpanForRequest(rootContext, requestName);
           });
+          call.on('error', function (err) {
+            if (agent.config_.enhancedDatabaseReporting) {
+              rootContext.addLabel('error', err);
+            }
+            endRootSpanForRequest(rootContext, requestName);
+          });
           return result;
         }, context);
       });
-    } else if (method_type == 'client_stream') {
+    } else if (method_type === 'client_stream') {
       // Start right before call to function
       // End right after serialization (which is done in the callback)
       shimmer.wrap(handlerSet, 'func', function (func) {
         return namespace.bind(function funcTrace(call, callback) {
           rootContext = startRootSpanForRequest(requestName);
           if (agent.config_.enhancedDatabaseReporting) {
-            // arguments[1] is the callback
-            arguments[1] = function (err, result) {
+            shimmer.wrap(call, 'sendMetadata', sendMetadataWrapperFactory(rootContext));
+          }
+          // arguments[1] is the callback
+          arguments[1] = function (err, result, trailer) {
+            if (agent.config_.enhancedDatabaseReporting) {
               if (err) {
                 rootContext.addLabel('error', err);
-              } else {
+              }
+              else {
                 rootContext.addLabel('result', JSON.stringify(result));
               }
-              return callback(err, result);
+              if (trailer) {
+                rootContext.addLabel('trailing_metadata', JSON.stringify(trailer.getMap()));
+              }
             }
-          }
+            if (err) {
+              // If there is an error, then no result will be serialized to
+              // be sent back to the client. So end the root span here.
+              endRootSpanForRequest(rootContext, requestName);
+            }
+            return callback(err, result);
+          };
           return func.apply(this, arguments);
         }, context);
       });
@@ -212,7 +255,7 @@ function serverRegisterWrap(register) {
           return serializeResult;
         };
       });
-    } else {
+    } else { // method_type === 'unary'
       // Start right before deserialization
       // End right after serialization
       shimmer.wrap(handlerSet, 'deserialize', function (deserialize) {
@@ -228,17 +271,31 @@ function serverRegisterWrap(register) {
       shimmer.wrap(handlerSet, 'func', function (func) {
         return namespace.bind(function funcTrace(call, callback) {
           if (agent.config_.enhancedDatabaseReporting) {
+            shimmer.wrap(call, 'sendMetadata', sendMetadataWrapperFactory(rootContext));
+          }
+          if (agent.config_.enhancedDatabaseReporting) {
             rootContext.addLabel('argument', JSON.stringify(call.request));
-            // arguments[1] is the callback
-            arguments[1] = function (err, result) {
+          }
+          // arguments[1] is the callback
+          arguments[1] = function (err, result, trailer) {
+            if (agent.config_.enhancedDatabaseReporting) {
               if (err) {
                 rootContext.addLabel('error', err);
-              } else {
+              }
+              else {
                 rootContext.addLabel('result', JSON.stringify(result));
               }
-              return callback(err, result);
+              if (trailer) {
+                rootContext.addLabel('trailing_metadata', JSON.stringify(trailer.getMap()));
+              }
             }
-          }
+            if (err) {
+              // If there is an error, then no result will be serialized to
+              // be sent back to the client. So end the root span here.
+              endRootSpanForRequest(rootContext, requestName);
+            }
+            return callback(err, result);
+          };
           return func.apply(this, arguments);
         }, context);
       });

--- a/lib/hooks/userspace/hook-grpc.js
+++ b/lib/hooks/userspace/hook-grpc.js
@@ -80,8 +80,8 @@ function makeClientMethod(method) {
           span.addLabel('error', err);
         }
         if (!spanEnded) {
-          spanEnded = true;
           agent.endSpan(span);
+          spanEnded = true;
         }
       });
       call.on('status', function(status) {
@@ -89,8 +89,8 @@ function makeClientMethod(method) {
           span.addLabel('status', JSON.stringify(status));
         }
         if (!spanEnded) {
-          spanEnded = true;
           agent.endSpan(span);
+          spanEnded = true;
         }
       });
     }

--- a/lib/trace-agent.js
+++ b/lib/trace-agent.js
@@ -207,7 +207,7 @@ TraceAgent.prototype.createRootSpanData = function(name, traceId, parentId,
   skipFrames = skipFrames || 0;
   var trace = new Trace(0, traceId); // project number added later
   var spanData = new SpanData(this, trace, name, parentId, true, skipFrames + 1);
-  spanData.span.kind = "RPC_SERVER";
+  spanData.span.kind = 'RPC_SERVER';
   cls.setRootContext(spanData);
   return spanData;
 };

--- a/lib/trace-agent.js
+++ b/lib/trace-agent.js
@@ -207,6 +207,7 @@ TraceAgent.prototype.createRootSpanData = function(name, traceId, parentId,
   skipFrames = skipFrames || 0;
   var trace = new Trace(0, traceId); // project number added later
   var spanData = new SpanData(this, trace, name, parentId, true, skipFrames + 1);
+  spanData.span.kind = "RPC_SERVER";
   cls.setRootContext(spanData);
   return spanData;
 };

--- a/test/hooks/common.js
+++ b/test/hooks/common.js
@@ -84,7 +84,7 @@ function getMatchingSpans(predicate) {
 function assertDurationCorrect(predicate) {
   // We assume that the tests never care about top level transactions created
   // by the harness itself
-  predicate = predicate || function(span) { return span.name !== 'outer'; };
+  predicate = predicate || function(span) { return span.kind === 'RPC_CLIENT'; };
   var span = getMatchingSpan(predicate);
   var duration = Date.parse(span.endTime) - Date.parse(span.startTime);
   assert(duration > SERVER_WAIT * (1 - FORGIVENESS),

--- a/test/hooks/common.js
+++ b/test/hooks/common.js
@@ -84,7 +84,7 @@ function getMatchingSpans(predicate) {
 function assertDurationCorrect(predicate) {
   // We assume that the tests never care about top level transactions created
   // by the harness itself
-  predicate = predicate || function(span) { return span.kind !== 'outer'; };
+  predicate = predicate || function(span) { return span.name !== 'outer'; };
   var span = getMatchingSpan(predicate);
   var duration = Date.parse(span.endTime) - Date.parse(span.startTime);
   assert(duration > SERVER_WAIT * (1 - FORGIVENESS),

--- a/test/hooks/common.js
+++ b/test/hooks/common.js
@@ -84,7 +84,7 @@ function getMatchingSpans(predicate) {
 function assertDurationCorrect(predicate) {
   // We assume that the tests never care about top level transactions created
   // by the harness itself
-  predicate = predicate || function(span) { return span.kind === 'RPC_CLIENT'; };
+  predicate = predicate || function(span) { return span.kind !== 'outer'; };
   var span = getMatchingSpan(predicate);
   var duration = Date.parse(span.endTime) - Date.parse(span.startTime);
   assert(duration > SERVER_WAIT * (1 - FORGIVENESS),

--- a/test/hooks/test-trace-grpc.js
+++ b/test/hooks/test-trace-grpc.js
@@ -201,7 +201,7 @@ Object.keys(versions).forEach(function(version) {
       client.testUnary({n: 42}, function(err, result) {
         assert.ifError(err);
         assert.strictEqual(result.n, 42);
-        assert.strictEqual(common.getTraces().length, 0);
+        assert.strictEqual(common.getMatchingSpans(grpcPredicate).length, 0);
         done();
       });
     });

--- a/test/hooks/test-trace-grpc.js
+++ b/test/hooks/test-trace-grpc.js
@@ -317,17 +317,15 @@ Object.keys(versions).forEach(function(version) {
         var stream = client.testServerStream({n: EMIT_ERROR}, metadata);
         stream.on('data', function(data) {});
         stream.on('error', function (err) {
-          process.nextTick(function () {
-            endTransaction();
-            var assertTraceProperties = function(predicate) {
-              var trace = common.getMatchingSpan(predicate);
-              assert(trace);
-              assert.strictEqual(trace.labels.error, 'Error: test');
-            };
-            assertTraceProperties(grpcClientPredicate);
-            assertTraceProperties(grpcServerPredicate);
-            done();
-          });
+          endTransaction();
+          var assertTraceProperties = function(predicate) {
+            var trace = common.getMatchingSpan(predicate);
+            assert(trace);
+            assert.strictEqual(trace.labels.error, 'Error: test');
+          };
+          assertTraceProperties(grpcClientPredicate);
+          assertTraceProperties(grpcServerPredicate);
+          done();
         })
       });
     });

--- a/test/hooks/test-trace-grpc.js
+++ b/test/hooks/test-trace-grpc.js
@@ -326,7 +326,7 @@ Object.keys(versions).forEach(function(version) {
           assertTraceProperties(grpcClientPredicate);
           assertTraceProperties(grpcServerPredicate);
           done();
-        })
+        });
       });
     });
 


### PR DESCRIPTION
This change introduces gRPC server function tracing. In addition to the timespan itself, the arguments, return results, and any metadata or errors are written in trace spans as well.