### PR TITLE
The module now exports a constructor

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ This module provides Stackdriver Trace support for Node.js applications. [Stackd
 
 3. Include and start the library *as the very first action in your application*:
 
-        require('@google/cloud-trace').start();
+        require('@google/cloud-trace').startAgent();
 
   If you use `--require` in your start up command, make sure that the trace agent is --required first.
 
@@ -47,7 +47,7 @@ If you are running somewhere other than the Google Cloud Platform, see [running 
 
 See [the default configuration](config.js) for a list of possible configuration options. These options can be passed to the agent through the object argument to the start command shown above:
 
-        require('@google/cloud-trace').start({samplingRate: 500});
+        require('@google/cloud-trace').startAgent({samplingRate: 500});
 
 Alternatively, you can provide configuration through a config file. This can be useful if you want to load our module using `--require` on the command line instead of editing your main script. You can start by copying the default config file and modifying it to suit your needs. The `GCLOUD_DIAGNOSTICS_CONFIG` environment variable should point to your configuration file.
 
@@ -142,7 +142,7 @@ For any of the web frameworks listed above (`express`, `hapi`, and `restify`), a
 The API is exposed by the `agent` returned by a call to `start`:
 
 ```javascript
-  var agent = require('@google/cloud-trace').start();
+  var agent = require('@google/cloud-trace').startAgent();
 ```
 
 For child spans, you can either use the `startSpan` and `endSpan` API, or use the `runInSpan` function that uses a callback-style. For root spans, you must use `runInRootSpan`.

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ This module provides Stackdriver Trace support for Node.js applications. [Stackd
 
 3. Include and start the library *as the very first action in your application*:
 
-        require('@google/cloud-trace').startAgent();
+        require('@google/cloud-trace')().startAgent();
 
   If you use `--require` in your start up command, make sure that the trace agent is --required first.
 
@@ -47,7 +47,7 @@ If you are running somewhere other than the Google Cloud Platform, see [running 
 
 See [the default configuration](config.js) for a list of possible configuration options. These options can be passed to the agent through the object argument to the start command shown above:
 
-        require('@google/cloud-trace').startAgent({samplingRate: 500});
+        require('@google/cloud-trace')().startAgent({samplingRate: 500});
 
 Alternatively, you can provide configuration through a config file. This can be useful if you want to load our module using `--require` on the command line instead of editing your main script. You can start by copying the default config file and modifying it to suit your needs. The `GCLOUD_DIAGNOSTICS_CONFIG` environment variable should point to your configuration file.
 
@@ -142,7 +142,7 @@ For any of the web frameworks listed above (`express`, `hapi`, and `restify`), a
 The API is exposed by the `agent` returned by a call to `start`:
 
 ```javascript
-  var agent = require('@google/cloud-trace').startAgent();
+  var agent = require('@google/cloud-trace')().startAgent();
 ```
 
 For child spans, you can either use the `startSpan` and `endSpan` API, or use the `runInSpan` function that uses a callback-style. For root spans, you must use `runInRootSpan`.

--- a/index.js
+++ b/index.js
@@ -129,7 +129,7 @@ Trace.prototype.addTransactionLabel = function(key, value) {
     return agent.addTransactionLabel(key, value);
 };
 
-Trace.prototype.start = function(projectConfig) {
+Trace.prototype.startAgent = function(projectConfig) {
   if (this.isActive()) { // already started.
     agent.logger.warn('Calling start on already started agent.' +
       'New configuration will be ignored.');
@@ -173,9 +173,9 @@ Trace.prototype.start = function(projectConfig) {
         // Fatal error. Disable the agent.
         logger.error('Unable to acquire the project number from metadata ' +
           'service. Please provide a valid project number as an env. ' +
-          'variable, or through config.projectId passed to start().' +
+          'variable, or through config.projectId passed to startAgent().' +
           err);
-        publicAgent.stop();
+        this.stop();
         return;
       }
       config.projectId = project;
@@ -218,5 +218,5 @@ module.exports = global._google_trace_agent = Trace;
 
 // If the module was --require'd from the command line, start the agent.
 if (module.parent && module.parent.id === 'internal/preload') {
-  module.exports.start();
+  module.exports.startAgent();
 }

--- a/index.js
+++ b/index.js
@@ -218,5 +218,5 @@ module.exports = global._google_trace_agent = Trace;
 
 // If the module was --require'd from the command line, start the agent.
 if (module.parent && module.parent.id === 'internal/preload') {
-  module.exports.startAgent();
+  module.exports().startAgent();
 }

--- a/index.js
+++ b/index.js
@@ -95,120 +95,126 @@ var initConfig = function(projectConfig) {
 /**
  * The singleton public agent. This is the public API of the module.
  */
-var publicAgent = {
-  isActive: function() {
+function Trace(options){
+  if(!(this instanceof Trace)) {
+    return new Trace(options);
+  }
+}
+
+Trace.prototype.isActive = function() {
     return agent !== phantomTraceAgent;
-  },
-
-  startSpan: function(name, labels) {
-    return agent.startSpan(name, labels);
-  },
-
-  endSpan: function(spanData, labels) {
-    return agent.endSpan(spanData, labels);
-  },
-
-  runInSpan: function(name, labels, fn) {
-    return agent.runInSpan(name, labels, fn);
-  },
-
-  runInRootSpan: function(name, labels, fn) {
-    return agent.runInRootSpan(name, labels, fn);
-  },
-
-  setTransactionName: function(name) {
-    return agent.setTransactionName(name);
-  },
-
-  addTransactionLabel: function(key, value) {
-    return agent.addTransactionLabel(key, value);
-  },
-
-  start: function(projectConfig) {
-    if (this.isActive()) { // already started.
-      agent.logger.warn('Calling start on already started agent.' +
-        'New configuration will be ignored.');
-      return this;
-    }
-
-    var config = initConfig(projectConfig);
-    if (!config.enabled) {
-      return this;
-    }
-    var logger = common.logger.create(config.logLevel, '@google/cloud-trace');
-    if (!semver.satisfies(process.versions.node, '>=0.12')) {
-      logger.error('Tracing is only supported on Node versions >=0.12');
-      return this;
-    }
-
-    if (config.projectId) {
-      logger.info('Locally provided ProjectId: ' + config.projectId);
-    }
-
-    if (onUncaughtExceptionValues.indexOf(config.onUncaughtException) === -1) {
-      logger.error('The value of onUncaughtException should be one of ',
-        onUncaughtExceptionValues);
-      throw new Error('Invalid value for onUncaughtException configuration.');
-    }
-
-    var headers = {};
-    headers[constants.TRACE_AGENT_REQUEST_HEADER] = 1;
-
-    if (modulesLoadedBeforeTrace.length > 0) {
-      logger.warn('Tracing might not work as the following modules ' +
-        'were loaded before the trace agent was initialized: ' +
-        JSON.stringify(modulesLoadedBeforeTrace));
-    }
-
-    if (typeof config.projectId === 'undefined') {
-      // Queue the work to acquire the projectNumber (potentially from the
-      // network.)
-      common.utils.getProjectNumber(headers, function(err, project) {
-        if (err) {
-          // Fatal error. Disable the agent.
-          logger.error('Unable to acquire the project number from metadata ' +
-            'service. Please provide a valid project number as an env. ' +
-            'variable, or through config.projectId passed to start().' +
-            err);
-          publicAgent.stop();
-          return;
-        }
-        config.projectId = project;
-      });
-    } else if (typeof config.projectId === 'number') {
-      config.projectId = config.projectId.toString();
-    } else if (typeof config.projectId !== 'string') {
-      logger.error('config.projectId, if provided, must be' +
-        ' a string or number. Disabling trace agent.');
-      return this;
-    }
-
-    agent = require('./src/trace-agent.js').get(config, logger);
-    return this; // for chaining
-  },
-
-  get: function() {
-    if (this.isActive()) {
-      return this;
-    }
-    throw new Error('The agent must be initialized by calling start.');
-  },
-
-  stop: function() {
-    if (this.isActive()) {
-      agent.stop();
-      agent = phantomTraceAgent;
-    }
-  },
-
-  /**
-   * For use in tests only.
-   * @private
-   */
-  private_: function() { return agent; }
 };
 
-module.exports = global._google_trace_agent = publicAgent;
+Trace.prototype.startSpan = function(name, labels) {
+    return agent.startSpan(name, labels);
+};
+
+Trace.prototype.endSpan = function(spanData, labels) {
+    return agent.endSpan(spanData, labels);
+};
+
+Trace.prototype.runInSpan = function(name, labels, fn) {
+    return agent.runInSpan(name, labels, fn);
+};
+
+Trace.prototype.runInRootSpan = function(name, labels, fn) {
+    return agent.runInRootSpan(name, labels, fn);
+};
+
+Trace.prototype.setTransactionName = function(name) {
+    return agent.setTransactionName(name);
+};
+
+Trace.prototype.addTransactionLabel = function(key, value) {
+    return agent.addTransactionLabel(key, value);
+};
+
+Trace.prototype.start = function(projectConfig) {
+  if (this.isActive()) { // already started.
+    agent.logger.warn('Calling start on already started agent.' +
+      'New configuration will be ignored.');
+    return this;
+  }
+
+  var config = initConfig(projectConfig);
+  if (!config.enabled) {
+    return this;
+  }
+  var logger = common.logger.create(config.logLevel, '@google/cloud-trace');
+  if (!semver.satisfies(process.versions.node, '>=0.12')) {
+    logger.error('Tracing is only supported on Node versions >=0.12');
+    return this;
+  }
+
+  if (config.projectId) {
+    logger.info('Locally provided ProjectId: ' + config.projectId);
+  }
+
+  if (onUncaughtExceptionValues.indexOf(config.onUncaughtException) === -1) {
+    logger.error('The value of onUncaughtException should be one of ',
+      onUncaughtExceptionValues);
+    throw new Error('Invalid value for onUncaughtException configuration.');
+  }
+
+  var headers = {};
+  headers[constants.TRACE_AGENT_REQUEST_HEADER] = 1;
+
+  if (modulesLoadedBeforeTrace.length > 0) {
+    logger.warn('Tracing might not work as the following modules ' +
+      'were loaded before the trace agent was initialized: ' +
+      JSON.stringify(modulesLoadedBeforeTrace));
+  }
+
+  if (typeof config.projectId === 'undefined') {
+    // Queue the work to acquire the projectNumber (potentially from the
+    // network.)
+    common.utils.getProjectNumber(headers, function(err, project) {
+      if (err) {
+        // Fatal error. Disable the agent.
+        logger.error('Unable to acquire the project number from metadata ' +
+          'service. Please provide a valid project number as an env. ' +
+          'variable, or through config.projectId passed to start().' +
+          err);
+        publicAgent.stop();
+        return;
+      }
+      config.projectId = project;
+    });
+  } else if (typeof config.projectId === 'number') {
+    config.projectId = config.projectId.toString();
+  } else if (typeof config.projectId !== 'string') {
+    logger.error('config.projectId, if provided, must be' +
+      ' a string or number. Disabling trace agent.');
+    return this;
+  }
+
+  agent = require('./src/trace-agent.js').get(config, logger);
+  return this; // for chaining
+};
+
+Trace.prototype.get = function() {
+  if (this.isActive()) {
+    return this;
+  }
+  throw new Error('The agent must be initialized by calling start.');
+};
+
+Trace.prototype.stop = function() {
+  if (this.isActive()) {
+    agent.stop();
+    agent = phantomTraceAgent;
+  }
+};
+
+/**
+ * For use in tests only.
+ * @private
+ */
+Trace.prototype.private_ = function() {
+  return agent;
+};
+
+module.exports = global._google_trace_agent = Trace;
 
 // If the module was --require'd from the command line, start the agent.
 if (module.parent && module.parent.id === 'internal/preload') {

--- a/index.js
+++ b/index.js
@@ -168,6 +168,7 @@ Trace.prototype.startAgent = function(projectConfig) {
   if (typeof config.projectId === 'undefined') {
     // Queue the work to acquire the projectNumber (potentially from the
     // network.)
+    var that = this;
     common.utils.getProjectNumber(headers, function(err, project) {
       if (err) {
         // Fatal error. Disable the agent.
@@ -175,7 +176,7 @@ Trace.prototype.startAgent = function(projectConfig) {
           'service. Please provide a valid project number as an env. ' +
           'variable, or through config.projectId passed to startAgent().' +
           err);
-        this.stop();
+        that.stop();
         return;
       }
       config.projectId = project;

--- a/test/fixtures/start-agent.js
+++ b/test/fixtures/start-agent.js
@@ -17,4 +17,4 @@
 
 process.env.GCLOUD_TRACE_LOGLEVEL = 4;
 require('glob'); // Load a module before agent
-require('../..').start();
+require('../..').startAgent();

--- a/test/fixtures/start-agent.js
+++ b/test/fixtures/start-agent.js
@@ -17,4 +17,4 @@
 
 process.env.GCLOUD_TRACE_LOGLEVEL = 4;
 require('glob'); // Load a module before agent
-require('../..').startAgent();
+require('../..')().startAgent();

--- a/test/hooks/common.js
+++ b/test/hooks/common.js
@@ -21,7 +21,7 @@ if (!process.env.GCLOUD_PROJECT) {
 }
 
 var config = { enhancedDatabaseReporting: true, samplingRate: 0 };
-var agent = require('../..').startAgent(config).private_();
+var agent = require('../..')().startAgent(config).private_();
 // We want to disable publishing to avoid conflicts with production.
 agent.traceWriter.publish_ = function() {};
 

--- a/test/hooks/common.js
+++ b/test/hooks/common.js
@@ -21,7 +21,7 @@ if (!process.env.GCLOUD_PROJECT) {
 }
 
 var config = { enhancedDatabaseReporting: true, samplingRate: 0 };
-var agent = require('../..').start(config).private_();
+var agent = require('../..').startAgent(config).private_();
 // We want to disable publishing to avoid conflicts with production.
 agent.traceWriter.publish_ = function() {};
 

--- a/test/hooks/test-hooks-interop-mongo-express.js
+++ b/test/hooks/test-hooks-interop-mongo-express.js
@@ -26,7 +26,7 @@ var assert = require('assert');
 var express = require('./fixtures/express4');
 var http = require('http');
 var mongoose = require('./fixtures/mongoose4');
-var agent = require('../..').get().private_();
+var agent = require('../..')().get().private_();
 var oldDebug = agent.logger.debug;
 agent.logger.debug = function(error) {
   assert(error.indexOf('mongo') === -1, error);

--- a/test/hooks/test-trace-grpc.js
+++ b/test/hooks/test-trace-grpc.js
@@ -16,7 +16,7 @@
 'use strict';
 
 var common = require('./common.js');
-require('../..').private_().config_.enhancedDatabaseReporting = true;
+require('../..')().private_().config_.enhancedDatabaseReporting = true;
 var assert = require('assert');
 var traceLabels = require('../../src/trace-labels.js');
 

--- a/test/hooks/test-trace-mysql.js
+++ b/test/hooks/test-trace-mysql.js
@@ -17,7 +17,7 @@
 
 var common = require('./common.js');
 var traceLabels = require('../../src/trace-labels.js');
-require('../..').private_().config_.enhancedDatabaseReporting = true;
+require('../..')().private_().config_.enhancedDatabaseReporting = true;
 var assert = require('assert');
 var mysql = require('./fixtures/mysql2');
 

--- a/test/non-interference/express-e2e.js
+++ b/test/non-interference/express-e2e.js
@@ -58,7 +58,7 @@ cp.execFileSync('npm', ['install']);
 // Reformat tests to use newly installed express
 console.log('Reformating tests');
 var gcloud_require = 'require(\'' + path.join(__dirname, '..', '..') +
-    '\').startAgent();';
+    '\')().startAgent();';
 glob(test_glob, function(err, files) {
   error = error || err;
   for (var i = 0; i < files.length; i++) {

--- a/test/non-interference/express-e2e.js
+++ b/test/non-interference/express-e2e.js
@@ -58,7 +58,7 @@ cp.execFileSync('npm', ['install']);
 // Reformat tests to use newly installed express
 console.log('Reformating tests');
 var gcloud_require = 'require(\'' + path.join(__dirname, '..', '..') +
-    '\').start();';
+    '\').startAgent();';
 glob(test_glob, function(err, files) {
   error = error || err;
   for (var i = 0; i < files.length; i++) {

--- a/test/non-interference/http-e2e.js
+++ b/test/non-interference/http-e2e.js
@@ -48,7 +48,7 @@ var test_glob = semver.satisfies(process.version, '0.12.x') ?
 // Run tests
 console.log('Running tests');
 var gcloud_require = 'require(\'' + path.join(__dirname, '..', '..') +
-    '\').startAgent();';
+    '\')().startAgent();';
 glob(test_glob, function(err, files) {
   var errors = 0;
   var testCount;

--- a/test/non-interference/http-e2e.js
+++ b/test/non-interference/http-e2e.js
@@ -48,7 +48,7 @@ var test_glob = semver.satisfies(process.version, '0.12.x') ?
 // Run tests
 console.log('Running tests');
 var gcloud_require = 'require(\'' + path.join(__dirname, '..', '..') +
-    '\').start();';
+    '\').startAgent();';
 glob(test_glob, function(err, files) {
   var errors = 0;
   var testCount;

--- a/test/non-interference/restify-e2e.js
+++ b/test/non-interference/restify-e2e.js
@@ -57,7 +57,7 @@ cp.execFileSync('npm', ['install']);
 // Reformat tests to use newly installed restify
 console.log('Reformating tests');
 var gcloud_require = 'require(\'' + path.join(__dirname, '..', '..') +
-    '\').start();';
+    '\').startAgent();';
 glob(test_glob, function(err, files) {
   for (var i = 0; i < files.length; i++) {
     cp.execFileSync('sed', ['-i', 's#\'use strict\';#' +

--- a/test/non-interference/restify-e2e.js
+++ b/test/non-interference/restify-e2e.js
@@ -57,7 +57,7 @@ cp.execFileSync('npm', ['install']);
 // Reformat tests to use newly installed restify
 console.log('Reformating tests');
 var gcloud_require = 'require(\'' + path.join(__dirname, '..', '..') +
-    '\').startAgent();';
+    '\')().startAgent();';
 glob(test_glob, function(err, files) {
   for (var i = 0; i < files.length; i++) {
     cp.execFileSync('sed', ['-i', 's#\'use strict\';#' +

--- a/test/performance/express/express-performance-runner.js
+++ b/test/performance/express/express-performance-runner.js
@@ -19,7 +19,7 @@
 if (process.argv[2] === '-i') {
   process.env.GCLOUD_TRACE_ENABLED = true;
   process.env.GCLOUD_TRACE_EXCLUDE_HTTP = true;
-  var traceAgent = require('../../..').startAgent().private_();
+  var traceAgent = require('../../..')().startAgent().private_();
   // We want to drop all spans and avoid network ops
   traceAgent.traceWriter.writeSpan = function() {};
 }

--- a/test/performance/express/express-performance-runner.js
+++ b/test/performance/express/express-performance-runner.js
@@ -19,7 +19,7 @@
 if (process.argv[2] === '-i') {
   process.env.GCLOUD_TRACE_ENABLED = true;
   process.env.GCLOUD_TRACE_EXCLUDE_HTTP = true;
-  var traceAgent = require('../../..').start().private_();
+  var traceAgent = require('../../..').startAgent().private_();
   // We want to drop all spans and avoid network ops
   traceAgent.traceWriter.writeSpan = function() {};
 }

--- a/test/performance/http/http-performance-runner.js
+++ b/test/performance/http/http-performance-runner.js
@@ -19,7 +19,7 @@
 var traceAgent;
 if (process.argv[2] === '-i') {
   process.env.GCLOUD_TRACE_ENABLED = true;
-  traceAgent = require('../../..').start().private_();
+  traceAgent = require('../../..').startAgent().private_();
   // We want to drop all spans and avoid network ops
   traceAgent.traceWriter.writeSpan = function() {};
 }

--- a/test/performance/http/http-performance-runner.js
+++ b/test/performance/http/http-performance-runner.js
@@ -19,7 +19,7 @@
 var traceAgent;
 if (process.argv[2] === '-i') {
   process.env.GCLOUD_TRACE_ENABLED = true;
-  traceAgent = require('../../..').startAgent().private_();
+  traceAgent = require('../../..')().startAgent().private_();
   // We want to drop all spans and avoid network ops
   traceAgent.traceWriter.writeSpan = function() {};
 }

--- a/test/performance/mongo/mongo-performance-runner.js
+++ b/test/performance/mongo/mongo-performance-runner.js
@@ -25,7 +25,7 @@
 var traceAgent;
 if (process.argv[2] === '-i') {
   process.env.GCLOUD_TRACE_ENABLED = true;
-  traceAgent = require('../../..').startAgent().private_();
+  traceAgent = require('../../..')().startAgent().private_();
   // We want to drop all spans and avoid network ops
   traceAgent.traceWriter.writeSpan = function() {};
 }

--- a/test/performance/mongo/mongo-performance-runner.js
+++ b/test/performance/mongo/mongo-performance-runner.js
@@ -25,7 +25,7 @@
 var traceAgent;
 if (process.argv[2] === '-i') {
   process.env.GCLOUD_TRACE_ENABLED = true;
-  traceAgent = require('../../..').start().private_();
+  traceAgent = require('../../..').startAgent().private_();
   // We want to drop all spans and avoid network ops
   traceAgent.traceWriter.writeSpan = function() {};
 }

--- a/test/performance/restify/restify-performance-runner.js
+++ b/test/performance/restify/restify-performance-runner.js
@@ -19,7 +19,7 @@
 if (process.argv[2] === '-i') {
   process.env.GCLOUD_TRACE_ENABLED = true;
   process.env.GCLOUD_TRACE_EXCLUDE_HTTP = true;
-  var traceAgent = require('../../..').startAgent().private_();
+  var traceAgent = require('../../..')().startAgent().private_();
   // We want to drop all spans and avoid network ops
   traceAgent.traceWriter.writeSpan = function() {};
 }

--- a/test/performance/restify/restify-performance-runner.js
+++ b/test/performance/restify/restify-performance-runner.js
@@ -19,7 +19,7 @@
 if (process.argv[2] === '-i') {
   process.env.GCLOUD_TRACE_ENABLED = true;
   process.env.GCLOUD_TRACE_EXCLUDE_HTTP = true;
-  var traceAgent = require('../../..').start().private_();
+  var traceAgent = require('../../..').startAgent().private_();
   // We want to drop all spans and avoid network ops
   traceAgent.traceWriter.writeSpan = function() {};
 }

--- a/test/standalone/test-agent-metadata.js
+++ b/test/standalone/test-agent-metadata.js
@@ -18,7 +18,7 @@
 
 var assert = require('assert');
 var nock = require('nock');
-var agent = require('../..');
+var agent = require('../..')();
 var traceLabels = require('../../src/trace-labels.js');
 
 nock.disableNetConnect();

--- a/test/standalone/test-agent-metadata.js
+++ b/test/standalone/test-agent-metadata.js
@@ -38,7 +38,7 @@ describe('agent interaction with metadata service', function() {
                 .times(2)
                 .reply(404, 'foo');
 
-    agent.start({logLevel: 0});
+    agent.startAgent({logLevel: 0});
     setTimeout(function() {
       assert.ok(!agent.isActive());
       scope.done();
@@ -52,7 +52,7 @@ describe('agent interaction with metadata service', function() {
                 .get('/computeMetadata/v1/project/numeric-project-id')
                 .times(2)
                 .reply(200, '1234');
-    agent.start({logLevel: 0});
+    agent.startAgent({logLevel: 0});
     setTimeout(function() {
       assert.ok(agent.isActive());
       assert.equal(agent.private_().config().projectId, '1234');
@@ -64,13 +64,13 @@ describe('agent interaction with metadata service', function() {
   it('should not query metadata service when config.projectId is set',
     function() {
       nock.disableNetConnect();
-      agent.start({projectId: 0, logLevel: 0});
+      agent.startAgent({projectId: 0, logLevel: 0});
     });
 
   it('should not query metadata service when env. var. is set', function() {
     nock.disableNetConnect();
     process.env.GCLOUD_PROJECT=0;
-    agent.start({logLevel: 0});
+    agent.startAgent({logLevel: 0});
     delete process.env.GCLOUD_PROJECT;
   });
 
@@ -81,7 +81,7 @@ describe('agent interaction with metadata service', function() {
                 .times(1)
                 .reply(200, 'host');
 
-    agent.start({projectId: 0, logLevel: 0});
+    agent.startAgent({projectId: 0, logLevel: 0});
     setTimeout(function() {
       agent.private_().namespace.run(function() {
         var spanData = agent.private_().createRootSpanData('name', 5, 0);
@@ -100,7 +100,7 @@ describe('agent interaction with metadata service', function() {
                 .times(1)
                 .reply(200, '1729');
 
-    agent.start({projectId: 0, logLevel: 0});
+    agent.startAgent({projectId: 0, logLevel: 0});
     setTimeout(function() {
       agent.private_().namespace.run(function() {
         var spanData = agent.private_().createRootSpanData('name', 5, 0);
@@ -114,7 +114,7 @@ describe('agent interaction with metadata service', function() {
 
   it('shouldn\'t add id or hostname labels if not present', function(done) {
     nock.disableNetConnect();
-    agent.start({projectId: 0, logLevel: 0});
+    agent.startAgent({projectId: 0, logLevel: 0});
     setTimeout(function() {
       agent.private_().namespace.run(function() {
         var spanData = agent.private_().createRootSpanData('name', 5, 0);
@@ -131,7 +131,7 @@ describe('agent interaction with metadata service', function() {
     process.env.GAE_MODULE_NAME = 'foo';
     process.env.GAE_MODULE_VERSION = '20151119t120000';
     process.env.GAE_MINOR_VERSION = '91992';
-    agent.start({projectId: 0, logLevel: 0});
+    agent.startAgent({projectId: 0, logLevel: 0});
     setTimeout(function() {
       agent.private_().namespace.run(function() {
         var spanData = agent.private_().createRootSpanData('name', 5, 0);
@@ -150,7 +150,7 @@ describe('agent interaction with metadata service', function() {
     process.env.GAE_MODULE_NAME = 'default';
     process.env.GAE_MODULE_VERSION = '20151119t130000';
     process.env.GAE_MINOR_VERSION = '81818';
-    agent.start({projectId: 0, logLevel: 0});
+    agent.startAgent({projectId: 0, logLevel: 0});
     setTimeout(function() {
       agent.private_().namespace.run(function() {
         var spanData = agent.private_().createRootSpanData('name', 5, 0);
@@ -176,7 +176,7 @@ describe('agent interaction with metadata service', function() {
                   .reply(200, 'host');
 
       delete process.env.GAE_MODULE_NAME;
-      agent.start({projectId: 0, logLevel: 0});
+      agent.startAgent({projectId: 0, logLevel: 0});
       setTimeout(function() {
         agent.private_().namespace.run(function() {
           var spanData = agent.private_().createRootSpanData('name', 5, 0);
@@ -198,7 +198,7 @@ describe('agent interaction with metadata service', function() {
                   .reply(404);
 
       delete process.env.GAE_MODULE_NAME;
-      agent.start({projectId: 0, logLevel: 0});
+      agent.startAgent({projectId: 0, logLevel: 0});
       setTimeout(function() {
         agent.private_().namespace.run(function() {
           var spanData = agent.private_().createRootSpanData('name', 5, 0);

--- a/test/standalone/test-agent-stopped.js
+++ b/test/standalone/test-agent-stopped.js
@@ -46,7 +46,7 @@ describe('express', function() {
 
 describe('hapi', function() {
   it('should not break if no project number is found', function(done) {
-    var agent = require('../..');
+    var agent = require('../..')();
     agent.startAgent();
     var hapi = require('../hooks/fixtures/hapi8');
     var server = new hapi.Server();
@@ -75,7 +75,7 @@ describe('hapi', function() {
 
 describe('restify', function() {
   it('should not break if no project number is found', function(done) {
-    var agent = require('../..');
+    var agent = require('../..')();
     agent.startAgent();
     var restify = require('../hooks/fixtures/restify4');
     var server = restify.createServer();

--- a/test/standalone/test-agent-stopped.js
+++ b/test/standalone/test-agent-stopped.js
@@ -23,7 +23,7 @@ process.env.GCLOUD_PROJECT = 0;
 
 describe('express', function() {
   it('should not break if no project number is found', function(done) {
-    var agent = require('../..');
+    var agent = require('../..')();
     agent.startAgent();
     var app = require('../hooks/fixtures/express4')();
     agent.stop();

--- a/test/standalone/test-agent-stopped.js
+++ b/test/standalone/test-agent-stopped.js
@@ -24,7 +24,7 @@ process.env.GCLOUD_PROJECT = 0;
 describe('express', function() {
   it('should not break if no project number is found', function(done) {
     var agent = require('../..');
-    agent.start();
+    agent.startAgent();
     var app = require('../hooks/fixtures/express4')();
     agent.stop();
     app.get('/', function (req, res) {
@@ -47,7 +47,7 @@ describe('express', function() {
 describe('hapi', function() {
   it('should not break if no project number is found', function(done) {
     var agent = require('../..');
-    agent.start();
+    agent.startAgent();
     var hapi = require('../hooks/fixtures/hapi8');
     var server = new hapi.Server();
     server.connection({ port: 8081 });
@@ -76,7 +76,7 @@ describe('hapi', function() {
 describe('restify', function() {
   it('should not break if no project number is found', function(done) {
     var agent = require('../..');
-    agent.start();
+    agent.startAgent();
     var restify = require('../hooks/fixtures/restify4');
     var server = restify.createServer();
     agent.stop();

--- a/test/standalone/test-config-credentials.js
+++ b/test/standalone/test-config-credentials.js
@@ -36,7 +36,7 @@ describe('test-config-credentials', function() {
       samplingRate: 0,
       keyFilename: path.join('test', 'fixtures', 'gcloud-credentials.json')
     };
-    var agent = require('../..').startAgent(config);
+    var agent = require('../..')().startAgent(config);
     nock.disableNetConnect();
     var scope = nock('https://accounts.google.com')
       .intercept('/o/oauth2/token', 'POST', function(body) {
@@ -68,7 +68,7 @@ describe('test-config-credentials', function() {
       samplingRate: 0,
       credentials: require('../fixtures/gcloud-credentials.json')
     };
-    var agent = require('../..').startAgent(config);
+    var agent = require('../..')().startAgent(config);
     nock.disableNetConnect();
     var scope = nock('https://accounts.google.com')
       .intercept('/o/oauth2/token', 'POST', function(body) {
@@ -113,7 +113,7 @@ describe('test-config-credentials', function() {
       assert.notEqual(config.credentials[field],
         correctCredentials[field]);
     });
-    var agent = require('../..').startAgent(config);
+    var agent = require('../..')().startAgent(config);
     nock.disableNetConnect();
     var scope = nock('https://accounts.google.com')
       .intercept('/o/oauth2/token', 'POST', function(body) {

--- a/test/standalone/test-config-credentials.js
+++ b/test/standalone/test-config-credentials.js
@@ -36,7 +36,7 @@ describe('test-config-credentials', function() {
       samplingRate: 0,
       keyFilename: path.join('test', 'fixtures', 'gcloud-credentials.json')
     };
-    var agent = require('../..').start(config);
+    var agent = require('../..').startAgent(config);
     nock.disableNetConnect();
     var scope = nock('https://accounts.google.com')
       .intercept('/o/oauth2/token', 'POST', function(body) {
@@ -68,7 +68,7 @@ describe('test-config-credentials', function() {
       samplingRate: 0,
       credentials: require('../fixtures/gcloud-credentials.json')
     };
-    var agent = require('../..').start(config);
+    var agent = require('../..').startAgent(config);
     nock.disableNetConnect();
     var scope = nock('https://accounts.google.com')
       .intercept('/o/oauth2/token', 'POST', function(body) {
@@ -113,7 +113,7 @@ describe('test-config-credentials', function() {
       assert.notEqual(config.credentials[field],
         correctCredentials[field]);
     });
-    var agent = require('../..').start(config);
+    var agent = require('../..').startAgent(config);
     nock.disableNetConnect();
     var scope = nock('https://accounts.google.com')
       .intercept('/o/oauth2/token', 'POST', function(body) {

--- a/test/standalone/test-config-json.js
+++ b/test/standalone/test-config-json.js
@@ -26,7 +26,7 @@ var assert = require('assert');
 process.env.GCLOUD_DIAGNOSTICS_CONFIG =
   path.join('test', 'fixtures', 'test-config.json');
 
-var agent = require('../..').startAgent();
+var agent = require('../..')().startAgent();
 
 describe('json config', function() {
   it('should load trace config from json file', function() {

--- a/test/standalone/test-config-json.js
+++ b/test/standalone/test-config-json.js
@@ -26,7 +26,7 @@ var assert = require('assert');
 process.env.GCLOUD_DIAGNOSTICS_CONFIG =
   path.join('test', 'fixtures', 'test-config.json');
 
-var agent = require('../..').start();
+var agent = require('../..').startAgent();
 
 describe('json config', function() {
   it('should load trace config from json file', function() {

--- a/test/standalone/test-config-priority.js
+++ b/test/standalone/test-config-priority.js
@@ -28,7 +28,7 @@ process.env.GCLOUD_DIAGNOSTICS_CONFIG =
 
 process.env.GCLOUD_TRACE_LOGLEVEL = 2;
 
-var agent = require('../..').startAgent({logLevel: 3, stackTraceLimit: 2,
+var agent = require('../..')().startAgent({logLevel: 3, stackTraceLimit: 2,
   flushDelaySeconds: 31});
 
 describe('should respect config load order', function() {

--- a/test/standalone/test-config-priority.js
+++ b/test/standalone/test-config-priority.js
@@ -28,7 +28,7 @@ process.env.GCLOUD_DIAGNOSTICS_CONFIG =
 
 process.env.GCLOUD_TRACE_LOGLEVEL = 2;
 
-var agent = require('../..').start({logLevel: 3, stackTraceLimit: 2,
+var agent = require('../..').startAgent({logLevel: 3, stackTraceLimit: 2,
   flushDelaySeconds: 31});
 
 describe('should respect config load order', function() {

--- a/test/standalone/test-config-relative-path.js
+++ b/test/standalone/test-config-relative-path.js
@@ -27,7 +27,7 @@ process.env.GCLOUD_DIAGNOSTICS_CONFIG = path.join('fixtures', 'test-config.js');
 
 process.chdir('test');
 
-var agent = require('../..').start();
+var agent = require('../..').startAgent();
 
 describe('relative config', function() {
   it('should load trace config from relative path', function() {

--- a/test/standalone/test-config-relative-path.js
+++ b/test/standalone/test-config-relative-path.js
@@ -27,7 +27,7 @@ process.env.GCLOUD_DIAGNOSTICS_CONFIG = path.join('fixtures', 'test-config.js');
 
 process.chdir('test');
 
-var agent = require('../..').startAgent();
+var agent = require('../..')().startAgent();
 
 describe('relative config', function() {
   it('should load trace config from relative path', function() {

--- a/test/standalone/test-default-ignore-ah-health.js
+++ b/test/standalone/test-default-ignore-ah-health.js
@@ -15,7 +15,7 @@
  */
 'use strict';
 
-var agent = require('../..').startAgent({samplingRate: 0});
+var agent = require('../..')().startAgent({samplingRate: 0});
 
 var assert = require('assert');
 var http = require('http');

--- a/test/standalone/test-default-ignore-ah-health.js
+++ b/test/standalone/test-default-ignore-ah-health.js
@@ -15,7 +15,7 @@
  */
 'use strict';
 
-var agent = require('../..').start({samplingRate: 0});
+var agent = require('../..').startAgent({samplingRate: 0});
 
 var assert = require('assert');
 var http = require('http');

--- a/test/standalone/test-env-disable.js
+++ b/test/standalone/test-env-disable.js
@@ -19,7 +19,7 @@
 process.env.GCLOUD_TRACE_DISABLE = 1;
 
 var assert = require('assert');
-var agent = require('../..');
+var agent = require('../..')();
 
 describe('should respect environment variables', function() {
   it('should respect GCLOUD_TRACE_DISABLE', function() {

--- a/test/standalone/test-env-disable.js
+++ b/test/standalone/test-env-disable.js
@@ -23,13 +23,13 @@ var agent = require('../..');
 
 describe('should respect environment variables', function() {
   it('should respect GCLOUD_TRACE_DISABLE', function() {
-    agent.start();
+    agent.startAgent();
     assert(!agent.isActive());
     agent.stop();
   });
 
   it('should prefer env to config', function() {
-    agent.start({enabled: true});
+    agent.startAgent({enabled: true});
     assert(!agent.isActive());
     agent.stop();
   });

--- a/test/standalone/test-env-log-level.js
+++ b/test/standalone/test-env-log-level.js
@@ -19,7 +19,7 @@
 process.env.GCLOUD_TRACE_LOGLEVEL = 4;
 
 var assert = require('assert');
-var agent = require('../..');
+var agent = require('../..')();
 
 describe('should respect environment variables', function() {
   it('should respect GCLOUD_TRACE_LOGLEVEL', function() {

--- a/test/standalone/test-env-log-level.js
+++ b/test/standalone/test-env-log-level.js
@@ -23,13 +23,13 @@ var agent = require('../..');
 
 describe('should respect environment variables', function() {
   it('should respect GCLOUD_TRACE_LOGLEVEL', function() {
-    agent.start();
+    agent.startAgent();
     assert.equal(agent.private_().config_.logLevel, 4);
     agent.stop();
   });
 
   it('should prefer env to config', function() {
-    agent.start({logLevel: 2});
+    agent.startAgent({logLevel: 2});
     assert.equal(agent.private_().config_.logLevel, 4);
     agent.stop();
   });

--- a/test/standalone/test-env-project-id.js
+++ b/test/standalone/test-env-project-id.js
@@ -23,13 +23,13 @@ var agent = require('../..');
 
 describe('should respect environment variables', function() {
   it('should respect GCLOUD_PROJECT', function() {
-    agent.start();
+    agent.startAgent();
     assert.equal(agent.private_().config_.projectId, 1729);
     agent.stop();
   });
 
   it('should prefer env to config', function() {
-    agent.start({projectId: 1927});
+    agent.startAgent({projectId: 1927});
     assert.equal(agent.private_().config_.projectId, 1729);
     agent.stop();
   });

--- a/test/standalone/test-env-project-id.js
+++ b/test/standalone/test-env-project-id.js
@@ -19,7 +19,7 @@
 process.env.GCLOUD_PROJECT = 1729;
 
 var assert = require('assert');
-var agent = require('../..');
+var agent = require('../..')();
 
 describe('should respect environment variables', function() {
   it('should respect GCLOUD_PROJECT', function() {

--- a/test/standalone/test-grpc-context.js
+++ b/test/standalone/test-grpc-context.js
@@ -15,7 +15,7 @@
  */
 'use strict';
 
-var agent = require('../..').start({ samplingRate: 0 }).private_();
+var agent = require('../..').startAgent({ samplingRate: 0 }).private_();
 
 var common = require('../hooks/common.js');
 var assert = require('assert');

--- a/test/standalone/test-grpc-context.js
+++ b/test/standalone/test-grpc-context.js
@@ -15,7 +15,7 @@
  */
 'use strict';
 
-var agent = require('../..').startAgent({ samplingRate: 0 }).private_();
+var agent = require('../..')().startAgent({ samplingRate: 0 }).private_();
 
 var common = require('../hooks/common.js');
 var assert = require('assert');

--- a/test/standalone/test-hooks-no-project-num.js
+++ b/test/standalone/test-hooks-no-project-num.js
@@ -35,7 +35,7 @@ describe('should not break without project num', function() {
     process.stderr.write = write;
   });
   it('mongo', function(done) {
-    var agent = require('../..').startAgent();
+    var agent = require('../..')().startAgent();
     var mongoose = require('../hooks/fixtures/mongoose4');
     var Simple = mongoose.model('Simple', new mongoose.Schema({
       f1: String,
@@ -54,7 +54,7 @@ describe('should not break without project num', function() {
   });
 
   it('redis', function(done) {
-    var agent = require('../..').startAgent();
+    var agent = require('../..')().startAgent();
     var redis = require('../hooks/fixtures/redis2.3');
     var client = redis.createClient();
     client.set('i', 1, function() {
@@ -67,7 +67,7 @@ describe('should not break without project num', function() {
 
   it('express', function(done) {
     var http = require('http');
-    var agent = require('../..').startAgent();
+    var agent = require('../..')().startAgent();
     var express = require('../hooks/fixtures/express4');
     var app = express();
     var server;
@@ -84,7 +84,7 @@ describe('should not break without project num', function() {
 
   it('restify', function(done) {
     var http = require('http');
-    var agent = require('../..').startAgent();
+    var agent = require('../..')().startAgent();
     var restify = require('../hooks/fixtures/restify4');
     var server = restify.createServer();
     server.get('/', function (req, res, next) {
@@ -104,7 +104,7 @@ describe('should not break without project num', function() {
 
   it('hapi', function(done) {
     var http = require('http');
-    var agent = require('../..').startAgent();
+    var agent = require('../..')().startAgent();
     var hapi = require('../hooks/fixtures/hapi8');
     var server = new hapi.Server();
     server.connection({ port: 8081 });
@@ -124,7 +124,7 @@ describe('should not break without project num', function() {
   });
 
   it('http', function(done) {
-    var agent = require('../..').startAgent();
+    var agent = require('../..')().startAgent();
     var req = require('http').get({ port: 8081 });
     req.on('error', function() {
       agent.stop();
@@ -133,7 +133,7 @@ describe('should not break without project num', function() {
   });
 
   it('mysql', function(done) {
-    var agent = require('../..').startAgent();
+    var agent = require('../..')().startAgent();
     var mysql = require('../hooks/fixtures/mysql2');
     var pool = mysql.createPool({
       host     : 'localhost',

--- a/test/standalone/test-hooks-no-project-num.js
+++ b/test/standalone/test-hooks-no-project-num.js
@@ -35,7 +35,7 @@ describe('should not break without project num', function() {
     process.stderr.write = write;
   });
   it('mongo', function(done) {
-    var agent = require('../..').start();
+    var agent = require('../..').startAgent();
     var mongoose = require('../hooks/fixtures/mongoose4');
     var Simple = mongoose.model('Simple', new mongoose.Schema({
       f1: String,
@@ -54,7 +54,7 @@ describe('should not break without project num', function() {
   });
 
   it('redis', function(done) {
-    var agent = require('../..').start();
+    var agent = require('../..').startAgent();
     var redis = require('../hooks/fixtures/redis2.3');
     var client = redis.createClient();
     client.set('i', 1, function() {
@@ -67,7 +67,7 @@ describe('should not break without project num', function() {
 
   it('express', function(done) {
     var http = require('http');
-    var agent = require('../..').start();
+    var agent = require('../..').startAgent();
     var express = require('../hooks/fixtures/express4');
     var app = express();
     var server;
@@ -84,7 +84,7 @@ describe('should not break without project num', function() {
 
   it('restify', function(done) {
     var http = require('http');
-    var agent = require('../..').start();
+    var agent = require('../..').startAgent();
     var restify = require('../hooks/fixtures/restify4');
     var server = restify.createServer();
     server.get('/', function (req, res, next) {
@@ -104,7 +104,7 @@ describe('should not break without project num', function() {
 
   it('hapi', function(done) {
     var http = require('http');
-    var agent = require('../..').start();
+    var agent = require('../..').startAgent();
     var hapi = require('../hooks/fixtures/hapi8');
     var server = new hapi.Server();
     server.connection({ port: 8081 });
@@ -124,7 +124,7 @@ describe('should not break without project num', function() {
   });
 
   it('http', function(done) {
-    var agent = require('../..').start();
+    var agent = require('../..').startAgent();
     var req = require('http').get({ port: 8081 });
     req.on('error', function() {
       agent.stop();
@@ -133,7 +133,7 @@ describe('should not break without project num', function() {
   });
 
   it('mysql', function(done) {
-    var agent = require('../..').start();
+    var agent = require('../..').startAgent();
     var mysql = require('../hooks/fixtures/mysql2');
     var pool = mysql.createPool({
       host     : 'localhost',

--- a/test/standalone/test-hooks-sample-warning.js
+++ b/test/standalone/test-hooks-sample-warning.js
@@ -20,7 +20,7 @@
 //   ex) docker -d
 // Run a mongo image binding the mongo port
 //   ex) docker run -p 27017:27017 -d mongo
-var agent = require('../..').startAgent({ samplingRate: 0 }).private_();
+var agent = require('../..')().startAgent({ samplingRate: 0 }).private_();
 
 var common = require('../hooks/common.js');
 

--- a/test/standalone/test-hooks-sample-warning.js
+++ b/test/standalone/test-hooks-sample-warning.js
@@ -20,7 +20,7 @@
 //   ex) docker -d
 // Run a mongo image binding the mongo port
 //   ex) docker run -p 27017:27017 -d mongo
-var agent = require('../..').start({ samplingRate: 0 }).private_();
+var agent = require('../..').startAgent({ samplingRate: 0 }).private_();
 
 var common = require('../hooks/common.js');
 

--- a/test/standalone/test-ignore-url-express.js
+++ b/test/standalone/test-ignore-url-express.js
@@ -15,7 +15,7 @@
  */
 'use strict';
 
-var agent = require('../..').start({ignoreUrls: ['/test'], samplingRate: 0});
+var agent = require('../..').startAgent({ignoreUrls: ['/test'], samplingRate: 0});
 
 var assert = require('assert');
 var http = require('http');

--- a/test/standalone/test-ignore-url-express.js
+++ b/test/standalone/test-ignore-url-express.js
@@ -15,7 +15,7 @@
  */
 'use strict';
 
-var agent = require('../..').startAgent({ignoreUrls: ['/test'], samplingRate: 0});
+var agent = require('../..')().startAgent({ignoreUrls: ['/test'], samplingRate: 0});
 
 var assert = require('assert');
 var http = require('http');

--- a/test/standalone/test-index.js
+++ b/test/standalone/test-index.js
@@ -22,7 +22,7 @@ if (!process.env.GCLOUD_PROJECT) {
 }
 
 var assert = require('assert');
-var agent = require('../..');
+var agent = require('../..')();
 var cls = require('../../src/cls.js');
 
 describe('index.js', function() {

--- a/test/standalone/test-index.js
+++ b/test/standalone/test-index.js
@@ -37,13 +37,13 @@ describe('index.js', function() {
     agent.stop(); // harmless to stop before a start.
     assert(!nodule[property].__unwrap,
       property + ' already wrapped before start');
-    agent.start();
+    agent.startAgent();
     assert(nodule[property].__unwrap,
       property + ' should get wrapped on start');
     agent.stop();
     assert(!nodule[property].__unwrap,
       property + ' should get unwrapped on stop');
-    agent.start();
+    agent.startAgent();
     assert(nodule[property].__unwrap,
       property + ' should get wrapped on start');
     agent.stop();
@@ -56,21 +56,21 @@ describe('index.js', function() {
   });
 
   it('should not attach exception handler with ignore option', function() {
-    agent.start();
+    agent.startAgent();
     // Mocha attaches 1 exception handler
     assert.equal(process.listeners('uncaughtException').length, 1);
     agent.stop();
   });
 
   it('should wrap/unwrap http on start/stop', function() {
-    agent.start(); // agent needs to be started before the first require.
+    agent.startAgent(); // agent needs to be started before the first require.
     var http = require('http');
     wrapTest(http, 'request');
     agent.stop();
   });
 
   it('should wrap/unwrap express on start/stop', function() {
-    agent.start();
+    agent.startAgent();
     var express = require('../hooks/fixtures/express4');
     var patchedMethods = require('methods');
     patchedMethods.push('use', 'route', 'param', 'all');
@@ -81,14 +81,14 @@ describe('index.js', function() {
   });
 
   it('should wrap/unwrap hapi on start/stop', function() {
-    agent.start();
+    agent.startAgent();
     var hapi = require('../hooks/fixtures/hapi8');
     wrapTest(hapi.Server.prototype, 'connection');
     agent.stop();
   });
 
   it('should wrap/unwrap mongodb-core on start/stop', function() {
-    agent.start();
+    agent.startAgent();
     var mongo = require('../hooks/fixtures/mongodb-core1');
     wrapTest(mongo.Server.prototype, 'command');
     wrapTest(mongo.Server.prototype, 'insert');
@@ -99,7 +99,7 @@ describe('index.js', function() {
   });
 
   it('should wrap/unwrap redis on start/stop', function() {
-    agent.start();
+    agent.startAgent();
     var redis = require('../hooks/fixtures/redis0.12');
     wrapTest(redis.RedisClient.prototype, 'send_command');
     wrapTest(redis, 'createClient');
@@ -107,14 +107,14 @@ describe('index.js', function() {
   });
 
   it('should wrap/unwrap restify on start/stop', function() {
-    agent.start();
+    agent.startAgent();
     var restify = require('../hooks/fixtures/restify4');
     wrapTest(restify, 'createServer');
     agent.stop();
   });
 
   it('should have equivalent enabled and disabled structure', function() {
-    agent.start();
+    agent.startAgent();
     assert.equal(typeof agent, 'object');
     assert.equal(typeof agent.startSpan, 'function');
     assert.equal(typeof agent.endSpan, 'function');
@@ -137,7 +137,7 @@ describe('index.js', function() {
   });
 
   it('should return the initialized agent on get', function() {
-    agent.start();
+    agent.startAgent();
     assert.equal(agent.get(), agent);
   });
 
@@ -154,7 +154,7 @@ describe('index.js', function() {
   });
 
   it('should produce real spans when enabled', function() {
-    agent.start();
+    agent.startAgent();
     cls.getNamespace().run(function() {
       agent.private_().createRootSpanData('root', 1, 2);
       var spanData = agent.startSpan('sub');
@@ -165,7 +165,7 @@ describe('index.js', function() {
   });
 
   it('should produce real spans runInSpan sync', function() {
-    agent.start();
+    agent.startAgent();
     cls.getNamespace().run(function() {
       var root = agent.private_().createRootSpanData('root', 1, 0);
       var testLabel = { key: 'val' };
@@ -184,7 +184,7 @@ describe('index.js', function() {
   });
 
   it('should produce real spans runInSpan async', function(done) {
-    agent.start();
+    agent.startAgent();
     cls.getNamespace().run(function() {
       var root = agent.private_().createRootSpanData('root', 1, 0);
       var testLabel = { key: 'val' };
@@ -212,7 +212,7 @@ describe('index.js', function() {
   });
 
   it('should produce real root spans runInRootSpan sync', function() {
-    agent.start();
+    agent.startAgent();
     cls.getNamespace().run(function() {
       var testLabel = { key: 'val' };
       agent.runInRootSpan('root', testLabel, function() {
@@ -232,7 +232,7 @@ describe('index.js', function() {
   });
 
   it('should produce real root spans runInRootSpan async', function(done) {
-    agent.start();
+    agent.startAgent();
     cls.getNamespace().run(function() {
       var testLabel = { key: 'val' };
       agent.runInRootSpan('root', testLabel, function(endSpan) {
@@ -260,7 +260,7 @@ describe('index.js', function() {
   });
 
   it('should not break with no root span', function() {
-    agent.start();
+    agent.startAgent();
     var span = agent.startSpan();
     agent.setTransactionName('noop');
     agent.addTransactionLabel('noop', 'noop');
@@ -269,7 +269,7 @@ describe('index.js', function() {
   });
 
   it('should not allow nested root spans', function(done) {
-    agent.start();
+    agent.startAgent();
     agent.runInRootSpan('root', function(cb1) {
       var finished = false;
       var finish = function () {
@@ -304,7 +304,7 @@ describe('index.js', function() {
   });
 
   it('should set transaction name and labels', function() {
-    agent.start();
+    agent.startAgent();
     cls.getNamespace().run(function() {
       var spanData = agent.private_().createRootSpanData('root', 1, 2);
       agent.setTransactionName('root2');

--- a/test/standalone/test-invalid-project-id.js
+++ b/test/standalone/test-invalid-project-id.js
@@ -23,10 +23,10 @@ var agent = require('../..');
 
 describe('index.js', function() {
   it('should complain when config.projectId is not a string or number', function() {
-    agent.start({projectId: 0, enabled: true, logLevel: 0});
+    agent.startAgent({projectId: 0, enabled: true, logLevel: 0});
     assert(agent.isActive());
     agent.stop();
-    agent.start({projectId: {test: false}, enabled: true, logLevel: 0});
+    agent.startAgent({projectId: {test: false}, enabled: true, logLevel: 0});
     assert(!agent.isActive());
   });
 });

--- a/test/standalone/test-invalid-project-id.js
+++ b/test/standalone/test-invalid-project-id.js
@@ -19,7 +19,7 @@
 delete process.env.GCLOUD_PROJECT;
 
 var assert = require('assert');
-var agent = require('../..');
+var agent = require('../..')();
 
 describe('index.js', function() {
   it('should complain when config.projectId is not a string or number', function() {

--- a/test/standalone/test-no-self-tracing.js
+++ b/test/standalone/test-no-self-tracing.js
@@ -34,7 +34,7 @@ describe('test-no-self-tracing', function() {
                 .get('/computeMetadata/v1/instance/hostname').reply(200)
                 .get('/computeMetadata/v1/instance/id').reply(200)
                 .get('/computeMetadata/v1/project/numeric-project-id').reply(200);
-    var agent = require('../..').startAgent();
+    var agent = require('../..')().startAgent();
     require('http'); // Must require http to force patching of the module
     var oldDebug = agent.private_().logger.debug;
     agent.private_().logger.debug = newDebug;
@@ -53,7 +53,7 @@ describe('test-no-self-tracing', function() {
                 .get('/computeMetadata/v1/instance/id').reply(200);
     var apiScope = nock('https://cloudtrace.googleapis.com')
                 .patch('/v1/projects/0/traces').reply(200);
-    var agent = require('../..').startAgent({ projectId: 0, bufferSize: 1 });
+    var agent = require('../..')().startAgent({ projectId: 0, bufferSize: 1 });
     agent.private_().traceWriter.request_ = request;
     require('http'); // Must require http to force patching of the module
     var oldDebug = agent.private_().logger.debug;

--- a/test/standalone/test-no-self-tracing.js
+++ b/test/standalone/test-no-self-tracing.js
@@ -34,7 +34,7 @@ describe('test-no-self-tracing', function() {
                 .get('/computeMetadata/v1/instance/hostname').reply(200)
                 .get('/computeMetadata/v1/instance/id').reply(200)
                 .get('/computeMetadata/v1/project/numeric-project-id').reply(200);
-    var agent = require('../..').start();
+    var agent = require('../..').startAgent();
     require('http'); // Must require http to force patching of the module
     var oldDebug = agent.private_().logger.debug;
     agent.private_().logger.debug = newDebug;
@@ -53,7 +53,7 @@ describe('test-no-self-tracing', function() {
                 .get('/computeMetadata/v1/instance/id').reply(200);
     var apiScope = nock('https://cloudtrace.googleapis.com')
                 .patch('/v1/projects/0/traces').reply(200);
-    var agent = require('../..').start({ projectId: 0, bufferSize: 1 });
+    var agent = require('../..').startAgent({ projectId: 0, bufferSize: 1 });
     agent.private_().traceWriter.request_ = request;
     require('http'); // Must require http to force patching of the module
     var oldDebug = agent.private_().logger.debug;

--- a/test/standalone/test-trace-header-context.js
+++ b/test/standalone/test-trace-header-context.js
@@ -23,7 +23,7 @@ var constants = require('../../src/constants.js');
 
 describe('test-trace-header-context', function() {
   beforeEach(function() {
-    require('../..').startAgent();
+    require('../..')().startAgent();
   });
 
   afterEach(function() {

--- a/test/standalone/test-trace-header-context.js
+++ b/test/standalone/test-trace-header-context.js
@@ -27,7 +27,7 @@ describe('test-trace-header-context', function() {
   });
 
   afterEach(function() {
-    require('../..').stop();
+    require('../..')().stop();
   });
 
   it('should work with string url', function(done) {

--- a/test/standalone/test-trace-header-context.js
+++ b/test/standalone/test-trace-header-context.js
@@ -23,7 +23,7 @@ var constants = require('../../src/constants.js');
 
 describe('test-trace-header-context', function() {
   beforeEach(function() {
-    require('../..').start();
+    require('../..').startAgent();
   });
 
   afterEach(function() {

--- a/test/standalone/test-trace-options-sampling.js
+++ b/test/standalone/test-trace-options-sampling.js
@@ -20,7 +20,7 @@
 //   ex) docker -d
 // Run a mongo image binding the mongo port
 //   ex) docker run -p 27017:27017 -d mongo
-require('../..').startAgent({ samplingRate: 1 });
+require('../..')().startAgent({ samplingRate: 1 });
 
 var common = require('../hooks/common.js');
 

--- a/test/standalone/test-trace-options-sampling.js
+++ b/test/standalone/test-trace-options-sampling.js
@@ -20,7 +20,7 @@
 //   ex) docker -d
 // Run a mongo image binding the mongo port
 //   ex) docker run -p 27017:27017 -d mongo
-require('../..').start({ samplingRate: 1 });
+require('../..').startAgent({ samplingRate: 1 });
 
 var common = require('../hooks/common.js');
 

--- a/test/standalone/test-trace-options.js
+++ b/test/standalone/test-trace-options.js
@@ -20,7 +20,7 @@
 //   ex) docker -d
 // Run a mongo image binding the mongo port
 //   ex) docker run -p 27017:27017 -d mongo
-require('../..').start({ samplingRate: 0 });
+require('../..').startAgent({ samplingRate: 0 });
 
 var common = require('../hooks/common.js');
 

--- a/test/standalone/test-trace-options.js
+++ b/test/standalone/test-trace-options.js
@@ -20,7 +20,7 @@
 //   ex) docker -d
 // Run a mongo image binding the mongo port
 //   ex) docker run -p 27017:27017 -d mongo
-require('../..').startAgent({ samplingRate: 0 });
+require('../..')().startAgent({ samplingRate: 0 });
 
 var common = require('../hooks/common.js');
 

--- a/test/standalone/test-trace-uncaught-exception.js
+++ b/test/standalone/test-trace-uncaught-exception.js
@@ -19,7 +19,7 @@
 var assert = require('assert');
 var nock = require('nock');
 var cls = require('../../src/cls.js');
-var agent = require('../..');
+var agent = require('../..')();
 var request = require('request');
 
 nock.disableNetConnect();

--- a/test/standalone/test-trace-uncaught-exception.js
+++ b/test/standalone/test-trace-uncaught-exception.js
@@ -62,7 +62,7 @@ describe('tracewriter publishing', function() {
       }, 20);
     });
     process.nextTick(function() {
-      var privateAgent = agent.start({
+      var privateAgent = agent.startAgent({
         bufferSize: 1000,
         samplingRate: 0,
         onUncaughtException: 'flush'

--- a/test/standalone/test-trace-writer.js
+++ b/test/standalone/test-trace-writer.js
@@ -19,7 +19,7 @@
 var assert = require('assert');
 var nock = require('nock');
 var cls = require('../../src/cls.js');
-var agent = require('../..');
+var agent = require('../..')();
 var request = require('request');
 
 nock.disableNetConnect();

--- a/test/standalone/test-trace-writer.js
+++ b/test/standalone/test-trace-writer.js
@@ -51,7 +51,7 @@ describe('tracewriter publishing', function() {
           assert.equal(JSON.stringify(body), JSON.stringify(parsedOriginal));
           return true;
         }).reply(200);
-    var privateAgent = agent.start({bufferSize: 2, samplingRate: 0}).private_();
+    var privateAgent = agent.startAgent({bufferSize: 2, samplingRate: 0}).private_();
     privateAgent.traceWriter.request_ = request; // Avoid authing
     cls.getNamespace().run(function() {
       queueSpans(2, privateAgent);
@@ -72,7 +72,7 @@ describe('tracewriter publishing', function() {
           assert.equal(JSON.stringify(body), JSON.stringify(parsedOriginal));
           return true;
         }).reply(200);
-    var privateAgent = agent.start({flushDelaySeconds: 0.01, samplingRate: -1}).private_();
+    var privateAgent = agent.startAgent({flushDelaySeconds: 0.01, samplingRate: -1}).private_();
     privateAgent.traceWriter.request_ = request; // Avoid authing
     cls.getNamespace().run(function() {
       queueSpans(1, privateAgent);
@@ -93,7 +93,7 @@ describe('tracewriter publishing', function() {
           assert.equal(JSON.stringify(body), JSON.stringify(parsedOriginal));
           return true;
         }).replyWithError('Simulated Network Error');
-    var privateAgent = agent.start({bufferSize: 2, samplingRate: -1}).private_();
+    var privateAgent = agent.startAgent({bufferSize: 2, samplingRate: -1}).private_();
     privateAgent.traceWriter.request_ = request; // Avoid authing
     cls.getNamespace().run(function() {
       queueSpans(2, privateAgent);

--- a/test/test-span-data.js
+++ b/test/test-span-data.js
@@ -21,7 +21,7 @@ if (!process.env.GCLOUD_PROJECT) {
   process.exit(1);
 }
 
-var agent = require('..').startAgent({ samplingRate: 0 }).private_();
+var agent = require('..')().startAgent({ samplingRate: 0 }).private_();
 var TraceLabels = require('../src/trace-labels.js');
 var assert = require('assert');
 var cls = require('../src/cls.js');

--- a/test/test-span-data.js
+++ b/test/test-span-data.js
@@ -21,7 +21,7 @@ if (!process.env.GCLOUD_PROJECT) {
   process.exit(1);
 }
 
-var agent = require('..').start({ samplingRate: 0 }).private_();
+var agent = require('..').startAgent({ samplingRate: 0 }).private_();
 var TraceLabels = require('../src/trace-labels.js');
 var assert = require('assert');
 var cls = require('../src/cls.js');


### PR DESCRIPTION
Now this module exports a constructor.  In addition, the `start` method has ben renamed to `startAgent`.  These changes were made to more closely align this module with the other Google Cloud API Client Libraries via the `google-cloud` modules in [1].

[1]: https://github.com/GoogleCloudPlatform/google-cloud-node
