### PR TITLE
Intercept connect module

### DIFF
--- a/lib/hooks/index.js
+++ b/lib/hooks/index.js
@@ -54,6 +54,8 @@ var toInstrument = Object.create(null, {
   'redis': { enumerable: true, value: { file: './userspace/hook-redis.js',
       patches: {} } },
   'restify': { enumerable: true, value: { file: './userspace/hook-restify.js',
+      patches: {} } },
+  'connect': { enumerable: true, value: { file: './userspace/hook-connect.js',
       patches: {} } }
 });
 
@@ -138,10 +140,20 @@ function activate(agent) {
           var loadPath = moduleRoot ? path.join(moduleRoot, file) : file;
           modulePatch[file].module = originalModuleLoad(loadPath, module, false);
         }
-        modulePatch[file].patch(modulePatch[file].module);
+        if (modulePatch[file].patch !== undefined) {
+          modulePatch[file].patch(modulePatch[file].module);
+        }
+        if (modulePatch[file].intercept !== undefined) {
+          modulePatch[file].module = modulePatch[file].intercept(modulePatch[file].module);
+        }
         modulePatch[file].active = true;
       });
       instrumentation.patches[moduleRoot] = modulePatch;
+      if (modulePatch[''] !== undefined && modulePatch[''].intercept !== undefined) {
+        return modulePatch[''].module;
+      } else {
+        return null;
+      }
     }
 
     function moduleAlreadyPatched(instrumentation, moduleRoot) {
@@ -175,8 +187,11 @@ function activate(agent) {
         }
         var moduleVersion = findModuleVersion(moduleRoot, originalModuleLoad);
         logger.info('Patching ' + request + ' at version ' + moduleVersion);
-        loadAndPatch(instrumentation, moduleRoot,
+        var patchedRoot = loadAndPatch(instrumentation, moduleRoot,
           moduleVersion);
+        if (patchedRoot !== null) {
+          return patchedRoot;
+        }
       }
 
       return originalModuleLoad.apply(this, arguments);
@@ -192,7 +207,9 @@ function deactivate() {
       for (var patchedFile in modulePatch) {
         var hook = modulePatch[patchedFile];
         logger.info('Attempting to unpatch ' + moduleName);
-        hook.unpatch(hook.module);
+        if (hook.unpatch !== undefined) {
+          hook.unpatch(hook.module);
+        }
         hook.active = false;
       }
     }

--- a/lib/hooks/userspace/hook-connect.js
+++ b/lib/hooks/userspace/hook-connect.js
@@ -1,0 +1,122 @@
+/**
+ * Copyright 2015 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+var cls = require('../../cls.js');
+var TraceLabels = require('../../trace-labels.js');
+var semver = require('semver');
+var constants = require('../../constants.js');
+var agent;
+
+var SUPPORTED_VERSIONS = '3.x';
+
+function middleware(req, res, next) {
+  var namespace = cls.getNamespace();
+  if (!namespace) {
+    agent.logger.info('Connect: no namespace found, ignoring request');
+    return next();
+  }
+  var traceHeader = agent.parseContextFromHeader(
+    req.headers[constants.TRACE_CONTEXT_HEADER_NAME.toLowerCase()]) || {};
+  if (!agent.shouldTrace(req.originalUrl, traceHeader.options)) {
+    return next();
+  }
+
+  namespace.bindEmitter(req);
+  namespace.bindEmitter(res);
+
+  var originalEnd = res.end;
+
+  namespace.run(function() {
+    var rootContext = startRootSpanForRequest(req, traceHeader);
+    var context = agent.generateTraceContext(rootContext, true);
+    if (context) {
+      res.setHeader(constants.TRACE_CONTEXT_HEADER_NAME, context);
+    } else {
+      agent.logger.warn('Connect: Attempted to generate trace context for nullSpan');
+    }
+
+    // wrap end
+    res.end = function(data, encoding, callback) {
+      res.end = originalEnd;
+      var returned = res.end(data, encoding, callback);
+
+      endRootSpanForRequest(rootContext, req, res);
+      return returned;
+    };
+
+    next();
+  });
+}
+
+/**
+ * Creates and sets up a new root span for the given request.
+ * @param {Object} req The request being processed.
+ * @param {Object} traceHeader The incoming trace header.
+ * @returns {!SpanData} The new initialized trace span data instance.
+ */
+function startRootSpanForRequest(req, traceHeader) {
+  var traceId = traceHeader.traceId;
+  var parentSpanId = traceHeader.spanId;
+  var url = 'connect:/' + req.originalUrl;
+
+  // we use the path part of the url as the span name and add the full
+  // url as a label
+  var rootContext = agent.createRootSpanData(req.originalUrl, traceId,
+    parentSpanId, 3);
+  rootContext.addLabel(TraceLabels.HTTP_METHOD_LABEL_KEY, req.method);
+  rootContext.addLabel(TraceLabels.HTTP_URL_LABEL_KEY, url);
+  rootContext.addLabel(TraceLabels.HTTP_SOURCE_IP, req.connection.remoteAddress);
+  return rootContext;
+}
+
+
+/**
+ * Ends the root span for the given request.
+ * @param {!SpanData} rootContext The span to close out.
+ * @param {Object} req The request being processed.
+ * @param {Object} res The response being processed.
+ */
+function endRootSpanForRequest(rootContext, req, res) {
+  if (req.route && req.route.path) {
+    rootContext.addLabel(
+      'connect/request.route.path', req.route.path);
+  }
+  rootContext.addLabel(
+      TraceLabels.HTTP_RESPONSE_CODE_LABEL_KEY, res.statusCode);
+  rootContext.close();
+}
+
+module.exports = function(version_, agent_) {
+  if (!semver.satisfies(version_, SUPPORTED_VERSIONS)) {
+    agent_.logger.info('Connect: unsupported version ' + version_ + ' loaded');
+    return {};
+  }
+  return {
+    // An empty relative path here matches the root module being loaded.
+    '': {
+      intercept: function(connect) {
+        agent = agent_;
+        return function() {
+          var app = connect();
+          app.use(middleware);
+          return app;
+        };
+      }
+    }
+  };
+};


### PR DESCRIPTION
This adds support for `connect`, which is used by `swagger-tools` (#304).

I had to add an interception concept here, because `connect` returns a function as it's `module.exports`, which means the traditional `patch`/`unpatch` does not work (as far as I could tell).