### PR TITLE
Added Custom Root Spans

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,9 @@ The trace configuration additionally exposes the `samplingRate` option which set
 
 ## Custom Tracing API
 
-The custom tracing API can be used to add custom spans to trace. A *span* is a particular unit of work within a trace, such as an RPC request. Currently, you can only use the custom tracing API inside the following web frameworks: `express`, `hapi`, `restify`.
+The custom tracing API can be used to add custom spans to trace. A *span* is a particular unit of work within a trace, such as an RPC request. Spans may be nested; the outermost span is called a *root span*, even if there are no nested child spans. In general, root spans typically correspond to incoming requests, while *child spans* typically correspond to outgoing requests, or other work that is triggered in response to incoming requests.
+
+For any of the web frameworks listed above (`express`, `hapi`, and `restify`), a root span is automatically started whenever an incoming request is received (in other words, all middleware already runs within a root span). If you wish to record a span outside of any of these frameworks, any traced code must run within a root span that you create yourself.
 
 The API is exposed by the `agent` returned by a call to `start`:
 
@@ -140,17 +142,17 @@ The API is exposed by the `agent` returned by a call to `start`:
   var agent = require('@google/cloud-trace').start();
 ```
 
-You can either use the `startSpan` and `endSpan` API, or use the `runInSpan` function that uses a callback-style.
+For child spans, you can either use the `startSpan` and `endSpan` API, or use the `runInSpan` function that uses a callback-style. For root spans, you must use `runInRootSpan`.
 
 ### Start & end
 
-To start a new span, use `agent.startSpan`. Each span requires a name, and you can optionally specify labels.
+To start a new child span, use `agent.startSpan`. Each span requires a name, and you can optionally specify labels.
 
 ```javascript
   var span = agent.startSpan('name', {label: 'value'});
 ```
 
-Once your work is complete, you can end the span with `agent.endSpan`. You can again optionally associate labels with the span:
+Once your work is complete, you can end a child span with `agent.endSpan`. You can again optionally associate labels with the span:
 
 ```javascript
   agent.endSpan(span, {label2: 'value'});
@@ -158,7 +160,7 @@ Once your work is complete, you can end the span with `agent.endSpan`. You can a
 
 ### Run in span
 
-`agent.runInSpan` takes a function to execute inside a custom span with the given name. The function may be synchronous or asynchronous. If it is asynchronous, it must accept a 'endSpan' function as an argument that should be called once the asynchronous work has completed.
+`agent.runInSpan` takes a function to execute inside a custom child span with the given name. The function may be synchronous or asynchronous. If it is asynchronous, it must accept a 'endSpan' function as an argument that should be called once the asynchronous work has completed.
 
 ```javascript
   agent.runInSpan('name', {label: 'value'}, function() {
@@ -166,6 +168,24 @@ Once your work is complete, you can end the span with `agent.endSpan`. You can a
   });
 
   agent.runInSpan('name', {label: 'value'}, function(endSpan) {
+    doAsyncWork(function(result) {
+      processResult(result);
+      endSpan({label2: 'value'});
+    });
+  });
+```
+
+### Run in root span
+
+`agent.runInRootSpan` behaves similarly to `agent.runInSpan`, except that the function is run within a root span.
+
+```javascript
+  agent.runInRootSpan('name', {label: 'value'}, function() {
+    // You can record child spans in here
+    doSynchronousWork();
+  });
+  agent.runInRootSpan('name', {label: 'value'}, function(endSpan) {
+    // You can record child spans in here
     doAsyncWork(function(result) {
       processResult(result);
       endSpan({label2: 'value'});

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ The trace configuration additionally exposes the `samplingRate` option which set
 
 ## Custom Tracing API
 
-The custom tracing API can be used to add custom spans to trace. A *span* is a particular unit of work within a trace, such as an RPC request. Spans may be nested; the outermost span is called a *root span*, even if there are no nested child spans. In general, root spans typically correspond to incoming requests, while *child spans* typically correspond to outgoing requests, or other work that is triggered in response to incoming requests.
+The custom tracing API can be used to add custom spans to trace. A *span* is a particular unit of work within a trace, such as an RPC request. Spans may be nested; the outermost span is called a *root span*, even if there are no nested child spans. Root spans typically correspond to incoming requests, while *child spans* typically correspond to outgoing requests, or other work that is triggered in response to incoming requests.
 
 For any of the web frameworks listed above (`express`, `hapi`, and `restify`), a root span is automatically started whenever an incoming request is received (in other words, all middleware already runs within a root span). If you wish to record a span outside of any of these frameworks, any traced code must run within a root span that you create yourself.
 

--- a/index.js
+++ b/index.js
@@ -56,6 +56,12 @@ var phantomTraceAgent = {
     }
     fn(function() {});
   },
+  runInRootSpan: function(name, labels, fn) {
+    if (typeof(labels) === 'function') {
+      fn = labels;
+    }
+    fn(function() {});
+  },
   setTransactionName: function() {},
   addTransactionLabel: function() {}
 };
@@ -104,6 +110,10 @@ var publicAgent = {
 
   runInSpan: function(name, labels, fn) {
     return agent.runInSpan(name, labels, fn);
+  },
+
+  runInRootSpan: function(name, labels, fn) {
+    return agent.runInRootSpan(name, labels, fn);
   },
 
   setTransactionName: function(name) {

--- a/lib/trace-agent.js
+++ b/lib/trace-agent.js
@@ -162,12 +162,13 @@ TraceAgent.prototype.runInRootSpan = function(name, labels, fn) {
     fn = labels;
     labels = undefined;
   }
-  this.namespace.run((function () {
+  var self = this;
+  this.namespace.run(function () {
     if (cls.getRootContext()) {
-      this.logger.error('Can\'t nest root spans');
+      self.logger.error('Can\'t nest root spans');
       return;
     }
-    var span = this.createRootSpanData(name, null, null, 3, 'SPAN_KIND_UNSPECIFIED');
+    var span = self.createRootSpanData(name, null, null, 3, 'SPAN_KIND_UNSPECIFIED');
     if (labels) {
       Object.keys(labels).forEach(function(key) {
         span.addLabel(key, labels[key]);
@@ -181,7 +182,7 @@ TraceAgent.prototype.runInRootSpan = function(name, labels, fn) {
         span.close();
       });
     }
-  }).bind(this));
+  });
 };
 
 /**
@@ -236,6 +237,8 @@ TraceAgent.prototype.shouldTrace = function(name, options) {
  * @param {string} parentId The id of the parent span.
  * @param {number=} skipFrames The number of caller frames to eliminate from
  *                            stack traces.
+ * @param {string} spanKind The kind of root span; one of 'RPC_SERVER',
+ *                          'RPC_CLIENT', or 'SPAN_KIND_UNSPECIFIED'.
  */
 TraceAgent.prototype.createRootSpanData = function(name, traceId, parentId,
     skipFrames, spanKind) {

--- a/lib/trace-agent.js
+++ b/lib/trace-agent.js
@@ -148,6 +148,44 @@ TraceAgent.prototype.runInSpan = function(name, labels, fn) {
 };
 
 /**
+ * Run the provided function in a new root span with the provided
+ * name. As with runInSpan, if the provided function accepts a parameter,
+ * it is assumed to be asynchronous, and a callback will be passed
+ * to the function to terminate the root span.
+ * @param {string} name The name of the resulting root span.
+ * @param {Object<string, string}>=} labels Labels to be attached
+ *   to the resulting span.
+ * @param {function(function()=)} fn The function to trace.
+ */
+TraceAgent.prototype.runInRootSpan = function(name, labels, fn) {
+  if (typeof(labels) === 'function') {
+    fn = labels;
+    labels = undefined;
+  }
+  this.namespace.run((function () {
+    if (cls.getRootContext()) {
+      this.logger.error('Can\'t nest root spans');
+      return;
+    }
+    var span = this.createRootSpanData(name, null, null, 0, 'SPAN_KIND_UNSPECIFIED');
+    if (labels) {
+      Object.keys(labels).forEach(function(key) {
+        span.addLabel(key, labels[key]);
+      });
+    }
+    if (fn.length === 0) {
+      fn();
+      span.close();
+    } else {
+      fn(function () {
+        span.close();
+      });
+      cls.setRootContext(null);
+    }
+  }).bind(this));
+};
+
+/**
  * Set the name of the root transaction.
  * @param {string} name The new name for the current root transaction.
  */
@@ -201,13 +239,14 @@ TraceAgent.prototype.shouldTrace = function(name, options) {
  *                            stack traces.
  */
 TraceAgent.prototype.createRootSpanData = function(name, traceId, parentId,
-    skipFrames) {
+    skipFrames, spanKind) {
   traceId = traceId || (uuid.v4().split('-').join(''));
   parentId = parentId || '0';
   skipFrames = skipFrames || 0;
+  spanKind = spanKind || 'RPC_SERVER';
   var trace = new Trace(0, traceId); // project number added later
   var spanData = new SpanData(this, trace, name, parentId, true, skipFrames + 1);
-  spanData.span.kind = 'RPC_SERVER';
+  spanData.span.kind = spanKind;
   cls.setRootContext(spanData);
   return spanData;
 };

--- a/lib/trace-agent.js
+++ b/lib/trace-agent.js
@@ -167,7 +167,7 @@ TraceAgent.prototype.runInRootSpan = function(name, labels, fn) {
       this.logger.error('Can\'t nest root spans');
       return;
     }
-    var span = this.createRootSpanData(name, null, null, 0, 'SPAN_KIND_UNSPECIFIED');
+    var span = this.createRootSpanData(name, null, null, 3, 'SPAN_KIND_UNSPECIFIED');
     if (labels) {
       Object.keys(labels).forEach(function(key) {
         span.addLabel(key, labels[key]);
@@ -180,7 +180,6 @@ TraceAgent.prototype.runInRootSpan = function(name, labels, fn) {
       fn(function () {
         span.close();
       });
-      cls.setRootContext(null);
     }
   }).bind(this));
 };


### PR DESCRIPTION
The trace agent now exposes a new method `runInRootSpan` with a similar signature to `runInSpan`. It is intended for users to create custom top-level spans.