### PR TITLE
The module now exports a constructor

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ This module provides Stackdriver Trace support for Node.js applications. [Stackd
 
 3. Include and start the library *as the very first action in your application*:
 
-        require('@google/cloud-trace').start();
+        require('@google/cloud-trace')().startAgent();
 
   If you use `--require` in your start up command, make sure that the trace agent is --required first.
 
@@ -47,7 +47,7 @@ If you are running somewhere other than the Google Cloud Platform, see [running 
 
 See [the default configuration](config.js) for a list of possible configuration options. These options can be passed to the agent through the object argument to the start command shown above:
 
-        require('@google/cloud-trace').start({samplingRate: 500});
+        require('@google/cloud-trace')().startAgent({samplingRate: 500});
 
 Alternatively, you can provide configuration through a config file. This can be useful if you want to load our module using `--require` on the command line instead of editing your main script. You can start by copying the default config file and modifying it to suit your needs. The `GCLOUD_DIAGNOSTICS_CONFIG` environment variable should point to your configuration file.
 
@@ -142,7 +142,7 @@ For any of the web frameworks listed above (`express`, `hapi`, and `restify`), a
 The API is exposed by the `agent` returned by a call to `start`:
 
 ```javascript
-  var agent = require('@google/cloud-trace').start();
+  var agent = require('@google/cloud-trace')().startAgent();
 ```
 
 For child spans, you can either use the `startSpan` and `endSpan` API, or use the `runInSpan` function that uses a callback-style. For root spans, you must use `runInRootSpan`.

--- a/index.js
+++ b/index.js
@@ -82,25 +82,6 @@ var initConfig = function(projectConfig) {
   return config;
 };
 
-function _printStack(name) {
-  /*
-  var stack = require('callsite');
-  console.log('Invoking ' + name + ' at:');
-  stack().forEach(function(site){
-    var file = site.getFileName();
-    if (file.indexOf('cloud-trace-nodejs') !== -1 &&
-          file.indexOf('node_modules') === -1 &&
-            !file.endsWith('index.js')){
-      console.log('  %s:%d',
-        //site.getFunctionName() || 'anonymous',
-        site.getFileName(),
-        site.getLineNumber());
-    }
-  });
-  console.log();
-  */
-}
-
 /**
  * The singleton public agent. This is the public API of the module.
  */
@@ -202,8 +183,6 @@ var publicAgent = {
   },
 
   stop: function() {
-    _printStack('publicAgent.stop with isActive=' + this.isActive());
-
     if (this.isActive()) {
       agent.stop();
       agent = phantomTraceAgent;
@@ -239,8 +218,6 @@ var publicAgent = {
  * @param {object} options - [Configuration object](#/docs)
  */
 function Trace(options) {
-  _printStack('Trace.new');
-
   if (!(this instanceof Trace)) {
     return new Trace(options);
   }
@@ -259,7 +236,6 @@ function Trace(options) {
  * trace.startAgent();
  */
 Trace.prototype.startAgent = function(config) {
-  _printStack('Trace.startAgent');
   publicAgent.startAgent(config);
   return publicAgent;
 };
@@ -269,7 +245,6 @@ Trace.prototype.isActive = function() {
 };
 
 Trace.prototype.get = function() {
-  _printStack('Trace.get');
   return publicAgent.get();
 };
 

--- a/index.js
+++ b/index.js
@@ -198,9 +198,26 @@ var publicAgent = {
   private_: function() { return agent; }
 };
 
-// TODO: Update the documentation for the supplied options
 /**
- * @param {object} options - These are currently ignored
+ * <p class="notice">
+ *   *This module is experimental, and should be used by early adopters. This
+ *   module uses APIs that may be undocumented and subject to change without
+ *   notice.*
+ * </p>
+ *
+ * This module provides Stackdriver Trace support for Node.js applications.
+ * [Stackdriver Trace](https://cloud.google.com/cloud-trace/) is a feature of
+ * [Google Cloud Platform](https://cloud.google.com/) that collects latency
+ * data (traces) from your applications and displays it in near real-time in
+ * the [Google Cloud Console][cloud-console].
+ *
+ * @constructor
+ * @alias module:trace
+ *
+ * @resource [What is Stackdriver Trace]{@link
+ *   https://cloud.google.com/cloud-trace/}
+ *
+ * @param {object} options - [Configuration object](#/docs)
  */
 function Trace(options) {
   if (!(this instanceof Trace)) {
@@ -208,8 +225,20 @@ function Trace(options) {
   }
 }
 
-Trace.prototype.startAgent = function(projectConfig) {
-  publicAgent.startAgent(projectConfig);
+/**
+ * Start the Trace agent that will make your application available for
+ * tracing with Stackdriver Trace.
+ *
+ * @param {object=} config - Trace configuration
+ *
+ * @resource [Introductory video]{@link
+ * https://www.youtube.com/watch?v=NCFDqeo7AeY}
+ *
+ * @example
+ * trace.startAgent();
+ */
+Trace.prototype.startAgent = function(config) {
+  publicAgent.startAgent(config);
   return publicAgent;
 };
 

--- a/index.js
+++ b/index.js
@@ -94,6 +94,13 @@ var initConfig = function(projectConfig) {
  * The singleton public agent. This is the public API of the module.
  */
 var publicAgent = {
+  __DISABLE_START_CHECK__: false,
+
+  _disableStartCheck: function() {
+    this.__DISABLE_START_CHECK__ = true;
+    return this;
+  },
+
   isActive: function() {
     return agent !== phantomTraceAgent && agent.isRunning();
   },
@@ -124,7 +131,13 @@ var publicAgent = {
 
   startAgent: function(projectConfig) {
     if (this.isActive()) { // already started.
-      throw new Error('Cannot call start on an already started agent.');
+      var message = 'Cannot call start on an already started agent.';
+      if (this.__DISABLE_START_CHECK__) {
+        console.log(message);
+      }
+      else {
+        throw new Error(message);
+      }
     }
 
     var config = initConfig(projectConfig);

--- a/index.js
+++ b/index.js
@@ -198,6 +198,7 @@ var publicAgent = {
   private_: function() { return agent; }
 };
 
+// TODO: Update the documentation for the supplied options
 /**
  * @param {object} options - These are currently ignored
  */

--- a/index.js
+++ b/index.js
@@ -212,7 +212,8 @@ Trace.prototype.startAgent = function(projectConfig) {
   return publicAgent;
 };
 
-module.exports = global._google_trace_agent = Trace;
+global._google_trace_agent = publicAgent;
+module.exports = Trace;
 
 // If the module was --require'd from the command line, start the agent.
 if (module.parent && module.parent.id === 'internal/preload') {

--- a/index.js
+++ b/index.js
@@ -114,7 +114,7 @@ var publicAgent = {
     return agent.addTransactionLabel(key, value);
   },
 
-  start: function(projectConfig) {
+  startAgent: function(projectConfig) {
     if (this.isActive()) { // already started.
       agent.logger.warn('Calling start on already started agent.' +
         'New configuration will be ignored.');
@@ -198,9 +198,23 @@ var publicAgent = {
   private_: function() { return agent; }
 };
 
-module.exports = global._google_trace_agent = publicAgent;
+/**
+ * @param {object} options - These are currently ignored
+ */
+function Trace(options) {
+  if (!(this instanceof Trace)) {
+    return new Trace(options);
+  }
+}
+
+Trace.prototype.startAgent = function(projectConfig) {
+  publicAgent.startAgent(projectConfig);
+  return publicAgent;
+};
+
+module.exports = global._google_trace_agent = Trace;
 
 // If the module was --require'd from the command line, start the agent.
 if (module.parent && module.parent.id === 'internal/preload') {
-  module.exports.start();
+  module.exports().startAgent();
 }

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "tmp": "0.0.31"
   },
   "dependencies": {
-    "@google-cloud/common": "^0.11.0",
+    "@google-cloud/common": "^0.12.0",
     "continuation-local-storage": "^3.1.4",
     "gcp-metadata": "^0.1.0",
     "is": "^3.2.0",

--- a/test/fixtures/preloaded-agent.js
+++ b/test/fixtures/preloaded-agent.js
@@ -16,7 +16,7 @@
 'use strict';
 
 var assert = require('assert');
-var agent = require('../../');
+var agent = require('../../')().startAgent();
 
 assert(agent.isActive());
 console.log('Preload test passed.');

--- a/test/fixtures/preloaded-agent.js
+++ b/test/fixtures/preloaded-agent.js
@@ -16,7 +16,8 @@
 'use strict';
 
 var assert = require('assert');
-var agent = require('../../')().startAgent();
+var agent = require('../../')();
 
 assert(agent.isActive());
+agent.get().stop();
 console.log('Preload test passed.');

--- a/test/fixtures/start-agent.js
+++ b/test/fixtures/start-agent.js
@@ -17,4 +17,4 @@
 
 process.env.GCLOUD_TRACE_LOGLEVEL = 4;
 require('glob'); // Load a module before agent
-require('../..').start();
+require('../..')().startAgent();

--- a/test/hooks/common.js
+++ b/test/hooks/common.js
@@ -75,6 +75,14 @@ function getMatchingSpans(agent, predicate) {
   return list;
 }
 
+function assertSpanDurationCorrect(span) {
+  var duration = Date.parse(span.endTime) - Date.parse(span.startTime);
+  assert(duration > SERVER_WAIT * (1 - FORGIVENESS),
+      'Duration was ' + duration + ', expected ' + SERVER_WAIT);
+  assert(duration < SERVER_WAIT * (1 + FORGIVENESS),
+      'Duration was ' + duration + ', expected ' + SERVER_WAIT);
+}
+
 /**
  * Verifies that the duration of the span captured
  * by the tracer matching the predicate `predicate`
@@ -96,11 +104,7 @@ function assertDurationCorrect(agent, predicate) {
   // by the harness itself
   predicate = predicate || function(span) { return span.name !== 'outer'; };
   var span = getMatchingSpan(agent, predicate);
-  var duration = Date.parse(span.endTime) - Date.parse(span.startTime);
-  assert(duration > SERVER_WAIT * (1 - FORGIVENESS),
-      'Duration was ' + duration + ', expected ' + SERVER_WAIT);
-  assert(duration < SERVER_WAIT * (1 + FORGIVENESS),
-      'Duration was ' + duration + ', expected ' + SERVER_WAIT);
+  assertSpanDurationCorrect(span);
 }
 
 function doRequest(agent, method, done, tracePredicate, path) {

--- a/test/hooks/common.js
+++ b/test/hooks/common.js
@@ -21,7 +21,7 @@ if (!process.env.GCLOUD_PROJECT) {
 }
 
 var config = { enhancedDatabaseReporting: true, samplingRate: 0 };
-var agent = require('../..').start(config).private_();
+var agent = require('../..')().startAgent(config).private_();
 // We want to disable publishing to avoid conflicts with production.
 agent.traceWriter.publish_ = function() {};
 

--- a/test/hooks/common.js
+++ b/test/hooks/common.js
@@ -136,12 +136,32 @@ function runInTransaction(agent, fn) {
   });
 }
 
+// Creates a child span that closes after the given duration.
+// Also calls cb after that duration.
+// Returns a method which, when called, closes the child span
+// right away and cancels callback from being called after the duration.
+function createChildSpan(agent, cb, duration) {
+  var span = agent.startSpan('inner');
+  var t = setTimeout(function() {
+    agent.endSpan(span);
+    if (cb) {
+      cb();
+    }
+  }, duration);
+  return function() {
+    agent.endSpan(span);
+    clearTimeout(t);
+  };
+}
+
 module.exports = {
+  assertSpanDurationCorrect: assertSpanDurationCorrect,
   assertDurationCorrect: assertDurationCorrect,
   cleanTraces: cleanTraces,
   getMatchingSpan: getMatchingSpan,
   getMatchingSpans: getMatchingSpans,
   doRequest: doRequest,
+  createChildSpan: createChildSpan,
   getTraces: getTraces,
   runInTransaction: runInTransaction,
   serverWait: SERVER_WAIT,

--- a/test/hooks/test-hooks-interop-mongo-express.js
+++ b/test/hooks/test-hooks-interop-mongo-express.js
@@ -26,7 +26,7 @@ var assert = require('assert');
 var express = require('./fixtures/express4');
 var http = require('http');
 var mongoose = require('./fixtures/mongoose4');
-var agent = require('../..').get().private_();
+var agent = require('../..')().startAgent().get().private_();
 var oldDebug = agent.logger.debug;
 agent.logger.debug = function(error) {
   assert(error.indexOf('mongo') === -1, error);

--- a/test/hooks/test-hooks-interop-mongo-express.js
+++ b/test/hooks/test-hooks-interop-mongo-express.js
@@ -26,15 +26,24 @@ var assert = require('assert');
 var express = require('./fixtures/express4');
 var http = require('http');
 var mongoose = require('./fixtures/mongoose4');
-var agent = require('../..')().startAgent().get().private_();
-var oldDebug = agent.logger.debug;
-agent.logger.debug = function(error) {
-  assert(error.indexOf('mongo') === -1, error);
-};
 
 var server;
 
 describe('mongodb + express', function() {
+  var agent;
+  var oldDebug;
+  before(function() {
+    agent = require('../..')().startAgent().get().private_();
+    oldDebug = agent.logger.debug;
+    agent.logger.debug = function(error) {
+      assert(error.indexOf('mongo') === -1, error);
+    };
+  });
+
+  after(function() {
+    agent.stop();
+  });
+
   it('should not lose context on startup', function(done) {
     var app = express();
     app.get('/', function (req, res) {
@@ -49,7 +58,7 @@ describe('mongodb + express', function() {
     server = app.listen(common.serverPort, function() {
       http.get({port: common.serverPort}, function(res) {
         server.close();
-        common.cleanTraces();
+        common.cleanTraces(agent);
         agent.logger.debug = oldDebug;
         done();
       });

--- a/test/hooks/test-hooks-interop-mongo-express.js
+++ b/test/hooks/test-hooks-interop-mongo-express.js
@@ -23,17 +23,19 @@
 var common = require('./common.js');
 
 var assert = require('assert');
-var express = require('./fixtures/express4');
 var http = require('http');
-var mongoose = require('./fixtures/mongoose4');
 
 var server;
 
 describe('mongodb + express', function() {
   var agent;
   var oldDebug;
+  var express;
+  var mongoose;
   before(function() {
     agent = require('../..')().startAgent().get().private_();
+    express = require('./fixtures/express4');
+    mongoose = require('./fixtures/mongoose4');
     oldDebug = agent.logger.debug;
     agent.logger.debug = function(error) {
       assert(error.indexOf('mongo') === -1, error);

--- a/test/hooks/test-trace-connect.js
+++ b/test/hooks/test-trace-connect.js
@@ -20,13 +20,16 @@ var http = require('http');
 var assert = require('assert');
 var constants = require('../../src/constants.js');
 var common = require('./common.js');
-var connect = require('./fixtures/connect3');
 
 var server;
 var write;
 
 describe('test-trace-connect', function() {
+  var agent;
+  var connect;
   before(function() {
+    agent = require('../..')().startAgent({ samplingRate: 0 }).private_();
+    connect = require('./fixtures/connect3');
     // Mute stderr to satiate appveyor
     write = process.stderr.write;
     process.stderr.write = function(c, e, cb) {
@@ -39,10 +42,11 @@ describe('test-trace-connect', function() {
 
   after(function() {
     process.stderr.write = write;
+    agent.stop();
   });
 
   afterEach(function() {
-    common.cleanTraces();
+    common.cleanTraces(agent);
     server.close();
   });
 
@@ -54,7 +58,7 @@ describe('test-trace-connect', function() {
       }, common.serverWait);
     });
     server = app.listen(common.serverPort, function() {
-      common.doRequest('GET', done, connectPredicate);
+      common.doRequest(agent, 'GET', done, connectPredicate);
     });
   });
 
@@ -71,7 +75,7 @@ describe('test-trace-connect', function() {
       }, common.serverWait / 2);
     });
     server = app.listen(common.serverPort, function() {
-      common.doRequest('GET', done, connectPredicate);
+      common.doRequest(agent, 'GET', done, connectPredicate);
     });
   });
 
@@ -84,7 +88,7 @@ describe('test-trace-connect', function() {
       }, common.serverWait);
     });
     server = app.listen(common.serverPort, function() {
-      common.doRequest('GET', done, connectPredicate);
+      common.doRequest(agent, 'GET', done, connectPredicate);
     });
   });
 
@@ -95,7 +99,7 @@ describe('test-trace-connect', function() {
     });
     server = app.listen(common.serverPort, function() {
       http.get({port: common.serverPort}, function(res) {
-        var labels = common.getMatchingSpan(connectPredicate).labels;
+        var labels = common.getMatchingSpan(agent, connectPredicate).labels;
         assert.equal(labels[traceLabels.HTTP_RESPONSE_CODE_LABEL_KEY], '200');
         assert.equal(labels[traceLabels.HTTP_METHOD_LABEL_KEY], 'GET');
         assert.equal(labels[traceLabels.HTTP_URL_LABEL_KEY], 'http://localhost:9042/');
@@ -112,7 +116,7 @@ describe('test-trace-connect', function() {
     });
     server = app.listen(common.serverPort, function() {
       http.get({port: common.serverPort}, function(res) {
-        var labels = common.getMatchingSpan(connectPredicate).labels;
+        var labels = common.getMatchingSpan(agent, connectPredicate).labels;
         var stackTrace = JSON.parse(labels[traceLabels.STACK_TRACE_DETAILS_KEY]);
         // Ensure that our middleware is on top of the stack
         assert.equal(stackTrace.stack_frame[0].method_name, 'middleware');
@@ -128,7 +132,7 @@ describe('test-trace-connect', function() {
     });
     server = app.listen(common.serverPort, function() {
       http.get({path: '/?a=b', port: common.serverPort}, function(res) {
-        var span = common.getMatchingSpan(connectPredicate);
+        var span = common.getMatchingSpan(agent, connectPredicate);
         assert.equal(span.name, '/');
         done();
       });
@@ -142,7 +146,7 @@ describe('test-trace-connect', function() {
     });
     server = app.listen(common.serverPort, function() {
       http.get({port: common.serverPort}, function(res) {
-        var labels = common.getMatchingSpan(connectPredicate).labels;
+        var labels = common.getMatchingSpan(agent, connectPredicate).labels;
         assert.equal(labels[traceLabels.HTTP_RESPONSE_CODE_LABEL_KEY], '500');
         done();
       });

--- a/test/hooks/test-trace-grpc.js
+++ b/test/hooks/test-trace-grpc.js
@@ -16,7 +16,7 @@
 'use strict';
 
 var common = require('./common.js');
-var agent = require('../..')().startAgent();
+var agent = require('../..')();
 agent.startAgent().private_().config_.enhancedDatabaseReporting = true;
 var assert = require('assert');
 var traceLabels = require('../../src/trace-labels.js');

--- a/test/hooks/test-trace-grpc.js
+++ b/test/hooks/test-trace-grpc.js
@@ -86,10 +86,12 @@ Object.keys(versions).forEach(function(version) {
         });
         call.on('end', function() {
           if (sum === EMIT_ERROR) {
-            if (stopChildSpan) {
-              stopChildSpan();
-            }
-            cb(new Error('test'));
+            triggerCb = function() {
+              if (stopChildSpan) {
+                stopChildSpan();
+              }
+              cb(new Error('test'));
+            };
           } else if (sum === SEND_METADATA) {
             call.sendMetadata(metadata);
             triggerCb = function() {
@@ -118,7 +120,7 @@ Object.keys(versions).forEach(function(version) {
       testBidiStream: function(stream) {
         var sum = 0;
         var stopChildSpan;
-        setTimeout(function() {
+        var t = setTimeout(function() {
           stream.end();
         }, common.serverWait);
         stream.on('data', function(data) {
@@ -133,10 +135,13 @@ Object.keys(versions).forEach(function(version) {
         stream.on('end', function() {
           stopChildSpan();
           if (sum === EMIT_ERROR) {
-          if (stopChildSpan) {
-            stopChildSpan();
-          }
-            stream.emit('error', new Error('test'));
+            clearTimeout(t);
+            setTimeout(function() {
+              if (stopChildSpan) {
+                stopChildSpan();
+              }
+              stream.emit('error', new Error('test'));
+            }, common.serverWait);
           } else if (sum === SEND_METADATA) {
             stream.sendMetadata(metadata);
           }

--- a/test/hooks/test-trace-grpc.js
+++ b/test/hooks/test-trace-grpc.js
@@ -16,7 +16,7 @@
 'use strict';
 
 var common = require('./common.js');
-var agent = require('../..')();
+var agent = require('../..')().startAgent();
 agent.startAgent().private_().config_.enhancedDatabaseReporting = true;
 var assert = require('assert');
 var traceLabels = require('../../src/trace-labels.js');

--- a/test/hooks/test-trace-grpc.js
+++ b/test/hooks/test-trace-grpc.js
@@ -16,8 +16,9 @@
 'use strict';
 
 var common = require('./common.js');
-var trace = require('../..')();
-trace.startAgent().private_().config_.enhancedDatabaseReporting = true;
+require('../..')().startAgent({
+  enhancedDatabaseReporting: true
+});
 var assert = require('assert');
 var traceLabels = require('../../src/trace-labels.js');
 

--- a/test/hooks/test-trace-grpc.js
+++ b/test/hooks/test-trace-grpc.js
@@ -16,8 +16,8 @@
 'use strict';
 
 var common = require('./common.js');
-var agent = require('../..')();
-agent.startAgent().private_().config_.enhancedDatabaseReporting = true;
+var trace = require('../..')();
+trace.startAgent().private_().config_.enhancedDatabaseReporting = true;
 var assert = require('assert');
 var traceLabels = require('../../src/trace-labels.js');
 

--- a/test/hooks/test-trace-grpc.js
+++ b/test/hooks/test-trace-grpc.js
@@ -16,7 +16,8 @@
 'use strict';
 
 var common = require('./common.js');
-require('../..').private_().config_.enhancedDatabaseReporting = true;
+var agent = require('../..')();
+agent.startAgent().private_().config_.enhancedDatabaseReporting = true;
 var assert = require('assert');
 var traceLabels = require('../../src/trace-labels.js');
 

--- a/test/hooks/test-trace-grpc.js
+++ b/test/hooks/test-trace-grpc.js
@@ -16,9 +16,8 @@
 'use strict';
 
 var common = require('./common.js');
-require('../..')().startAgent({
-  enhancedDatabaseReporting: true
-});
+var trace = require('../..')();
+trace.startAgent().private_().config_.enhancedDatabaseReporting = true;
 var assert = require('assert');
 var traceLabels = require('../../src/trace-labels.js');
 

--- a/test/hooks/test-trace-grpc.js
+++ b/test/hooks/test-trace-grpc.js
@@ -15,11 +15,15 @@
  */
 'use strict';
 
-var common = require('./common.js');
 var agent = require('../..')().startAgent().private_();
 agent.config_.enhancedDatabaseReporting = true;
+
+var common = require('./common.js');
+common.init(agent);
+
 var assert = require('assert');
 var traceLabels = require('../../src/trace-labels.js');
+var findIndex = require('lodash.findindex');
 
 var versions = {
   grpc1: require('./fixtures/grpc1')
@@ -150,6 +154,56 @@ Object.keys(versions).forEach(function(version) {
         grpc.credentials.createInsecure());
   }
 
+  function callUnary(cb) {
+    client.testUnary({n: 42}, function(err, result) {
+      assert.ifError(err);
+      assert.strictEqual(result.n, 42);
+      cb();
+    });
+  }
+
+  function callClientStream(cb) {
+    var stream = client.testClientStream(function(err, result) {
+      assert.ifError(err);
+      assert.strictEqual(result.n, 45);
+      cb();
+    });
+    for (var i = 0; i < 10; ++i) {
+      stream.write({n: i});
+    }
+    stream.end();
+  }
+
+  function callServerStream(cb) {
+    var stream = client.testServerStream({n: 42});
+    var sum = 0;
+    stream.on('data', function(data) {
+      sum += data.n;
+    });
+    stream.on('status', function(status) {
+      assert.strictEqual(status.code, grpc.status.OK);
+      assert.strictEqual(sum, 45);
+      cb();
+    });
+  }
+
+  function callBidi(cb) {
+    var stream = client.testBidiStream();
+    var sum = 0;
+    stream.on('data', function(data) {
+      sum += data.n;
+    });
+    for (var i = 0; i < 10; ++i) {
+      stream.write({n: i});
+    }
+    stream.end();
+    stream.on('status', function(status) {
+      assert.strictEqual(status.code, grpc.status.OK);
+      assert.strictEqual(sum, 45);
+      cb();
+    });
+  }
+
   describe(version, function() {
     before(function() {
       var proto = grpc.load(protoFile).nodetest;
@@ -172,10 +226,8 @@ Object.keys(versions).forEach(function(version) {
 
     it('should accurately measure time for unary requests', function(done) {
       common.runInTransaction(agent, function(endTransaction) {
-        client.testUnary({n: 42}, function(err, result) {
+        callUnary(function() {
           endTransaction();
-          assert.ifError(err);
-          assert.strictEqual(result.n, 42);
           var assertTraceProperties = function(predicate) {
             var trace = common.getMatchingSpan(agent, predicate);
             assert(trace);
@@ -187,6 +239,7 @@ Object.keys(versions).forEach(function(version) {
           assertTraceProperties(grpcServerOuterPredicate);
           // Check that a child span was created in gRPC root span 
           assert(common.getMatchingSpan(agent, grpcServerInnerPredicate));
+          // var shouldTraceArgs = common.getShouldTraceArgs();
           done();
         });
       });
@@ -194,10 +247,8 @@ Object.keys(versions).forEach(function(version) {
 
     it('should accurately measure time for client streaming requests', function(done) {
       common.runInTransaction(agent, function(endTransaction) {
-        var stream = client.testClientStream(function(err, result) {
+        callClientStream(function() {
           endTransaction();
-          assert.ifError(err);
-          assert.strictEqual(result.n, 45);
           var assertTraceProperties = function(predicate) {
             var trace = common.getMatchingSpan(agent, predicate);
             assert(trace);
@@ -210,24 +261,13 @@ Object.keys(versions).forEach(function(version) {
           assert(common.getMatchingSpan(agent, grpcServerInnerPredicate));
           done();
         });
-        for (var i = 0; i < 10; ++i) {
-          stream.write({n: i});
-        }
-        stream.end();
       });
     });
 
     it('should accurately measure time for server streaming requests', function(done) {
       common.runInTransaction(agent, function(endTransaction) {
-        var stream = client.testServerStream({n: 42});
-        var sum = 0;
-        stream.on('data', function(data) {
-          sum += data.n;
-        });
-        stream.on('status', function(status) {
+        callServerStream(function() {
           endTransaction();
-          assert.strictEqual(status.code, grpc.status.OK);
-          assert.strictEqual(sum, 45);
           var assertTraceProperties = function(predicate) {
             var trace = common.getMatchingSpan(agent, predicate);
             assert(trace);
@@ -248,19 +288,8 @@ Object.keys(versions).forEach(function(version) {
 
     it('should accurately measure time for bidi streaming requests', function(done) {
       common.runInTransaction(agent, function(endTransaction) {
-        var stream = client.testBidiStream();
-        var sum = 0;
-        stream.on('data', function(data) {
-          sum += data.n;
-        });
-        for (var i = 0; i < 10; ++i) {
-          stream.write({n: i});
-        }
-        stream.end();
-        stream.on('status', function(status) {
+        callBidi(function() {
           endTransaction();
-          assert.strictEqual(status.code, grpc.status.OK);
-          assert.strictEqual(sum, 45);
           var assertTraceProperties = function(predicate) {
             var trace = common.getMatchingSpan(agent, predicate);
             assert(trace);
@@ -279,12 +308,41 @@ Object.keys(versions).forEach(function(version) {
     });
 
     it('should not break if no parent transaction', function(done) {
-      client.testUnary({n: 42}, function(err, result) {
-        assert.ifError(err);
-        assert.strictEqual(result.n, 42);
+      callUnary(function() {
         assert.strictEqual(common.getMatchingSpans(agent, grpcClientPredicate).length, 0);
         done();
       });
+    });
+
+    it('should respect the tracing policy', function(done) {
+      var next = function() {
+        var args = common.getShouldTraceArgs(agent);
+        assert.strictEqual(args.length, 4,
+          'expected one call for each of four gRPC method types but got ' +
+          args.length + ' instead');
+        for (var i = 0; i < args.length; i++) {
+          assert.strictEqual(args[i].length, 1);
+        }
+        var prefix = 'grpc:/nodetest.Tester/Test';
+        assert.notStrictEqual(findIndex(args, function(arg) {
+          return arg[0] === prefix + 'Unary';
+        }, -1));
+        assert.notStrictEqual(findIndex(args, function(arg) {
+          return arg[0] === prefix + 'ClientStream';
+        }, -1));
+        assert.notStrictEqual(findIndex(args, function(arg) {
+          return arg[0] === prefix + 'ServerStream';
+        }, -1));
+        assert.notStrictEqual(findIndex(args, function(arg) {
+          return arg[0] === prefix + 'BidiStream';
+        }, -1));
+        done();
+      };
+      next = callUnary.bind(null, next);
+      next = callClientStream.bind(null, next);
+      next = callServerStream.bind(null, next);
+      next = callBidi.bind(null, next);
+      next();
     });
 
     it('should not let root spans interfere with one another', function(done) {
@@ -319,44 +377,6 @@ Object.keys(versions).forEach(function(version) {
           });
         };
       };
-
-      // Define the gRPC calls.
-      function callUnary(cb) {
-        client.testUnary({n: 42}, function(err, result) {
-          assert.ifError(err);
-          cb();
-        });
-      }
-      function callClientStream(cb) {
-        var stream = client.testClientStream(function(err, result) {
-          assert.ifError(err);
-          cb();
-        });
-        for (var i = 0; i < 10; ++i) {
-          stream.write({n: i});
-        }
-        stream.end();
-      }
-      function callServerStream(cb) {
-        var stream = client.testServerStream({n: 42});
-        var sum = 0;
-        stream.on('data', function(data) {
-          sum += data.n;
-        });
-        stream.on('status', cb);
-      }
-      function callBidi(cb) {
-        var stream = client.testBidiStream();
-        var sum = 0;
-        stream.on('data', function(data) {
-          sum += data.n;
-        });
-        for (var i = 0; i < 10; ++i) {
-          stream.write({n: i});
-        }
-        stream.end();
-        stream.on('status', cb);
-      }
 
       // Call queueCallTogether with every possible pair of gRPC calls.
       var methods = [ callUnary, callClientStream, callServerStream, callBidi ];

--- a/test/hooks/test-trace-hapi.js
+++ b/test/hooks/test-trace-hapi.js
@@ -25,6 +25,7 @@ var semver = require('semver');
 
 var server;
 
+var agent = require('../..')().startAgent({ samplingRate: 0 }).private_();
 var versions = {
   hapi8: './fixtures/hapi8',
   hapi9: './fixtures/hapi9',
@@ -37,6 +38,7 @@ var versions = {
   hapi16: './fixtures/hapi16'
 };
 
+var count = 0;
 Object.keys(versions).forEach(function(version) {
   if (version.substring(4) > 10 && semver.satisfies(process.version, '<4')) {
     // v11 started using ES6 features (const)
@@ -44,8 +46,16 @@ Object.keys(versions).forEach(function(version) {
   }
   var hapi = require(versions[version]);
   describe(version, function() {
+    after(function() {
+      count++;
+
+      if (count === versions.length) {
+        agent.stop();
+      }
+    });
+
     afterEach(function(done) {
-      common.cleanTraces();
+      common.cleanTraces(agent);
       server.stop(done);
     });
 
@@ -62,7 +72,7 @@ Object.keys(versions).forEach(function(version) {
         }
       });
       server.start(function() {
-        common.doRequest('GET', done, hapiPredicate);
+        common.doRequest(agent, 'GET', done, hapiPredicate);
       });
     });
 
@@ -79,7 +89,7 @@ Object.keys(versions).forEach(function(version) {
         }
       });
       server.start(function() {
-        common.doRequest('POST', done, hapiPredicate);
+        common.doRequest(agent, 'POST', done, hapiPredicate);
       });
     });
 
@@ -99,7 +109,7 @@ Object.keys(versions).forEach(function(version) {
         handler: { custom: { val: common.serverRes } }
       });
       server.start(function() {
-        common.doRequest('GET', done, hapiPredicate);
+        common.doRequest(agent, 'GET', done, hapiPredicate);
       });
     });
 
@@ -128,7 +138,7 @@ Object.keys(versions).forEach(function(version) {
       }, function(err) {
         assert(!err);
         server.start(function() {
-          common.doRequest('GET', done, hapiPredicate);
+          common.doRequest(agent, 'GET', done, hapiPredicate);
         });
       });
     });
@@ -156,7 +166,7 @@ Object.keys(versions).forEach(function(version) {
       });
       server.start(function() {
         assert(afterSuccess);
-        common.doRequest('GET', done, hapiPredicate);
+        common.doRequest(agent, 'GET', done, hapiPredicate);
       });
     });
 
@@ -184,7 +194,7 @@ Object.keys(versions).forEach(function(version) {
           assert(extensionSuccess);
           done();
         };
-        common.doRequest('GET', cb, hapiPredicate);
+        common.doRequest(agent, 'GET', cb, hapiPredicate);
       });
     });
 
@@ -200,7 +210,7 @@ Object.keys(versions).forEach(function(version) {
       });
       server.start(function() {
         http.get({port: common.serverPort}, function(res) {
-          var labels = common.getMatchingSpan(hapiPredicate).labels;
+          var labels = common.getMatchingSpan(agent, hapiPredicate).labels;
           assert.equal(labels[traceLabels.HTTP_RESPONSE_CODE_LABEL_KEY], '200');
           assert.equal(labels[traceLabels.HTTP_METHOD_LABEL_KEY], 'GET');
           assert.equal(labels[traceLabels.HTTP_URL_LABEL_KEY], 'http://localhost:9042/');
@@ -222,7 +232,7 @@ Object.keys(versions).forEach(function(version) {
       });
       server.start(function() {
         http.get({port: common.serverPort}, function(res) {
-          var labels = common.getMatchingSpan(hapiPredicate).labels;
+          var labels = common.getMatchingSpan(agent, hapiPredicate).labels;
           var stackTrace = JSON.parse(labels[traceLabels.STACK_TRACE_DETAILS_KEY]);
           // Ensure that our middleware is on top of the stack
           assert.equal(stackTrace.stack_frame[0].method_name, 'middleware');
@@ -243,7 +253,7 @@ Object.keys(versions).forEach(function(version) {
       });
       server.start(function() {
         http.get({path: '/?a=b', port: common.serverPort}, function(res) {
-          var span = common.getMatchingSpan(hapiPredicate);
+          var span = common.getMatchingSpan(agent, hapiPredicate);
           assert.equal(span.name, '/');
           done();
         });

--- a/test/hooks/test-trace-mysql.js
+++ b/test/hooks/test-trace-mysql.js
@@ -17,18 +17,8 @@
 
 var common = require('./common.js');
 var traceLabels = require('../../src/trace-labels.js');
-require('../..')().startAgent({
-  enhancedDatabaseReporting: true
-});
 var assert = require('assert');
-var mysql = require('./fixtures/mysql2');
 
-var pool = mysql.createPool({
-  host     : 'localhost',
-  user     : 'root',
-  password : 'Password12!',
-  database : 'test'
-});
 var connection;
 
 var obj = {
@@ -37,6 +27,26 @@ var obj = {
 };
 
 describe('test-trace-mysql', function() {
+  var agent;
+  var mysql;
+  var pool;
+  before(function() {
+    agent = require('../..')().startAgent({
+      enhancedDatabaseReporting: true
+    }).private_();
+    mysql = require('./fixtures/mysql2');
+    pool = mysql.createPool({
+      host     : 'localhost',
+      user     : 'root',
+      password : 'Password12!',
+      database : 'test'
+    });
+  });
+
+  after(function() {
+    agent.stop();
+  });
+
   beforeEach(function(done) {
     pool.getConnection(function(err, conn) {
       assert(!err, 'Skipping: Failed to connect to mysql.');
@@ -46,7 +56,7 @@ describe('test-trace-mysql', function() {
           connection = conn;
           assert(!err);
           assert.equal(res.affectedRows, 1);
-          common.cleanTraces();
+          common.cleanTraces(agent);
           done();
         });
       });
@@ -57,20 +67,20 @@ describe('test-trace-mysql', function() {
     connection.query('DROP TABLE t', function(err) {
       assert(!err);
       connection.release();
-      common.cleanTraces();
+      common.cleanTraces(agent);
       done();
     });
   });
 
   it('should perform basic operations', function(done) {
-    common.runInTransaction(function(endRootSpan) {
+    common.runInTransaction(agent, function(endRootSpan) {
       connection.query('SELECT * FROM t', function(err, res) {
         endRootSpan();
         assert(!err);
         assert.equal(res.length, 1);
         assert.equal(res[0].k, 1);
         assert.equal(res[0].v, 'obj');
-        var spans = common.getMatchingSpans(function (span) {
+        var spans = common.getMatchingSpans(agent, function (span) {
           return span.name === 'mysql-query';
         });
         assert.equal(spans.length, 1);
@@ -81,11 +91,11 @@ describe('test-trace-mysql', function() {
   });
 
   it('should remove trace frames from stack', function(done) {
-    common.runInTransaction(function(endRootSpan) {
+    common.runInTransaction(agent, function(endRootSpan) {
       connection.query('SELECT * FROM t', function(err, res) {
         endRootSpan();
         assert(!err);
-        var spans = common.getMatchingSpans(function (span) {
+        var spans = common.getMatchingSpans(agent, function (span) {
           return span.name === 'mysql-query';
         });
         var labels = spans[0].labels;
@@ -99,7 +109,7 @@ describe('test-trace-mysql', function() {
   });
 
   it('should work with events', function(done) {
-    common.runInTransaction(function(endRootSpan) {
+    common.runInTransaction(agent, function(endRootSpan) {
       var query = connection.query('SELECT * FROM t');
       query.on('result', function(row) {
         assert.equal(row.k, 1);
@@ -107,7 +117,7 @@ describe('test-trace-mysql', function() {
       });
       query.on('end', function() {
         endRootSpan();
-        var spans = common.getMatchingSpans(function (span) {
+        var spans = common.getMatchingSpans(agent, function (span) {
           return span.name === 'mysql-query';
         });
         assert.equal(spans.length, 1);
@@ -118,11 +128,11 @@ describe('test-trace-mysql', function() {
   });
 
   it('should work without events or callback', function(done) {
-    common.runInTransaction(function(endRootSpan) {
+    common.runInTransaction(agent, function(endRootSpan) {
       connection.query('SELECT * FROM t');
       setTimeout(function() {
         endRootSpan();
-        var spans = common.getMatchingSpans(function (span) {
+        var spans = common.getMatchingSpans(agent, function (span) {
           return span.name === 'mysql-query';
         });
         assert.equal(spans.length, 1);
@@ -137,7 +147,7 @@ describe('test-trace-mysql', function() {
       k: 2,
       v: 'obj2'
     };
-    common.runInTransaction(function(endRootSpan) {
+    common.runInTransaction(agent, function(endRootSpan) {
       connection.beginTransaction(function(err) {
         assert(!err);
         connection.query('INSERT INTO t SET ?', obj2, function(err, res) {
@@ -159,7 +169,7 @@ describe('test-trace-mysql', function() {
                   assert.equal(res.length, 1);
                   assert.equal(res[0].k, 1);
                   assert.equal(res[0].v, 'obj');
-                  var spans = common.getMatchingSpans(function (span) {
+                  var spans = common.getMatchingSpans(agent, function (span) {
                     return span.name === 'mysql-query';
                   });
                   var expectedCmds = ['START TRANSACTION', 'INSERT INTO t SET ?',

--- a/test/hooks/test-trace-mysql.js
+++ b/test/hooks/test-trace-mysql.js
@@ -17,7 +17,8 @@
 
 var common = require('./common.js');
 var traceLabels = require('../../src/trace-labels.js');
-require('../..').private_().config_.enhancedDatabaseReporting = true;
+var agent = require('../..')().startAgent();
+agent.private_().config_.enhancedDatabaseReporting = true;
 var assert = require('assert');
 var mysql = require('./fixtures/mysql2');
 

--- a/test/hooks/test-trace-mysql.js
+++ b/test/hooks/test-trace-mysql.js
@@ -17,9 +17,8 @@
 
 var common = require('./common.js');
 var traceLabels = require('../../src/trace-labels.js');
-require('../..')().startAgent({
-  enhancedDatabaseReporting: true
-});
+var agent = require('../..')().startAgent();
+agent.private_().config_.enhancedDatabaseReporting = true;
 var assert = require('assert');
 var mysql = require('./fixtures/mysql2');
 

--- a/test/hooks/test-trace-mysql.js
+++ b/test/hooks/test-trace-mysql.js
@@ -17,8 +17,9 @@
 
 var common = require('./common.js');
 var traceLabels = require('../../src/trace-labels.js');
-var agent = require('../..')().startAgent();
-agent.private_().config_.enhancedDatabaseReporting = true;
+require('../..')().startAgent({
+  enhancedDatabaseReporting: true
+});
 var assert = require('assert');
 var mysql = require('./fixtures/mysql2');
 

--- a/test/hooks/test-trace-redis.js
+++ b/test/hooks/test-trace-redis.js
@@ -24,6 +24,7 @@ var common = require('./common.js');
 var traceLabels = require('../../src/trace-labels.js');
 
 var assert = require('assert');
+var agent = require('../..')().startAgent({ samplingRate: 0 }).private_();
 var versions = {
   redis0: require('./fixtures/redis0.12'),
   redis2dot3: require('./fixtures/redis2.3'),
@@ -32,34 +33,43 @@ var versions = {
   redisHiredis05: require('./fixtures/redis2.3-hiredis0.5')
 };
 
+var count = 0;
 var client;
 Object.keys(versions).forEach(function(version) {
   var redis = versions[version];
   describe(version, function() {
+    after(function() {
+      count++;
+
+      if (count === versions.length) {
+        agent.stop();
+      }
+    });
+
     beforeEach(function(done) {
       client = redis.createClient();
       client.on('error', function(err) {
         assert(false, 'redis error ' + err);
       });
       client.set('beforeEach', 42, function() {
-        common.cleanTraces();
+        common.cleanTraces(agent);
         done();
       });
     });
 
     afterEach(function(done) {
       client.quit(function() {
-        common.cleanTraces();
+        common.cleanTraces(agent);
         done();
       });
     });
 
     it('should accurately measure get time', function(done) {
-      common.runInTransaction(function(endTransaction) {
+      common.runInTransaction(agent, function(endTransaction) {
         client.get('beforeEach', function(err, n) {
           endTransaction();
           assert.equal(n, 42);
-          var trace = common.getMatchingSpan(redisPredicate.bind(null, 'redis-get'));
+          var trace = common.getMatchingSpan(agent, redisPredicate.bind(null, 'redis-get'));
           assert(trace);
           done();
         });
@@ -67,10 +77,10 @@ Object.keys(versions).forEach(function(version) {
     });
 
     it('should accurately measure set time', function(done) {
-      common.runInTransaction(function(endTransaction) {
+      common.runInTransaction(agent, function(endTransaction) {
         client.set('key', 'val', function(err) {
           endTransaction();
-          var trace = common.getMatchingSpan(redisPredicate.bind(null, 'redis-set'));
+          var trace = common.getMatchingSpan(agent, redisPredicate.bind(null, 'redis-set'));
           assert(trace);
           done();
         });
@@ -78,11 +88,11 @@ Object.keys(versions).forEach(function(version) {
     });
 
     it('should accurately measure hset time', function(done) {
-      common.runInTransaction(function(endTransaction) {
+      common.runInTransaction(agent, function(endTransaction) {
         // Test error case as hset requires 3 parameters
         client.hset('key', 'val', function(err) {
           endTransaction();
-          var trace = common.getMatchingSpan(redisPredicate.bind(null, 'redis-hset'));
+          var trace = common.getMatchingSpan(agent, redisPredicate.bind(null, 'redis-hset'));
           assert(trace);
           done();
         });
@@ -90,11 +100,11 @@ Object.keys(versions).forEach(function(version) {
     });
 
     it('should remove trace frames from stack', function(done) {
-      common.runInTransaction(function(endTransaction) {
+      common.runInTransaction(agent, function(endTransaction) {
         // Test error case as hset requires 3 parameters
         client.hset('key', 'val', function(err) {
           endTransaction();
-          var trace = common.getMatchingSpan(redisPredicate.bind(null, 'redis-hset'));
+          var trace = common.getMatchingSpan(agent, redisPredicate.bind(null, 'redis-hset'));
           var labels = trace.labels;
           var stackTrace = JSON.parse(labels[traceLabels.STACK_TRACE_DETAILS_KEY]);
           // Ensure that our patch is on top of the stack

--- a/test/non-interference/express-e2e.js
+++ b/test/non-interference/express-e2e.js
@@ -48,7 +48,7 @@ process.chdir(express_dir);
 
 // Remove name to allow for cyclic dependency
 console.log('Updating express metadata');
-cp.execFileSync('sed', ['-i', 's/"express"/"e"/', 'package.json']);
+cp.execFileSync('sed', ['-i.bak', 's/"express"/"e"/', 'package.json']);
 
 // Install express as it's own dependency
 console.log('Installing express dependencies');
@@ -62,14 +62,14 @@ var gcloud_require = 'require(\'' + path.join(__dirname, '..', '..') +
 glob(test_glob, function(err, files) {
   error = error || err;
   for (var i = 0; i < files.length; i++) {
-    cp.execFileSync('sed', ['-i', 's#\'use strict\';#' +
+    cp.execFileSync('sed', ['-i.bak', 's#\'use strict\';#' +
         '\'use strict\';' + gcloud_require + '#g', files[i]]);
     if (cp.spawnSync('grep', ['-q', gcloud_require, files[i]]).status) {
       cp.execSync('echo "' + gcloud_require + '" | cat - ' + files[i] +
           ' >' +  files[i] + '.instru.js' + '&& mv ' + files[i] +
           '.instru.js' + ' ' + files[i]);
     }
-    cp.execFileSync('sed', ['-i', 's#require(\'\\.\\./\\?\')#require(\'express\')#',
+    cp.execFileSync('sed', ['-i.bak', 's#require(\'\\.\\./\\?\')#require(\'express\')#',
         files[i]]);
   }
   // Run tests

--- a/test/non-interference/express-e2e.js
+++ b/test/non-interference/express-e2e.js
@@ -58,7 +58,7 @@ cp.execFileSync('npm', ['install']);
 // Reformat tests to use newly installed express
 console.log('Reformating tests');
 var gcloud_require = 'require(\'' + path.join(__dirname, '..', '..') +
-    '\').start();';
+    '\')().startAgent();';
 glob(test_glob, function(err, files) {
   error = error || err;
   for (var i = 0; i < files.length; i++) {

--- a/test/non-interference/express-e2e.js
+++ b/test/non-interference/express-e2e.js
@@ -58,7 +58,7 @@ cp.execFileSync('npm', ['install']);
 // Reformat tests to use newly installed express
 console.log('Reformating tests');
 var gcloud_require = 'require(\'' + path.join(__dirname, '..', '..') +
-    '\')().startAgent();';
+    '\')().startAgent()._disableStartCheck();';
 glob(test_glob, function(err, files) {
   error = error || err;
   for (var i = 0; i < files.length; i++) {

--- a/test/non-interference/http-e2e.js
+++ b/test/non-interference/http-e2e.js
@@ -39,7 +39,9 @@ cp.execFileSync('git', ['clone', '--branch', process.version,
     'https://github.com/nodejs/node.git', '--depth', '1', node_dir]);
 fs.mkdirSync(path.join(node_dir, 'test', 'tmp'));
 console.log('Turning off global checks');
-cp.execFileSync('sed', ['-i', 's/exports.globalCheck = true/' +
+// The use of the -i flag as '-i.bak' to specify a backup extension of '.bak'
+// is needed to ensure that the command works on both Linux and OS X
+cp.execFileSync('sed', ['-i.bak', 's/exports.globalCheck = true/' +
     'exports.globalCheck = false/g', path.join(node_dir, 'test', 'common.js')]);
 var test_glob = semver.satisfies(process.version, '0.12.x') ?
     path.join(node_dir, 'test', 'simple', 'test-http*.js') :
@@ -66,7 +68,9 @@ glob(test_glob, function(err, files) {
       console.log('Skipped: ' + files[testCount]);
       continue;
     }
-    cp.execFileSync('sed', ['-i', 's#\'use strict\';#' +
+    // The use of the -i flag as '-i.bak' to specify a backup extension of 
+    // '.bak' is needed to ensure that the command works on both Linux and OS X
+    cp.execFileSync('sed', ['-i.bak', 's#\'use strict\';#' +
         '\'use strict\';' + gcloud_require + '#g', files[testCount]]);
     if (cp.spawnSync('grep', ['-q', gcloud_require, files[testCount]]).status) {
       cp.execSync('echo "' + gcloud_require + '" | cat - ' + files[testCount] +

--- a/test/non-interference/http-e2e.js
+++ b/test/non-interference/http-e2e.js
@@ -48,7 +48,7 @@ var test_glob = semver.satisfies(process.version, '0.12.x') ?
 // Run tests
 console.log('Running tests');
 var gcloud_require = 'require(\'' + path.join(__dirname, '..', '..') +
-    '\').start();';
+    '\')().startAgent();';
 glob(test_glob, function(err, files) {
   var errors = 0;
   var testCount;

--- a/test/non-interference/restify-e2e.js
+++ b/test/non-interference/restify-e2e.js
@@ -47,7 +47,7 @@ process.chdir(restify_dir);
 
 // Remove name to allow for cyclic dependency
 console.log('Updating restify metadata');
-cp.execFileSync('sed', ['-i', 's/"restify"/"r"/', 'package.json']);
+cp.execFileSync('sed', ['-i.bak', 's/"restify"/"r"/', 'package.json']);
 
 // Install restify as it's own dependency
 console.log('Installing restify dependencies');
@@ -60,14 +60,14 @@ var gcloud_require = 'require(\'' + path.join(__dirname, '..', '..') +
     '\')().startAgent();';
 glob(test_glob, function(err, files) {
   for (var i = 0; i < files.length; i++) {
-    cp.execFileSync('sed', ['-i', 's#\'use strict\';#' +
+    cp.execFileSync('sed', ['-i.bak', 's#\'use strict\';#' +
         '\'use strict\'; ' + gcloud_require + '#g', files[i]]);
     if (cp.spawnSync('grep', ['-q', gcloud_require, files[i]]).status) {
       cp.execSync('echo "' + gcloud_require + '" | cat - ' + files[i] +
           ' >' +  files[i] + '.instru.js' + '&& mv ' + files[i] +
           '.instru.js' + ' ' + files[i]);
     }
-    cp.execFileSync('sed', ['-i', 's#require(\'\\.\\./lib\')#require(\'restify\')#',
+    cp.execFileSync('sed', ['-i.bak', 's#require(\'\\.\\./lib\')#require(\'restify\')#',
         files[i]]);
   }
   // Run tests

--- a/test/non-interference/restify-e2e.js
+++ b/test/non-interference/restify-e2e.js
@@ -57,7 +57,7 @@ cp.execFileSync('npm', ['install']);
 // Reformat tests to use newly installed restify
 console.log('Reformating tests');
 var gcloud_require = 'require(\'' + path.join(__dirname, '..', '..') +
-    '\').start();';
+    '\')().startAgent();';
 glob(test_glob, function(err, files) {
   for (var i = 0; i < files.length; i++) {
     cp.execFileSync('sed', ['-i', 's#\'use strict\';#' +

--- a/test/non-interference/restify-e2e.js
+++ b/test/non-interference/restify-e2e.js
@@ -57,7 +57,7 @@ cp.execFileSync('npm', ['install']);
 // Reformat tests to use newly installed restify
 console.log('Reformating tests');
 var gcloud_require = 'require(\'' + path.join(__dirname, '..', '..') +
-    '\')().startAgent();';
+    '\')().startAgent()._disableStartCheck();';
 glob(test_glob, function(err, files) {
   for (var i = 0; i < files.length; i++) {
     cp.execFileSync('sed', ['-i.bak', 's#\'use strict\';#' +

--- a/test/performance/express/express-performance-runner.js
+++ b/test/performance/express/express-performance-runner.js
@@ -19,7 +19,7 @@
 if (process.argv[2] === '-i') {
   process.env.GCLOUD_TRACE_ENABLED = true;
   process.env.GCLOUD_TRACE_EXCLUDE_HTTP = true;
-  var traceAgent = require('../../..').start().private_();
+  var traceAgent = require('../../..')().startAgent().private_();
   // We want to drop all spans and avoid network ops
   traceAgent.traceWriter.writeSpan = function() {};
 }

--- a/test/performance/http/http-performance-runner.js
+++ b/test/performance/http/http-performance-runner.js
@@ -19,7 +19,7 @@
 var traceAgent;
 if (process.argv[2] === '-i') {
   process.env.GCLOUD_TRACE_ENABLED = true;
-  traceAgent = require('../../..').start().private_();
+  traceAgent = require('../../..')().startAgent().private_();
   // We want to drop all spans and avoid network ops
   traceAgent.traceWriter.writeSpan = function() {};
 }

--- a/test/performance/mongo/mongo-performance-runner.js
+++ b/test/performance/mongo/mongo-performance-runner.js
@@ -25,7 +25,7 @@
 var traceAgent;
 if (process.argv[2] === '-i') {
   process.env.GCLOUD_TRACE_ENABLED = true;
-  traceAgent = require('../../..').start().private_();
+  traceAgent = require('../../..')().startAgent().private_();
   // We want to drop all spans and avoid network ops
   traceAgent.traceWriter.writeSpan = function() {};
 }

--- a/test/performance/restify/restify-performance-runner.js
+++ b/test/performance/restify/restify-performance-runner.js
@@ -19,7 +19,7 @@
 if (process.argv[2] === '-i') {
   process.env.GCLOUD_TRACE_ENABLED = true;
   process.env.GCLOUD_TRACE_EXCLUDE_HTTP = true;
-  var traceAgent = require('../../..').start().private_();
+  var traceAgent = require('../../..')().startAgent().private_();
   // We want to drop all spans and avoid network ops
   traceAgent.traceWriter.writeSpan = function() {};
 }

--- a/test/standalone/test-agent-metadata.js
+++ b/test/standalone/test-agent-metadata.js
@@ -18,7 +18,7 @@
 
 var assert = require('assert');
 var nock = require('nock');
-var agent = require('../..')();
+var agent = require('../..')().startAgent();
 var traceLabels = require('../../src/trace-labels.js');
 
 nock.disableNetConnect();

--- a/test/standalone/test-agent-metadata.js
+++ b/test/standalone/test-agent-metadata.js
@@ -18,7 +18,7 @@
 
 var assert = require('assert');
 var nock = require('nock');
-var agent = require('../..')().startAgent();
+var agent = require('../..')();
 var traceLabels = require('../../src/trace-labels.js');
 
 nock.disableNetConnect();
@@ -38,7 +38,7 @@ describe('agent interaction with metadata service', function() {
                 .times(2)
                 .reply(404, 'foo');
 
-    agent.start({logLevel: 0});
+    agent.startAgent({logLevel: 0});
     setTimeout(function() {
       assert.ok(!agent.isActive());
       scope.done();
@@ -52,7 +52,7 @@ describe('agent interaction with metadata service', function() {
                 .get('/computeMetadata/v1/project/numeric-project-id')
                 .times(2)
                 .reply(200, '1234');
-    agent.start({logLevel: 0});
+    agent.startAgent({logLevel: 0});
     setTimeout(function() {
       assert.ok(agent.isActive());
       assert.equal(agent.private_().config().projectId, '1234');
@@ -64,13 +64,13 @@ describe('agent interaction with metadata service', function() {
   it('should not query metadata service when config.projectId is set',
     function() {
       nock.disableNetConnect();
-      agent.start({projectId: 0, logLevel: 0});
+      agent.startAgent({projectId: 0, logLevel: 0});
     });
 
   it('should not query metadata service when env. var. is set', function() {
     nock.disableNetConnect();
     process.env.GCLOUD_PROJECT=0;
-    agent.start({logLevel: 0});
+    agent.startAgent({logLevel: 0});
     delete process.env.GCLOUD_PROJECT;
   });
 
@@ -81,7 +81,7 @@ describe('agent interaction with metadata service', function() {
                 .times(1)
                 .reply(200, 'host');
 
-    agent.start({projectId: 0, logLevel: 0});
+    agent.startAgent({projectId: 0, logLevel: 0});
     setTimeout(function() {
       agent.private_().namespace.run(function() {
         var spanData = agent.private_().createRootSpanData('name', 5, 0);
@@ -100,7 +100,7 @@ describe('agent interaction with metadata service', function() {
                 .times(1)
                 .reply(200, '1729');
 
-    agent.start({projectId: 0, logLevel: 0});
+    agent.startAgent({projectId: 0, logLevel: 0});
     setTimeout(function() {
       agent.private_().namespace.run(function() {
         var spanData = agent.private_().createRootSpanData('name', 5, 0);
@@ -114,7 +114,7 @@ describe('agent interaction with metadata service', function() {
 
   it('shouldn\'t add id or hostname labels if not present', function(done) {
     nock.disableNetConnect();
-    agent.start({projectId: 0, logLevel: 0});
+    agent.startAgent({projectId: 0, logLevel: 0});
     setTimeout(function() {
       agent.private_().namespace.run(function() {
         var spanData = agent.private_().createRootSpanData('name', 5, 0);
@@ -131,7 +131,7 @@ describe('agent interaction with metadata service', function() {
     process.env.GAE_MODULE_NAME = 'foo';
     process.env.GAE_MODULE_VERSION = '20151119t120000';
     process.env.GAE_MINOR_VERSION = '91992';
-    agent.start({projectId: 0, logLevel: 0});
+    agent.startAgent({projectId: 0, logLevel: 0});
     setTimeout(function() {
       agent.private_().namespace.run(function() {
         var spanData = agent.private_().createRootSpanData('name', 5, 0);
@@ -150,7 +150,7 @@ describe('agent interaction with metadata service', function() {
     process.env.GAE_MODULE_NAME = 'default';
     process.env.GAE_MODULE_VERSION = '20151119t130000';
     process.env.GAE_MINOR_VERSION = '81818';
-    agent.start({projectId: 0, logLevel: 0});
+    agent.startAgent({projectId: 0, logLevel: 0});
     setTimeout(function() {
       agent.private_().namespace.run(function() {
         var spanData = agent.private_().createRootSpanData('name', 5, 0);
@@ -176,7 +176,7 @@ describe('agent interaction with metadata service', function() {
                   .reply(200, 'host');
 
       delete process.env.GAE_MODULE_NAME;
-      agent.start({projectId: 0, logLevel: 0});
+      agent.startAgent({projectId: 0, logLevel: 0});
       setTimeout(function() {
         agent.private_().namespace.run(function() {
           var spanData = agent.private_().createRootSpanData('name', 5, 0);
@@ -198,7 +198,7 @@ describe('agent interaction with metadata service', function() {
                   .reply(404);
 
       delete process.env.GAE_MODULE_NAME;
-      agent.start({projectId: 0, logLevel: 0});
+      agent.startAgent({projectId: 0, logLevel: 0});
       setTimeout(function() {
         agent.private_().namespace.run(function() {
           var spanData = agent.private_().createRootSpanData('name', 5, 0);

--- a/test/standalone/test-agent-metadata.js
+++ b/test/standalone/test-agent-metadata.js
@@ -18,7 +18,7 @@
 
 var assert = require('assert');
 var nock = require('nock');
-var agent = require('../..');
+var agent = require('../..')();
 var traceLabels = require('../../src/trace-labels.js');
 
 nock.disableNetConnect();

--- a/test/standalone/test-agent-metadata.js
+++ b/test/standalone/test-agent-metadata.js
@@ -18,7 +18,7 @@
 
 var assert = require('assert');
 var nock = require('nock');
-var agent = require('../..')();
+var trace = require('../..')();
 var traceLabels = require('../../src/trace-labels.js');
 
 nock.disableNetConnect();
@@ -27,6 +27,7 @@ delete process.env.GCLOUD_PROJECT;
 
 describe('agent interaction with metadata service', function() {
 
+  var agent;
   afterEach(function() {
     agent.stop();
   });
@@ -38,7 +39,7 @@ describe('agent interaction with metadata service', function() {
                 .times(2)
                 .reply(404, 'foo');
 
-    agent.startAgent({logLevel: 0});
+    agent = trace.startAgent({logLevel: 0});
     setTimeout(function() {
       assert.ok(!agent.isActive());
       scope.done();
@@ -52,7 +53,7 @@ describe('agent interaction with metadata service', function() {
                 .get('/computeMetadata/v1/project/numeric-project-id')
                 .times(2)
                 .reply(200, '1234');
-    agent.startAgent({logLevel: 0});
+    agent = trace.startAgent({logLevel: 0});
     setTimeout(function() {
       assert.ok(agent.isActive());
       assert.equal(agent.private_().config().projectId, '1234');
@@ -64,13 +65,13 @@ describe('agent interaction with metadata service', function() {
   it('should not query metadata service when config.projectId is set',
     function() {
       nock.disableNetConnect();
-      agent.startAgent({projectId: 0, logLevel: 0});
+      agent = trace.startAgent({projectId: 0, logLevel: 0});
     });
 
   it('should not query metadata service when env. var. is set', function() {
     nock.disableNetConnect();
     process.env.GCLOUD_PROJECT=0;
-    agent.startAgent({logLevel: 0});
+    agent = trace.startAgent({logLevel: 0});
     delete process.env.GCLOUD_PROJECT;
   });
 
@@ -81,7 +82,7 @@ describe('agent interaction with metadata service', function() {
                 .times(1)
                 .reply(200, 'host');
 
-    agent.startAgent({projectId: 0, logLevel: 0});
+    agent = trace.startAgent({projectId: 0, logLevel: 0});
     setTimeout(function() {
       agent.private_().namespace.run(function() {
         var spanData = agent.private_().createRootSpanData('name', 5, 0);
@@ -100,7 +101,7 @@ describe('agent interaction with metadata service', function() {
                 .times(1)
                 .reply(200, '1729');
 
-    agent.startAgent({projectId: 0, logLevel: 0});
+    agent = trace.startAgent({projectId: 0, logLevel: 0});
     setTimeout(function() {
       agent.private_().namespace.run(function() {
         var spanData = agent.private_().createRootSpanData('name', 5, 0);
@@ -114,7 +115,7 @@ describe('agent interaction with metadata service', function() {
 
   it('shouldn\'t add id or hostname labels if not present', function(done) {
     nock.disableNetConnect();
-    agent.startAgent({projectId: 0, logLevel: 0});
+    agent = trace.startAgent({projectId: 0, logLevel: 0});
     setTimeout(function() {
       agent.private_().namespace.run(function() {
         var spanData = agent.private_().createRootSpanData('name', 5, 0);
@@ -131,7 +132,7 @@ describe('agent interaction with metadata service', function() {
     process.env.GAE_MODULE_NAME = 'foo';
     process.env.GAE_MODULE_VERSION = '20151119t120000';
     process.env.GAE_MINOR_VERSION = '91992';
-    agent.startAgent({projectId: 0, logLevel: 0});
+    agent = trace.startAgent({projectId: 0, logLevel: 0});
     setTimeout(function() {
       agent.private_().namespace.run(function() {
         var spanData = agent.private_().createRootSpanData('name', 5, 0);
@@ -150,7 +151,7 @@ describe('agent interaction with metadata service', function() {
     process.env.GAE_MODULE_NAME = 'default';
     process.env.GAE_MODULE_VERSION = '20151119t130000';
     process.env.GAE_MINOR_VERSION = '81818';
-    agent.startAgent({projectId: 0, logLevel: 0});
+    agent = trace.startAgent({projectId: 0, logLevel: 0});
     setTimeout(function() {
       agent.private_().namespace.run(function() {
         var spanData = agent.private_().createRootSpanData('name', 5, 0);
@@ -176,7 +177,7 @@ describe('agent interaction with metadata service', function() {
                   .reply(200, 'host');
 
       delete process.env.GAE_MODULE_NAME;
-      agent.startAgent({projectId: 0, logLevel: 0});
+      agent = trace.startAgent({projectId: 0, logLevel: 0});
       setTimeout(function() {
         agent.private_().namespace.run(function() {
           var spanData = agent.private_().createRootSpanData('name', 5, 0);
@@ -198,7 +199,7 @@ describe('agent interaction with metadata service', function() {
                   .reply(404);
 
       delete process.env.GAE_MODULE_NAME;
-      agent.startAgent({projectId: 0, logLevel: 0});
+      agent = trace.startAgent({projectId: 0, logLevel: 0});
       setTimeout(function() {
         agent.private_().namespace.run(function() {
           var spanData = agent.private_().createRootSpanData('name', 5, 0);

--- a/test/standalone/test-agent-metadata.js
+++ b/test/standalone/test-agent-metadata.js
@@ -19,7 +19,6 @@
 var proxyquire  = require('proxyquire');
 var assert = require('assert');
 var nock = require('nock');
-var trace = require('../..')();
 var traceLabels = require('../../src/trace-labels.js');
 
 nock.disableNetConnect();
@@ -28,6 +27,7 @@ delete process.env.GCLOUD_PROJECT;
 
 describe('agent interaction with metadata service', function() {
   var agent;
+  var trace;
 
   before(function() {
     // Setup: Monkeypatch gcp-metadata to not ask for retries at all.
@@ -39,6 +39,7 @@ describe('agent interaction with metadata service', function() {
         }, callback);
       }
     });
+    trace = require('../..')();
   });
 
   afterEach(function() {

--- a/test/standalone/test-agent-stopped.js
+++ b/test/standalone/test-agent-stopped.js
@@ -23,7 +23,7 @@ process.env.GCLOUD_PROJECT = 0;
 
 describe('express', function() {
   it('should not break if no project number is found', function(done) {
-    var agent = require('../..')();
+    var agent = require('../..')().startAgent();
     agent.startAgent();
     var app = require('../hooks/fixtures/express4')();
     agent.stop();
@@ -46,7 +46,7 @@ describe('express', function() {
 
 describe('hapi', function() {
   it('should not break if no project number is found', function(done) {
-    var agent = require('../..')();
+    var agent = require('../..')().startAgent();
     agent.startAgent();
     var hapi = require('../hooks/fixtures/hapi8');
     var server = new hapi.Server();
@@ -75,7 +75,7 @@ describe('hapi', function() {
 
 describe('restify', function() {
   it('should not break if no project number is found', function(done) {
-    var agent = require('../..')();
+    var agent = require('../..')().startAgent();
     agent.startAgent();
     var restify = require('../hooks/fixtures/restify4');
     var server = restify.createServer();

--- a/test/standalone/test-agent-stopped.js
+++ b/test/standalone/test-agent-stopped.js
@@ -23,8 +23,8 @@ process.env.GCLOUD_PROJECT = 0;
 
 describe('express', function() {
   it('should not break if no project number is found', function(done) {
-    var agent = require('../..');
-    agent.start();
+    var agent = require('../..')();
+    agent.startAgent();
     var app = require('../hooks/fixtures/express4')();
     agent.stop();
     app.get('/', function (req, res) {
@@ -46,8 +46,8 @@ describe('express', function() {
 
 describe('hapi', function() {
   it('should not break if no project number is found', function(done) {
-    var agent = require('../..');
-    agent.start();
+    var agent = require('../..')();
+    agent.startAgent();
     var hapi = require('../hooks/fixtures/hapi8');
     var server = new hapi.Server();
     server.connection({ port: 8081 });
@@ -75,8 +75,8 @@ describe('hapi', function() {
 
 describe('restify', function() {
   it('should not break if no project number is found', function(done) {
-    var agent = require('../..');
-    agent.start();
+    var agent = require('../..')();
+    agent.startAgent();
     var restify = require('../hooks/fixtures/restify4');
     var server = restify.createServer();
     agent.stop();

--- a/test/standalone/test-agent-stopped.js
+++ b/test/standalone/test-agent-stopped.js
@@ -23,7 +23,7 @@ process.env.GCLOUD_PROJECT = 0;
 
 describe('express', function() {
   it('should not break if no project number is found', function(done) {
-    var agent = require('../..')().startAgent();
+    var agent = require('../..')();
     agent.startAgent();
     var app = require('../hooks/fixtures/express4')();
     agent.stop();
@@ -46,7 +46,7 @@ describe('express', function() {
 
 describe('hapi', function() {
   it('should not break if no project number is found', function(done) {
-    var agent = require('../..')().startAgent();
+    var agent = require('../..')();
     agent.startAgent();
     var hapi = require('../hooks/fixtures/hapi8');
     var server = new hapi.Server();
@@ -75,7 +75,7 @@ describe('hapi', function() {
 
 describe('restify', function() {
   it('should not break if no project number is found', function(done) {
-    var agent = require('../..')().startAgent();
+    var agent = require('../..')();
     agent.startAgent();
     var restify = require('../hooks/fixtures/restify4');
     var server = restify.createServer();

--- a/test/standalone/test-agent-stopped.js
+++ b/test/standalone/test-agent-stopped.js
@@ -23,8 +23,7 @@ process.env.GCLOUD_PROJECT = 0;
 
 describe('express', function() {
   it('should not break if no project number is found', function(done) {
-    var agent = require('../..')();
-    agent.startAgent();
+    var agent = require('../..')().startAgent();
     var app = require('../hooks/fixtures/express4')();
     agent.stop();
     app.get('/', function (req, res) {
@@ -46,8 +45,7 @@ describe('express', function() {
 
 describe('hapi', function() {
   it('should not break if no project number is found', function(done) {
-    var agent = require('../..')();
-    agent.startAgent();
+    var agent = require('../..')().startAgent();
     var hapi = require('../hooks/fixtures/hapi8');
     var server = new hapi.Server();
     server.connection({ port: 8081 });
@@ -75,8 +73,7 @@ describe('hapi', function() {
 
 describe('restify', function() {
   it('should not break if no project number is found', function(done) {
-    var agent = require('../..')();
-    agent.startAgent();
+    var agent = require('../..')().startAgent();
     var restify = require('../hooks/fixtures/restify4');
     var server = restify.createServer();
     agent.stop();

--- a/test/standalone/test-config-credentials.js
+++ b/test/standalone/test-config-credentials.js
@@ -36,7 +36,7 @@ describe('test-config-credentials', function() {
       samplingRate: 0,
       keyFilename: path.join('test', 'fixtures', 'gcloud-credentials.json')
     };
-    var agent = require('../..').start(config);
+    var agent = require('../..')().startAgent(config);
     nock.disableNetConnect();
     var scope = nock('https://accounts.google.com')
       .intercept('/o/oauth2/token', 'POST', function(body) {
@@ -68,7 +68,7 @@ describe('test-config-credentials', function() {
       samplingRate: 0,
       credentials: require('../fixtures/gcloud-credentials.json')
     };
-    var agent = require('../..').start(config);
+    var agent = require('../..')().startAgent(config);
     nock.disableNetConnect();
     var scope = nock('https://accounts.google.com')
       .intercept('/o/oauth2/token', 'POST', function(body) {
@@ -113,7 +113,7 @@ describe('test-config-credentials', function() {
       assert.notEqual(config.credentials[field],
         correctCredentials[field]);
     });
-    var agent = require('../..').start(config);
+    var agent = require('../..')().startAgent(config);
     nock.disableNetConnect();
     var scope = nock('https://accounts.google.com')
       .intercept('/o/oauth2/token', 'POST', function(body) {

--- a/test/standalone/test-default-ignore-ah-health.js
+++ b/test/standalone/test-default-ignore-ah-health.js
@@ -15,7 +15,7 @@
  */
 'use strict';
 
-var agent = require('../..').start({samplingRate: 0});
+var agent = require('../..')().startAgent({samplingRate: 0});
 
 var assert = require('assert');
 var http = require('http');

--- a/test/standalone/test-env-log-level.js
+++ b/test/standalone/test-env-log-level.js
@@ -19,7 +19,7 @@
 process.env.GCLOUD_TRACE_LOGLEVEL = 4;
 
 var assert = require('assert');
-var agent = require('../..')();
+var agent = require('../..')().startAgent();
 
 describe('should respect environment variables', function() {
   it('should respect GCLOUD_TRACE_LOGLEVEL', function() {

--- a/test/standalone/test-env-log-level.js
+++ b/test/standalone/test-env-log-level.js
@@ -19,17 +19,17 @@
 process.env.GCLOUD_TRACE_LOGLEVEL = 4;
 
 var assert = require('assert');
-var agent = require('../..')();
+var trace = require('../..')();
 
 describe('should respect environment variables', function() {
   it('should respect GCLOUD_TRACE_LOGLEVEL', function() {
-    agent.startAgent();
+    var agent = trace.startAgent();
     assert.equal(agent.private_().config_.logLevel, 4);
     agent.stop();
   });
 
   it('should prefer env to config', function() {
-    agent.startAgent({logLevel: 2});
+    var agent = trace.startAgent({logLevel: 2});
     assert.equal(agent.private_().config_.logLevel, 4);
     agent.stop();
   });

--- a/test/standalone/test-env-log-level.js
+++ b/test/standalone/test-env-log-level.js
@@ -19,7 +19,7 @@
 process.env.GCLOUD_TRACE_LOGLEVEL = 4;
 
 var assert = require('assert');
-var agent = require('../..')().startAgent();
+var agent = require('../..')();
 
 describe('should respect environment variables', function() {
   it('should respect GCLOUD_TRACE_LOGLEVEL', function() {

--- a/test/standalone/test-env-log-level.js
+++ b/test/standalone/test-env-log-level.js
@@ -19,17 +19,17 @@
 process.env.GCLOUD_TRACE_LOGLEVEL = 4;
 
 var assert = require('assert');
-var agent = require('../..');
+var agent = require('../..')();
 
 describe('should respect environment variables', function() {
   it('should respect GCLOUD_TRACE_LOGLEVEL', function() {
-    agent.start();
+    agent.startAgent();
     assert.equal(agent.private_().config_.logLevel, 4);
     agent.stop();
   });
 
   it('should prefer env to config', function() {
-    agent.start({logLevel: 2});
+    agent.startAgent({logLevel: 2});
     assert.equal(agent.private_().config_.logLevel, 4);
     agent.stop();
   });

--- a/test/standalone/test-env-project-id.js
+++ b/test/standalone/test-env-project-id.js
@@ -19,17 +19,17 @@
 process.env.GCLOUD_PROJECT = 1729;
 
 var assert = require('assert');
-var agent = require('../..')();
+var trace = require('../..')();
 
 describe('should respect environment variables', function() {
   it('should respect GCLOUD_PROJECT', function() {
-    agent.startAgent();
+    var agent = trace.startAgent();
     assert.equal(agent.private_().config_.projectId, 1729);
     agent.stop();
   });
 
   it('should prefer env to config', function() {
-    agent.startAgent({projectId: 1927});
+    var agent = trace.startAgent({projectId: 1927});
     assert.equal(agent.private_().config_.projectId, 1729);
     agent.stop();
   });

--- a/test/standalone/test-env-project-id.js
+++ b/test/standalone/test-env-project-id.js
@@ -19,7 +19,7 @@
 process.env.GCLOUD_PROJECT = 1729;
 
 var assert = require('assert');
-var agent = require('../..')().startAgent();
+var agent = require('../..')();
 
 describe('should respect environment variables', function() {
   it('should respect GCLOUD_PROJECT', function() {

--- a/test/standalone/test-env-project-id.js
+++ b/test/standalone/test-env-project-id.js
@@ -19,7 +19,7 @@
 process.env.GCLOUD_PROJECT = 1729;
 
 var assert = require('assert');
-var agent = require('../..')();
+var agent = require('../..')().startAgent();
 
 describe('should respect environment variables', function() {
   it('should respect GCLOUD_PROJECT', function() {

--- a/test/standalone/test-env-project-id.js
+++ b/test/standalone/test-env-project-id.js
@@ -19,17 +19,17 @@
 process.env.GCLOUD_PROJECT = 1729;
 
 var assert = require('assert');
-var agent = require('../..');
+var agent = require('../..')();
 
 describe('should respect environment variables', function() {
   it('should respect GCLOUD_PROJECT', function() {
-    agent.start();
+    agent.startAgent();
     assert.equal(agent.private_().config_.projectId, 1729);
     agent.stop();
   });
 
   it('should prefer env to config', function() {
-    agent.start({projectId: 1927});
+    agent.startAgent({projectId: 1927});
     assert.equal(agent.private_().config_.projectId, 1729);
     agent.stop();
   });

--- a/test/standalone/test-grpc-context.js
+++ b/test/standalone/test-grpc-context.js
@@ -15,7 +15,7 @@
  */
 'use strict';
 
-var agent = require('../..').start({ samplingRate: 0 }).private_();
+var agent = require('../..')().startAgent({ samplingRate: 0 }).private_();
 
 var common = require('../hooks/common.js');
 var assert = require('assert');

--- a/test/standalone/test-grpc-context.js
+++ b/test/standalone/test-grpc-context.js
@@ -15,9 +15,10 @@
  */
 'use strict';
 
+var common = require('../hooks/common.js');
+
 var agent = require('../..')().startAgent({ samplingRate: 0 }).private_();
 
-var common = require('../hooks/common.js');
 var assert = require('assert');
 var express = require('../hooks/fixtures/express4');
 var http = require('http');
@@ -148,57 +149,57 @@ Object.keys(versions).forEach(function(version) {
     });
 
     afterEach(function() {
-      common.cleanTraces();
+      common.cleanTraces(agent);
     });
 
     it('grpc should preserve context for unary requests', function(done) {
       http.get({port: common.serverPort, path: '/unary'}, function(res) {
-        assert.strictEqual(common.getTraces().length, 2);
+        assert.strictEqual(common.getTraces(agent).length, 2);
         // gRPC Server: 1 root span, 1 http span.
-        assert.strictEqual(common.getTraces()[0].spans.length, 2);
-        assert.strictEqual(common.getTraces()[0].spans[0].kind, 'RPC_SERVER');
+        assert.strictEqual(common.getTraces(agent)[0].spans.length, 2);
+        assert.strictEqual(common.getTraces(agent)[0].spans[0].kind, 'RPC_SERVER');
         // gRPC Client: 1 root span from express, 1 gRPC span, 1 http span.
-        assert.strictEqual(common.getTraces()[1].spans.length, 3);
+        assert.strictEqual(common.getTraces(agent)[1].spans.length, 3);
         done();
       });
     });
 
     it('grpc should preserve context for client requests', function(done) {
       http.get({port: common.serverPort, path: '/client'}, function(res) {
-        assert.strictEqual(common.getTraces().length, 2);
+        assert.strictEqual(common.getTraces(agent).length, 2);
         // gRPC Server: 1 root span, 11 http spans (10 from 'data' listeners,
         // 1 from 'end' listener).
-        assert.strictEqual(common.getTraces()[0].spans.length, 12);
-        assert.strictEqual(common.getTraces()[0].spans[0].kind, 'RPC_SERVER');
+        assert.strictEqual(common.getTraces(agent)[0].spans.length, 12);
+        assert.strictEqual(common.getTraces(agent)[0].spans[0].kind, 'RPC_SERVER');
         // gRPC Client: 1 root span from express, 1 gRPC span, 1 http span.
-        assert.strictEqual(common.getTraces()[1].spans.length, 3);
+        assert.strictEqual(common.getTraces(agent)[1].spans.length, 3);
         done();
       });
     });
 
     it('grpc should preserve context for server requests', function(done) {
       http.get({port: common.serverPort, path: '/server'}, function(res) {
-        assert.strictEqual(common.getTraces().length, 2);
+        assert.strictEqual(common.getTraces(agent).length, 2);
         // gRPC Server: 1 root span, 1 http span.
-        assert.strictEqual(common.getTraces()[0].spans.length, 2);
-        assert.strictEqual(common.getTraces()[0].spans[0].kind, 'RPC_SERVER');
+        assert.strictEqual(common.getTraces(agent)[0].spans.length, 2);
+        assert.strictEqual(common.getTraces(agent)[0].spans[0].kind, 'RPC_SERVER');
         // gRPC Client: 1 root span from express, 1 gRPC span, and 11 http spans
         // (10 from 'data' listeners and 1 from the 'status' listener).
-        assert.strictEqual(common.getTraces()[1].spans.length, 13);
+        assert.strictEqual(common.getTraces(agent)[1].spans.length, 13);
         done();
       });
     });
 
     it('grpc should preserve context for bidi requests', function(done) {
       http.get({port: common.serverPort, path: '/bidi'}, function(res) {
-        assert.strictEqual(common.getTraces().length, 2);
+        assert.strictEqual(common.getTraces(agent).length, 2);
         // gRPC Server: 1 root span, 11 http spans (10 from 'data' listeners,
         // 1 from 'end' listener).
-        assert.strictEqual(common.getTraces()[0].spans.length, 12);
-        assert.strictEqual(common.getTraces()[0].spans[0].kind, 'RPC_SERVER');
+        assert.strictEqual(common.getTraces(agent)[0].spans.length, 12);
+        assert.strictEqual(common.getTraces(agent)[0].spans[0].kind, 'RPC_SERVER');
         // gRPC Client: 1 root span from express, 1 gRPC span, and 11 http spans
         // (10 from 'data' listeners and 1 from the 'status' listener).
-        assert.strictEqual(common.getTraces()[1].spans.length, 13);
+        assert.strictEqual(common.getTraces(agent)[1].spans.length, 13);
         done();
       });
     });

--- a/test/standalone/test-hooks-no-project-num.js
+++ b/test/standalone/test-hooks-no-project-num.js
@@ -35,7 +35,7 @@ describe('should not break without project num', function() {
     process.stderr.write = write;
   });
   it('mongo', function(done) {
-    var agent = require('../..').start();
+    var agent = require('../..')().startAgent();
     var mongoose = require('../hooks/fixtures/mongoose4');
     var Simple = mongoose.model('Simple', new mongoose.Schema({
       f1: String,
@@ -54,7 +54,7 @@ describe('should not break without project num', function() {
   });
 
   it('redis', function(done) {
-    var agent = require('../..').start();
+    var agent = require('../..')().startAgent();
     var redis = require('../hooks/fixtures/redis2.3');
     var client = redis.createClient();
     client.set('i', 1, function() {
@@ -67,7 +67,7 @@ describe('should not break without project num', function() {
 
   it('express', function(done) {
     var http = require('http');
-    var agent = require('../..').start();
+    var agent = require('../..')().startAgent();
     var express = require('../hooks/fixtures/express4');
     var app = express();
     var server;
@@ -84,7 +84,7 @@ describe('should not break without project num', function() {
 
   it('restify', function(done) {
     var http = require('http');
-    var agent = require('../..').start();
+    var agent = require('../..')().startAgent();
     var restify = require('../hooks/fixtures/restify4');
     var server = restify.createServer();
     server.get('/', function (req, res, next) {
@@ -104,7 +104,7 @@ describe('should not break without project num', function() {
 
   it('hapi', function(done) {
     var http = require('http');
-    var agent = require('../..').start();
+    var agent = require('../..')().startAgent();
     var hapi = require('../hooks/fixtures/hapi8');
     var server = new hapi.Server();
     server.connection({ port: 8081 });
@@ -124,7 +124,7 @@ describe('should not break without project num', function() {
   });
 
   it('http', function(done) {
-    var agent = require('../..').start();
+    var agent = require('../..')().startAgent();
     var req = require('http').get({ port: 8081 });
     req.on('error', function() {
       agent.stop();
@@ -133,7 +133,7 @@ describe('should not break without project num', function() {
   });
 
   it('mysql', function(done) {
-    var agent = require('../..').start();
+    var agent = require('../..')().startAgent();
     var mysql = require('../hooks/fixtures/mysql2');
     var pool = mysql.createPool({
       host     : 'localhost',

--- a/test/standalone/test-hooks-sample-warning.js
+++ b/test/standalone/test-hooks-sample-warning.js
@@ -20,7 +20,7 @@
 //   ex) docker -d
 // Run a mongo image binding the mongo port
 //   ex) docker run -p 27017:27017 -d mongo
-var agent = require('../..').start({ samplingRate: 0 }).private_();
+var agent = require('../..')().startAgent({ samplingRate: 0 }).private_();
 
 var common = require('../hooks/common.js');
 

--- a/test/standalone/test-ignore-url-express.js
+++ b/test/standalone/test-ignore-url-express.js
@@ -15,7 +15,10 @@
  */
 'use strict';
 
-var agent = require('../..').start({ignoreUrls: ['/test'], samplingRate: 0});
+var agent = require('../..')().startAgent({
+  ignoreUrls: ['/test'],
+  samplingRate: 0
+});
 
 var assert = require('assert');
 var http = require('http');

--- a/test/standalone/test-index.js
+++ b/test/standalone/test-index.js
@@ -22,7 +22,7 @@ if (!process.env.GCLOUD_PROJECT) {
 }
 
 var assert = require('assert');
-var agent = require('../..')().startAgent();
+var agent = require('../..')();
 var cls = require('../../src/cls.js');
 
 describe('index.js', function() {
@@ -37,16 +37,16 @@ describe('index.js', function() {
     agent.stop(); // harmless to stop before a start.
     assert(!nodule[property].__unwrap,
       property + ' already wrapped before start');
-    agent.start();
+    agent.startAgent();
     assert(nodule[property].__unwrap,
       property + ' should get wrapped on start');
     agent.stop();
     assert(!nodule[property].__unwrap,
       property + ' should get unwrapped on stop');
-    agent.start();
+    agent.startAgent();
     assert(nodule[property].__unwrap,
       property + ' should get wrapped on start');
-    agent.stop();
+    agent.stopAgent();
     assert(!nodule[property].__unwrap,
       property + ' should get unwrapped on stop');
   }
@@ -56,21 +56,21 @@ describe('index.js', function() {
   });
 
   it('should not attach exception handler with ignore option', function() {
-    agent.start();
+    agent.startAgent();
     // Mocha attaches 1 exception handler
     assert.equal(process.listeners('uncaughtException').length, 1);
     agent.stop();
   });
 
   it('should wrap/unwrap http on start/stop', function() {
-    agent.start(); // agent needs to be started before the first require.
+    agent.startAgent(); // agent needs to be started before the first require.
     var http = require('http');
     wrapTest(http, 'request');
     agent.stop();
   });
 
   it('should wrap/unwrap express on start/stop', function() {
-    agent.start();
+    agent.startAgent();
     var express = require('../hooks/fixtures/express4');
     var patchedMethods = require('methods');
     patchedMethods.push('use', 'route', 'param', 'all');
@@ -81,14 +81,14 @@ describe('index.js', function() {
   });
 
   it('should wrap/unwrap hapi on start/stop', function() {
-    agent.start();
+    agent.startAgent();
     var hapi = require('../hooks/fixtures/hapi8');
     wrapTest(hapi.Server.prototype, 'connection');
     agent.stop();
   });
 
   it('should wrap/unwrap mongodb-core on start/stop', function() {
-    agent.start();
+    agent.startAgent();
     var mongo = require('../hooks/fixtures/mongodb-core1');
     wrapTest(mongo.Server.prototype, 'command');
     wrapTest(mongo.Server.prototype, 'insert');
@@ -99,7 +99,7 @@ describe('index.js', function() {
   });
 
   it('should wrap/unwrap redis on start/stop', function() {
-    agent.start();
+    agent.startAgent();
     var redis = require('../hooks/fixtures/redis0.12');
     wrapTest(redis.RedisClient.prototype, 'send_command');
     wrapTest(redis, 'createClient');
@@ -107,14 +107,14 @@ describe('index.js', function() {
   });
 
   it('should wrap/unwrap restify on start/stop', function() {
-    agent.start();
+    agent.startAgent();
     var restify = require('../hooks/fixtures/restify4');
     wrapTest(restify, 'createServer');
     agent.stop();
   });
 
   it('should have equivalent enabled and disabled structure', function() {
-    agent.start();
+    agent.startAgent();
     assert.equal(typeof agent, 'object');
     assert.equal(typeof agent.startSpan, 'function');
     assert.equal(typeof agent.endSpan, 'function');
@@ -137,7 +137,7 @@ describe('index.js', function() {
   });
 
   it('should return the initialized agent on get', function() {
-    agent.start();
+    agent.startAgent();
     assert.equal(agent.get(), agent);
   });
 
@@ -154,7 +154,7 @@ describe('index.js', function() {
   });
 
   it('should produce real spans when enabled', function() {
-    agent.start();
+    agent.startAgent();
     cls.getNamespace().run(function() {
       agent.private_().createRootSpanData('root', 1, 2);
       var spanData = agent.startSpan('sub');
@@ -165,7 +165,7 @@ describe('index.js', function() {
   });
 
   it('should produce real spans runInSpan sync', function() {
-    agent.start();
+    agent.startAgent();
     cls.getNamespace().run(function() {
       var root = agent.private_().createRootSpanData('root', 1, 0);
       var testLabel = { key: 'val' };
@@ -184,7 +184,7 @@ describe('index.js', function() {
   });
 
   it('should produce real spans runInSpan async', function(done) {
-    agent.start();
+    agent.startAgent();
     cls.getNamespace().run(function() {
       var root = agent.private_().createRootSpanData('root', 1, 0);
       var testLabel = { key: 'val' };
@@ -212,7 +212,7 @@ describe('index.js', function() {
   });
 
   it('should produce real root spans runInRootSpan sync', function() {
-    agent.start();
+    agent.startAgent();
     cls.getNamespace().run(function() {
       var testLabel = { key: 'val' };
       agent.runInRootSpan('root', testLabel, function() {
@@ -232,7 +232,7 @@ describe('index.js', function() {
   });
 
   it('should produce real root spans runInRootSpan async', function(done) {
-    agent.start();
+    agent.startAgent();
     cls.getNamespace().run(function() {
       var testLabel = { key: 'val' };
       agent.runInRootSpan('root', testLabel, function(endSpan) {
@@ -260,7 +260,7 @@ describe('index.js', function() {
   });
 
   it('should not break with no root span', function() {
-    agent.start();
+    agent.startAgent();
     var span = agent.startSpan();
     agent.setTransactionName('noop');
     agent.addTransactionLabel('noop', 'noop');
@@ -269,7 +269,7 @@ describe('index.js', function() {
   });
 
   it('should not allow nested root spans', function(done) {
-    agent.start();
+    agent.startAgent();
     agent.runInRootSpan('root', function(cb1) {
       var finished = false;
       var finish = function () {
@@ -304,7 +304,7 @@ describe('index.js', function() {
   });
 
   it('should set transaction name and labels', function() {
-    agent.start();
+    agent.startAgent();
     cls.getNamespace().run(function() {
       var spanData = agent.private_().createRootSpanData('root', 1, 2);
       agent.setTransactionName('root2');

--- a/test/standalone/test-index.js
+++ b/test/standalone/test-index.js
@@ -26,10 +26,19 @@ var trace = require('../..')();
 var cls = require('../../src/cls.js');
 
 describe('index.js', function() {
-  function wrapTest(nodule, property) {
+
+  it('should be harmless to stop before a start', function() {
+    var agent = trace.startAgent();
+    agent.stop();
+    agent.stop();
+    agent.stop();
+  });
+
+  function wrapTest(agent, nodule, property) {
+    agent.stop(); // harmless to stop before a start.
     assert(!nodule[property].__unwrap,
       property + ' already wrapped before start');
-    var agent = trace.startAgent();
+    agent = trace.startAgent();
     assert(nodule[property].__unwrap,
       property + ' should get wrapped on start');
     agent.stop();
@@ -44,7 +53,7 @@ describe('index.js', function() {
   }
 
   it('should wrap/unwrap module._load on start/stop', function() {
-    wrapTest(require('module'), '_load');
+    wrapTest(trace.startAgent(), require('module'), '_load');
   });
 
   it('should not attach exception handler with ignore option', function() {
@@ -57,7 +66,7 @@ describe('index.js', function() {
   it('should wrap/unwrap http on start/stop', function() {
     var agent = trace.startAgent(); // agent needs to be started before the first require.
     var http = require('http');
-    wrapTest(http, 'request');
+    wrapTest(agent, http, 'request');
     agent.stop();
   });
 
@@ -67,7 +76,7 @@ describe('index.js', function() {
     var patchedMethods = require('methods');
     patchedMethods.push('use', 'route', 'param', 'all');
     patchedMethods.forEach(function(method) {
-      wrapTest(express.application, method);
+      wrapTest(agent, express.application, method);
     });
     agent.stop();
   });
@@ -75,33 +84,33 @@ describe('index.js', function() {
   it('should wrap/unwrap hapi on start/stop', function() {
     var agent = trace.startAgent();
     var hapi = require('../hooks/fixtures/hapi8');
-    wrapTest(hapi.Server.prototype, 'connection');
+    wrapTest(agent, hapi.Server.prototype, 'connection');
     agent.stop();
   });
 
   it('should wrap/unwrap mongodb-core on start/stop', function() {
     var agent = trace.startAgent();
     var mongo = require('../hooks/fixtures/mongodb-core1');
-    wrapTest(mongo.Server.prototype, 'command');
-    wrapTest(mongo.Server.prototype, 'insert');
-    wrapTest(mongo.Server.prototype, 'update');
-    wrapTest(mongo.Server.prototype, 'remove');
-    wrapTest(mongo.Cursor.prototype, 'next');
+    wrapTest(agent, mongo.Server.prototype, 'command');
+    wrapTest(agent, mongo.Server.prototype, 'insert');
+    wrapTest(agent, mongo.Server.prototype, 'update');
+    wrapTest(agent, mongo.Server.prototype, 'remove');
+    wrapTest(agent, mongo.Cursor.prototype, 'next');
     agent.stop();
   });
 
   it('should wrap/unwrap redis on start/stop', function() {
     var agent = trace.startAgent();
     var redis = require('../hooks/fixtures/redis0.12');
-    wrapTest(redis.RedisClient.prototype, 'send_command');
-    wrapTest(redis, 'createClient');
+    wrapTest(agent, redis.RedisClient.prototype, 'send_command');
+    wrapTest(agent, redis, 'createClient');
     agent.stop();
   });
 
   it('should wrap/unwrap restify on start/stop', function() {
     var agent = trace.startAgent();
     var restify = require('../hooks/fixtures/restify4');
-    wrapTest(restify, 'createServer');
+    wrapTest(agent, restify, 'createServer');
     agent.stop();
   });
 

--- a/test/standalone/test-index.js
+++ b/test/standalone/test-index.js
@@ -22,7 +22,7 @@ if (!process.env.GCLOUD_PROJECT) {
 }
 
 var assert = require('assert');
-var agent = require('../..');
+var agent = require('../..')();
 var cls = require('../../src/cls.js');
 
 describe('index.js', function() {

--- a/test/standalone/test-index.js
+++ b/test/standalone/test-index.js
@@ -136,6 +136,7 @@ describe('index.js', function() {
   it('should return the initialized agent on get', function() {
     var agent = trace.startAgent();
     assert.equal(agent.get(), agent);
+    agent.stop();
   });
 
   it('should allow start, end, runIn span calls when disabled', function() {

--- a/test/standalone/test-index.js
+++ b/test/standalone/test-index.js
@@ -22,31 +22,23 @@ if (!process.env.GCLOUD_PROJECT) {
 }
 
 var assert = require('assert');
-var agent = require('../..')();
+var trace = require('../..')();
 var cls = require('../../src/cls.js');
 
 describe('index.js', function() {
-
-  it('should be harmless to stop before a start', function() {
-    agent.stop();
-    agent.stop();
-    agent.stop();
-  });
-
   function wrapTest(nodule, property) {
-    agent.stop(); // harmless to stop before a start.
     assert(!nodule[property].__unwrap,
       property + ' already wrapped before start');
-    agent.startAgent();
+    var agent = trace.startAgent();
     assert(nodule[property].__unwrap,
       property + ' should get wrapped on start');
     agent.stop();
     assert(!nodule[property].__unwrap,
       property + ' should get unwrapped on stop');
-    agent.startAgent();
+    agent = trace.startAgent();
     assert(nodule[property].__unwrap,
       property + ' should get wrapped on start');
-    agent.stopAgent();
+    agent.stop();
     assert(!nodule[property].__unwrap,
       property + ' should get unwrapped on stop');
   }
@@ -56,21 +48,21 @@ describe('index.js', function() {
   });
 
   it('should not attach exception handler with ignore option', function() {
-    agent.startAgent();
+    var agent = trace.startAgent();
     // Mocha attaches 1 exception handler
     assert.equal(process.listeners('uncaughtException').length, 1);
     agent.stop();
   });
 
   it('should wrap/unwrap http on start/stop', function() {
-    agent.startAgent(); // agent needs to be started before the first require.
+    var agent = trace.startAgent(); // agent needs to be started before the first require.
     var http = require('http');
     wrapTest(http, 'request');
     agent.stop();
   });
 
   it('should wrap/unwrap express on start/stop', function() {
-    agent.startAgent();
+    var agent = trace.startAgent();
     var express = require('../hooks/fixtures/express4');
     var patchedMethods = require('methods');
     patchedMethods.push('use', 'route', 'param', 'all');
@@ -81,14 +73,14 @@ describe('index.js', function() {
   });
 
   it('should wrap/unwrap hapi on start/stop', function() {
-    agent.startAgent();
+    var agent = trace.startAgent();
     var hapi = require('../hooks/fixtures/hapi8');
     wrapTest(hapi.Server.prototype, 'connection');
     agent.stop();
   });
 
   it('should wrap/unwrap mongodb-core on start/stop', function() {
-    agent.startAgent();
+    var agent = trace.startAgent();
     var mongo = require('../hooks/fixtures/mongodb-core1');
     wrapTest(mongo.Server.prototype, 'command');
     wrapTest(mongo.Server.prototype, 'insert');
@@ -99,7 +91,7 @@ describe('index.js', function() {
   });
 
   it('should wrap/unwrap redis on start/stop', function() {
-    agent.startAgent();
+    var agent = trace.startAgent();
     var redis = require('../hooks/fixtures/redis0.12');
     wrapTest(redis.RedisClient.prototype, 'send_command');
     wrapTest(redis, 'createClient');
@@ -107,14 +99,14 @@ describe('index.js', function() {
   });
 
   it('should wrap/unwrap restify on start/stop', function() {
-    agent.startAgent();
+    var agent = trace.startAgent();
     var restify = require('../hooks/fixtures/restify4');
     wrapTest(restify, 'createServer');
     agent.stop();
   });
 
   it('should have equivalent enabled and disabled structure', function() {
-    agent.startAgent();
+    var agent = trace.startAgent();
     assert.equal(typeof agent, 'object');
     assert.equal(typeof agent.startSpan, 'function');
     assert.equal(typeof agent.endSpan, 'function');
@@ -132,16 +124,13 @@ describe('index.js', function() {
     assert.equal(typeof agent.addTransactionLabel, 'function');
   });
 
-  it('should throw if get called before start', function() {
-    assert.throws(function() { agent.get(); }, Error);
-  });
-
   it('should return the initialized agent on get', function() {
-    agent.startAgent();
+    var agent = trace.startAgent();
     assert.equal(agent.get(), agent);
   });
 
   it('should allow start, end, runIn span calls when disabled', function() {
+    var agent = trace.startAgent();
     agent.stop();
     var span = agent.startSpan();
     agent.endSpan(span);
@@ -154,7 +143,7 @@ describe('index.js', function() {
   });
 
   it('should produce real spans when enabled', function() {
-    agent.startAgent();
+    var agent = trace.startAgent();
     cls.getNamespace().run(function() {
       agent.private_().createRootSpanData('root', 1, 2);
       var spanData = agent.startSpan('sub');
@@ -165,7 +154,7 @@ describe('index.js', function() {
   });
 
   it('should produce real spans runInSpan sync', function() {
-    agent.startAgent();
+    var agent = trace.startAgent();
     cls.getNamespace().run(function() {
       var root = agent.private_().createRootSpanData('root', 1, 0);
       var testLabel = { key: 'val' };
@@ -184,7 +173,7 @@ describe('index.js', function() {
   });
 
   it('should produce real spans runInSpan async', function(done) {
-    agent.startAgent();
+    var agent = trace.startAgent();
     cls.getNamespace().run(function() {
       var root = agent.private_().createRootSpanData('root', 1, 0);
       var testLabel = { key: 'val' };
@@ -212,7 +201,7 @@ describe('index.js', function() {
   });
 
   it('should produce real root spans runInRootSpan sync', function() {
-    agent.startAgent();
+    var agent = trace.startAgent();
     cls.getNamespace().run(function() {
       var testLabel = { key: 'val' };
       agent.runInRootSpan('root', testLabel, function() {
@@ -232,7 +221,7 @@ describe('index.js', function() {
   });
 
   it('should produce real root spans runInRootSpan async', function(done) {
-    agent.startAgent();
+    var agent = trace.startAgent();
     cls.getNamespace().run(function() {
       var testLabel = { key: 'val' };
       agent.runInRootSpan('root', testLabel, function(endSpan) {
@@ -260,7 +249,7 @@ describe('index.js', function() {
   });
 
   it('should not break with no root span', function() {
-    agent.startAgent();
+    var agent = trace.startAgent();
     var span = agent.startSpan();
     agent.setTransactionName('noop');
     agent.addTransactionLabel('noop', 'noop');
@@ -269,7 +258,7 @@ describe('index.js', function() {
   });
 
   it('should not allow nested root spans', function(done) {
-    agent.startAgent();
+    var agent = trace.startAgent();
     agent.runInRootSpan('root', function(cb1) {
       var finished = false;
       var finish = function () {
@@ -304,7 +293,7 @@ describe('index.js', function() {
   });
 
   it('should set transaction name and labels', function() {
-    agent.startAgent();
+    var agent = trace.startAgent();
     cls.getNamespace().run(function() {
       var spanData = agent.private_().createRootSpanData('root', 1, 2);
       agent.setTransactionName('root2');
@@ -316,6 +305,6 @@ describe('index.js', function() {
   });
 
   it('should set agent on global object', function() {
-    assert.equal(global._google_trace_agent, agent);
+    assert.equal(global._google_trace_agent, trace.startAgent());
   });
 });

--- a/test/standalone/test-index.js
+++ b/test/standalone/test-index.js
@@ -22,7 +22,7 @@ if (!process.env.GCLOUD_PROJECT) {
 }
 
 var assert = require('assert');
-var agent = require('../..')();
+var agent = require('../..')().startAgent();
 var cls = require('../../src/cls.js');
 
 describe('index.js', function() {

--- a/test/standalone/test-invalid-project-id.js
+++ b/test/standalone/test-invalid-project-id.js
@@ -19,11 +19,11 @@
 delete process.env.GCLOUD_PROJECT;
 
 var assert = require('assert');
-var agent = require('../..')();
+var trace = require('../..')();
 
 describe('index.js', function() {
   it('should complain when config.projectId is not a string or number', function() {
-    agent.startAgent({projectId: 0, enabled: true, logLevel: 0});
+    var agent = trace.startAgent({projectId: 0, enabled: true, logLevel: 0});
     assert(agent.isActive());
     agent.stop();
     agent.startAgent({projectId: {test: false}, enabled: true, logLevel: 0});

--- a/test/standalone/test-invalid-project-id.js
+++ b/test/standalone/test-invalid-project-id.js
@@ -19,14 +19,14 @@
 delete process.env.GCLOUD_PROJECT;
 
 var assert = require('assert');
-var agent = require('../..');
+var agent = require('../..')();
 
 describe('index.js', function() {
   it('should complain when config.projectId is not a string or number', function() {
-    agent.start({projectId: 0, enabled: true, logLevel: 0});
+    agent.startAgent({projectId: 0, enabled: true, logLevel: 0});
     assert(agent.isActive());
     agent.stop();
-    agent.start({projectId: {test: false}, enabled: true, logLevel: 0});
+    agent.startAgent({projectId: {test: false}, enabled: true, logLevel: 0});
     assert(!agent.isActive());
   });
 });

--- a/test/standalone/test-invalid-project-id.js
+++ b/test/standalone/test-invalid-project-id.js
@@ -19,7 +19,7 @@
 delete process.env.GCLOUD_PROJECT;
 
 var assert = require('assert');
-var agent = require('../..')().startAgent();
+var agent = require('../..')();
 
 describe('index.js', function() {
   it('should complain when config.projectId is not a string or number', function() {

--- a/test/standalone/test-invalid-project-id.js
+++ b/test/standalone/test-invalid-project-id.js
@@ -19,7 +19,7 @@
 delete process.env.GCLOUD_PROJECT;
 
 var assert = require('assert');
-var agent = require('../..')();
+var agent = require('../..')().startAgent();
 
 describe('index.js', function() {
   it('should complain when config.projectId is not a string or number', function() {

--- a/test/standalone/test-mysql-pool.js
+++ b/test/standalone/test-mysql-pool.js
@@ -22,8 +22,18 @@ var semver = require('semver');
 
 // hapi 13 and hapi-plugin-mysql uses const
 if (semver.satisfies(process.version, '>=4')) {
-  var Hapi = require('../hooks/fixtures/hapi13');
   describe('test-trace-mysql', function() {
+    var agent;
+    var Hapi;
+    before(function() {
+      agent = require('../..')().startAgent({ samplingRate: 0 }).private_();
+      Hapi = require('../hooks/fixtures/hapi13');
+    });
+
+    after(function() {
+      agent.stop();
+    });
+
     it('should work with connection pool access', function(done) {
       var server = new Hapi.Server();
       server.connection({ port: common.serverPort });
@@ -52,7 +62,7 @@ if (semver.satisfies(process.version, '>=4')) {
             var result = '';
             res.on('data', function(data) { result += data; });
             res.on('end', function() {
-              var spans = common.getMatchingSpans(function (span) {
+              var spans = common.getMatchingSpans(agent, function (span) {
                 return span.name === 'mysql-query';
               });
               assert.equal(spans.length, 1);

--- a/test/standalone/test-mysql-pool.js
+++ b/test/standalone/test-mysql-pool.js
@@ -26,7 +26,8 @@ if (semver.satisfies(process.version, '>=4')) {
     var agent;
     var Hapi;
     before(function() {
-      agent = require('../..')().startAgent({ samplingRate: 0 }).private_();
+      agent = require('../..')().startAgent({ samplingRate: 0,
+                                              enhancedDatabaseReporting: true }).private_();
       Hapi = require('../hooks/fixtures/hapi13');
     });
 
@@ -65,6 +66,7 @@ if (semver.satisfies(process.version, '>=4')) {
               var spans = common.getMatchingSpans(agent, function (span) {
                 return span.name === 'mysql-query';
               });
+              console.log('spans=' + JSON.stringify(spans, null, 2));
               assert.equal(spans.length, 1);
               assert.equal(spans[0].labels.sql, 'SELECT * FROM t');
               done();

--- a/test/standalone/test-mysql-pool.js
+++ b/test/standalone/test-mysql-pool.js
@@ -66,7 +66,6 @@ if (semver.satisfies(process.version, '>=4')) {
               var spans = common.getMatchingSpans(agent, function (span) {
                 return span.name === 'mysql-query';
               });
-              console.log('spans=' + JSON.stringify(spans, null, 2));
               assert.equal(spans.length, 1);
               assert.equal(spans[0].labels.sql, 'SELECT * FROM t');
               done();

--- a/test/standalone/test-no-self-tracing.js
+++ b/test/standalone/test-no-self-tracing.js
@@ -34,7 +34,7 @@ describe('test-no-self-tracing', function() {
                 .get('/computeMetadata/v1/instance/hostname').reply(200)
                 .get('/computeMetadata/v1/instance/id').reply(200)
                 .get('/computeMetadata/v1/project/numeric-project-id').reply(200);
-    var agent = require('../..').start();
+    var agent = require('../..')().startAgent();
     require('http'); // Must require http to force patching of the module
     var oldDebug = agent.private_().logger.debug;
     agent.private_().logger.debug = newDebug;
@@ -53,7 +53,7 @@ describe('test-no-self-tracing', function() {
                 .get('/computeMetadata/v1/instance/id').reply(200);
     var apiScope = nock('https://cloudtrace.googleapis.com')
                 .patch('/v1/projects/0/traces').reply(200);
-    var agent = require('../..').start({ projectId: 0, bufferSize: 1 });
+    var agent = require('../..')().startAgent({ projectId: 0, bufferSize: 1 });
     agent.private_().traceWriter.request_ = request;
     require('http'); // Must require http to force patching of the module
     var oldDebug = agent.private_().logger.debug;

--- a/test/standalone/test-trace-cluster.js
+++ b/test/standalone/test-trace-cluster.js
@@ -18,9 +18,19 @@
 
 var common = require('../hooks/common.js');
 var cluster = require('cluster');
-var express = require('../hooks/fixtures/express4');
 
 describe('test-trace-cluster', function() {
+  var agent;
+  var express;
+  before(function() {
+    agent = require('../..')().startAgent({samplingRate: 0}).private_();
+    express = require('../hooks/fixtures/express4');
+  });
+
+  after(function() {
+    agent.stop();
+  });
+
   it('should not interfere with express span', function(done) {
     if (cluster.isMaster) {
       cluster.fork();
@@ -41,7 +51,7 @@ describe('test-trace-cluster', function() {
           server.close();
           done();
         };
-        common.doRequest('GET', finalize, expressPredicate);
+        common.doRequest(agent, 'GET', finalize, expressPredicate);
       });
     }
   });

--- a/test/standalone/test-trace-gcloud.js
+++ b/test/standalone/test-trace-gcloud.js
@@ -23,6 +23,15 @@ var path = require('path');
 nock.disableNetConnect();
 
 describe('test-trace-gcloud', function() {
+  var agent;
+  before(function() {
+    agent = require('../..')().startAgent({ samplingRate: 0 }).private_();
+  });
+
+  after(function() {
+    agent.stop();
+  });
+
   // This does a gcloud.datastore.get() request that makes a gRPC 'lookup' call.
   // It attempts to authenticate using Google Auth by connecting to
   // 'accounts.google.com:443/o/oauth2/token', but fails because of Nock.
@@ -36,7 +45,7 @@ describe('test-trace-gcloud', function() {
     this.timeout(20000);
     process.env.GOOGLE_APPLICATION_CREDENTIALS =
         path.join(__dirname, '..', 'fixtures', 'gcloud-credentials.json');
-    common.runInTransaction(function(endTransaction) {
+    common.runInTransaction(agent, function(endTransaction) {
       var gcloud = require('../hooks/fixtures/google-cloud0.44');
       var ds = gcloud.datastore();
       var key = ds.key(['bad', 'key']);
@@ -46,13 +55,13 @@ describe('test-trace-gcloud', function() {
         assert.strictEqual(err.code, 401);
         assert.notStrictEqual(
             err.message.indexOf('accounts.google.com:443/o/oauth2/token'), -1);
-        var trace = common.getMatchingSpan(grpcPredicate);
+        var trace = common.getMatchingSpan(agent, grpcPredicate);
         assert(trace);
         assert.notStrictEqual(trace.labels.argument.indexOf(
             '"keys":[{"path":[{"kind":"bad","name":"key"}]}]'), -1);
         assert(trace.labels.error);
         delete process.env.GOOGLE_APPLICATION_CREDENTIALS;
-        common.cleanTraces();
+        common.cleanTraces(agent);
         done();
       });
     });

--- a/test/standalone/test-trace-gcloud.js
+++ b/test/standalone/test-trace-gcloud.js
@@ -25,7 +25,8 @@ nock.disableNetConnect();
 describe('test-trace-gcloud', function() {
   var agent;
   before(function() {
-    agent = require('../..')().startAgent({ samplingRate: 0 }).private_();
+    agent = require('../..')().startAgent({ samplingRate: 0,
+      enhancedDatabaseReporting: true }).private_();
   });
 
   after(function() {

--- a/test/standalone/test-trace-header-context.js
+++ b/test/standalone/test-trace-header-context.js
@@ -16,6 +16,7 @@
 'use strict';
 
 var common = require('../hooks/common.js');
+var cls = require('../../src/cls.js');
 var http = require('http');
 var assert = require('assert');
 var constants = require('../../src/constants.js');
@@ -33,7 +34,8 @@ describe('test-trace-header-context', function() {
   });
 
   afterEach(function() {
-    agent.namespace.set('root', null);
+    cls.destroyNamespace();
+    agent.namespace = cls.createNamespace();
   });
 
   it('should work with string url', function(done) {

--- a/test/standalone/test-trace-header-context.js
+++ b/test/standalone/test-trace-header-context.js
@@ -23,7 +23,7 @@ var constants = require('../../src/constants.js');
 
 describe('test-trace-header-context', function() {
   beforeEach(function() {
-    require('../..').start();
+    require('../..')().startAgent();
   });
 
   afterEach(function() {

--- a/test/standalone/test-trace-header-context.js
+++ b/test/standalone/test-trace-header-context.js
@@ -18,16 +18,17 @@
 var common = require('../hooks/common.js');
 var http = require('http');
 var assert = require('assert');
-var express = require('../hooks/fixtures/express4');
 var constants = require('../../src/constants.js');
 
 describe('test-trace-header-context', function() {
   var agent;
-  beforeEach(function() {
-    agent = require('../..')().startAgent();
+  var express;
+  before(function() {
+    agent = require('../..')().startAgent({ samplingRate: 0 }).private_();
+    express = require('../hooks/fixtures/express4');
   });
 
-  afterEach(function() {
+  after(function() {
     agent.stop();
   });
 
@@ -41,14 +42,14 @@ describe('test-trace-header-context', function() {
     app.get('/self', function(req, res) {
       assert(req.headers[constants.TRACE_CONTEXT_HEADER_NAME]);
       res.send(common.serverRes);
-      var traces = common.getTraces();
+      var traces = common.getTraces(agent);
       assert.equal(traces.length, 2);
       assert.equal(traces[0].spans.length, 2);
       assert.equal(traces[1].spans.length, 1);
       assert.equal(traces[0].spans[0].name, '/');
       assert.equal(traces[0].spans[1].name, 'localhost');
       assert.equal(traces[1].spans[0].name, '/self');
-      common.cleanTraces();
+      common.cleanTraces(agent);
       server.close();
       done();
     });
@@ -67,14 +68,14 @@ describe('test-trace-header-context', function() {
     app.get('/self', function(req, res) {
       assert(req.headers[constants.TRACE_CONTEXT_HEADER_NAME]);
       res.send(common.serverRes);
-      var traces = common.getTraces();
+      var traces = common.getTraces(agent);
       assert.equal(traces.length, 2);
       assert.equal(traces[0].spans.length, 2);
       assert.equal(traces[1].spans.length, 1);
       assert.equal(traces[0].spans[0].name, '/');
       assert.equal(traces[0].spans[1].name, 'localhost');
       assert.equal(traces[1].spans[0].name, '/self');
-      common.cleanTraces();
+      common.cleanTraces(agent);
       server.close();
       done();
     });
@@ -99,14 +100,14 @@ describe('test-trace-header-context', function() {
         req.headers[constants.TRACE_CONTEXT_HEADER_NAME].slice(8),
         ';o=1');
       res.send(common.serverRes);
-      var traces = common.getTraces();
+      var traces = common.getTraces(agent);
       assert.equal(traces.length, 2);
       assert.equal(traces[0].spans.length, 2);
       assert.equal(traces[1].spans.length, 1);
       assert.equal(traces[0].spans[0].name, '/');
       assert.equal(traces[0].spans[1].name, 'localhost');
       assert.equal(traces[1].spans[0].name, '/self');
-      common.cleanTraces();
+      common.cleanTraces(agent);
       server.close();
       done();
     });

--- a/test/standalone/test-trace-header-context.js
+++ b/test/standalone/test-trace-header-context.js
@@ -32,6 +32,10 @@ describe('test-trace-header-context', function() {
     agent.stop();
   });
 
+  afterEach(function() {
+    agent.namespace.set('root', null)
+  });
+
   it('should work with string url', function(done) {
     var app = express();
     var server;

--- a/test/standalone/test-trace-header-context.js
+++ b/test/standalone/test-trace-header-context.js
@@ -22,12 +22,13 @@ var express = require('../hooks/fixtures/express4');
 var constants = require('../../src/constants.js');
 
 describe('test-trace-header-context', function() {
+  var agent;
   beforeEach(function() {
-    require('../..')().startAgent();
+    agent = require('../..')().startAgent();
   });
 
   afterEach(function() {
-    require('../..').stop();
+    agent.stop();
   });
 
   it('should work with string url', function(done) {

--- a/test/standalone/test-trace-header-context.js
+++ b/test/standalone/test-trace-header-context.js
@@ -33,7 +33,7 @@ describe('test-trace-header-context', function() {
   });
 
   afterEach(function() {
-    agent.namespace.set('root', null)
+    agent.namespace.set('root', null);
   });
 
   it('should work with string url', function(done) {

--- a/test/standalone/test-trace-koa.js
+++ b/test/standalone/test-trace-koa.js
@@ -16,7 +16,6 @@
 'use strict';
 
 var common = require('../hooks/common.js');
-var koa = require('../hooks/fixtures/koa1');
 var http = require('http');
 var assert = require('assert');
 var constants = require('../../src/constants.js');
@@ -25,9 +24,20 @@ var TraceLabels = require('../../src/trace-labels.js');
 var server;
 
 describe('test-trace-koa', function() {
+  var agent;
+  var koa;
+  before(function() {
+    agent = require('../..')().startAgent().private_();
+    koa = require('../hooks/fixtures/koa1');
+  });
+
   afterEach(function() {
-    common.cleanTraces();
+    common.cleanTraces(agent);
     server.close();
+  });
+
+  after(function() {
+    agent.stop();
   });
 
   it('should accurately measure get time, get', function(done) {
@@ -40,7 +50,7 @@ describe('test-trace-koa', function() {
       };
     });
     server = app.listen(common.serverPort, function() {
-      common.doRequest('GET', done, koaPredicate);
+      common.doRequest(agent, 'GET', done, koaPredicate);
     });
   });
 
@@ -65,7 +75,7 @@ describe('test-trace-koa', function() {
             TraceLabels.HTTP_SOURCE_IP,
             TraceLabels.HTTP_RESPONSE_CODE_LABEL_KEY
           ];
-          var span = common.getMatchingSpan(koaPredicate);
+          var span = common.getMatchingSpan(agent, koaPredicate);
           expectedKeys.forEach(function(key) {
             assert(span.labels[key]);
           });
@@ -86,7 +96,7 @@ describe('test-trace-koa', function() {
     });
     server = app.listen(common.serverPort, function() {
       http.get({port: common.serverPort}, function(res) {
-        var labels = common.getMatchingSpan(koaPredicate).labels;
+        var labels = common.getMatchingSpan(agent, koaPredicate).labels;
         var stackTrace = JSON.parse(labels[TraceLabels.STACK_TRACE_DETAILS_KEY]);
         // Ensure that our middleware is on top of the stack
         assert.equal(stackTrace.stack_frame[0].method_name, 'middleware');
@@ -106,7 +116,7 @@ describe('test-trace-koa', function() {
     });
     server = app.listen(common.serverPort, function() {
       http.get({path: '/?a=b', port: common.serverPort}, function(res) {
-        var name = common.getMatchingSpan(koaPredicate).name;
+        var name = common.getMatchingSpan(agent, koaPredicate).name;
         assert.equal(name, '/');
         done();
       });

--- a/test/standalone/test-trace-options-sampling.js
+++ b/test/standalone/test-trace-options-sampling.js
@@ -20,15 +20,22 @@
 //   ex) docker -d
 // Run a mongo image binding the mongo port
 //   ex) docker run -p 27017:27017 -d mongo
-require('../..')().startAgent({ samplingRate: 1 });
-
 var common = require('../hooks/common.js');
-
 var assert = require('assert');
-var express = require('../hooks/fixtures/express4');
 var http = require('http');
 
 describe('express + mongo with trace options header + sampling', function() {
+  var agent;
+  var express;
+  before(function() {
+    agent = require('../..')().startAgent({ samplingRate: 1 }).private_();
+    express = require('../hooks/fixtures/express4');
+  });
+
+  after(function() {
+    agent.stop();
+  });
+
   it('should trace when enabled', function(done) {
     var app = express();
     app.get('/', function (req, res) {
@@ -45,8 +52,8 @@ describe('express + mongo with trace options header + sampling', function() {
         res.on('end', function() {
           if (++doneCount === 5) {
             // Only one trace should be sampled even though all have enabled header.
-            assert.equal(common.getTraces().length, 1);
-            common.cleanTraces();
+            assert.equal(common.getTraces(agent).length, 1);
+            common.cleanTraces(agent);
             server.close();
             done();
           }

--- a/test/standalone/test-trace-options-sampling.js
+++ b/test/standalone/test-trace-options-sampling.js
@@ -20,7 +20,7 @@
 //   ex) docker -d
 // Run a mongo image binding the mongo port
 //   ex) docker run -p 27017:27017 -d mongo
-require('../..').start({ samplingRate: 1 });
+require('../..')().startAgent({ samplingRate: 1 });
 
 var common = require('../hooks/common.js');
 

--- a/test/standalone/test-trace-options.js
+++ b/test/standalone/test-trace-options.js
@@ -20,7 +20,7 @@
 //   ex) docker -d
 // Run a mongo image binding the mongo port
 //   ex) docker run -p 27017:27017 -d mongo
-require('../..').start({ samplingRate: 0 });
+require('../..')().startAgent({ samplingRate: 0 });
 
 var common = require('../hooks/common.js');
 

--- a/test/standalone/test-trace-options.js
+++ b/test/standalone/test-trace-options.js
@@ -20,15 +20,23 @@
 //   ex) docker -d
 // Run a mongo image binding the mongo port
 //   ex) docker run -p 27017:27017 -d mongo
-require('../..')().startAgent({ samplingRate: 0 });
-
 var common = require('../hooks/common.js');
 
 var assert = require('assert');
-var express = require('../hooks/fixtures/express4');
 var http = require('http');
 
 describe('express + mongo with trace options header', function() {
+  var agent;
+  var express;
+  before(function() {
+    agent = require('../..')().startAgent({ samplingRate: 0 }).private_();
+    express = require('../hooks/fixtures/express4');
+  });
+
+  after(function() {
+    agent.stop();
+  });
+
   it('should trace when enabled', function(done) {
     var app = express();
     app.get('/', function (req, res) {
@@ -39,8 +47,8 @@ describe('express + mongo with trace options header', function() {
     var server = app.listen(common.serverPort, function() {
       var shouldTraceOptions = [1,3,5,7];
       var shouldNotTraceOptions = [0,2,4,6];
-      sendRequests(shouldTraceOptions, shouldTraceOptions.length, function() {
-        sendRequests(shouldNotTraceOptions, 0, function() {
+      sendRequests(agent, shouldTraceOptions, shouldTraceOptions.length, function() {
+        sendRequests(agent, shouldNotTraceOptions, 0, function() {
           server.close();
           done();
         });
@@ -49,7 +57,7 @@ describe('express + mongo with trace options header', function() {
   });
 });
 
-function sendRequests(options, expectedTraceCount, done) {
+function sendRequests(agent, options, expectedTraceCount, done) {
   var doneCount = 0;
   options.forEach(function(option) {
     var headers = {};
@@ -58,8 +66,8 @@ function sendRequests(options, expectedTraceCount, done) {
       res.on('data', function() {});
       res.on('end', function() {
         if (++doneCount === options.length) {
-          assert.equal(common.getTraces().length, expectedTraceCount);
-          common.cleanTraces();
+          assert.equal(common.getTraces(agent).length, expectedTraceCount);
+          common.cleanTraces(agent);
           done();
         }
       });

--- a/test/standalone/test-trace-uncaught-exception.js
+++ b/test/standalone/test-trace-uncaught-exception.js
@@ -19,7 +19,7 @@
 var assert = require('assert');
 var nock = require('nock');
 var cls = require('../../src/cls.js');
-var agent = require('../..')();
+var trace = require('../..')();
 var request = require('request');
 
 nock.disableNetConnect();
@@ -43,6 +43,11 @@ var formatBuffer = function(buffer) {
 
 describe('tracewriter publishing', function() {
 
+  var agent;
+  beforeEach(function() {
+    agent = trace.startAgent();
+  });
+
   it('should publish on unhandled exception', function(done) {
     process.removeAllListeners('uncaughtException'); // Remove mocha handler
     var buf;
@@ -62,6 +67,8 @@ describe('tracewriter publishing', function() {
       }, 20);
     });
     process.nextTick(function() {
+      // TODO: (DK) Check if stop() should be called here
+      agent.stop();
       var privateAgent = agent.startAgent({
         bufferSize: 1000,
         samplingRate: 0,

--- a/test/standalone/test-trace-uncaught-exception.js
+++ b/test/standalone/test-trace-uncaught-exception.js
@@ -44,10 +44,6 @@ var formatBuffer = function(buffer) {
 describe('tracewriter publishing', function() {
 
   var agent;
-  beforeEach(function() {
-    agent = trace.startAgent();
-  });
-
   it('should publish on unhandled exception', function(done) {
     process.removeAllListeners('uncaughtException'); // Remove mocha handler
     var buf;
@@ -67,13 +63,12 @@ describe('tracewriter publishing', function() {
       }, 20);
     });
     process.nextTick(function() {
-      // TODO: (DK) Check if stop() should be called here
-      agent.stop();
-      var privateAgent = agent.startAgent({
+      agent = trace.startAgent({
         bufferSize: 1000,
         samplingRate: 0,
         onUncaughtException: 'flush'
-      }).private_();
+      });
+      var privateAgent = agent.private_();
       privateAgent.traceWriter.request_ = request; // Avoid authing
       cls.getNamespace().run(function() {
         queueSpans(2, privateAgent);

--- a/test/standalone/test-trace-uncaught-exception.js
+++ b/test/standalone/test-trace-uncaught-exception.js
@@ -19,7 +19,7 @@
 var assert = require('assert');
 var nock = require('nock');
 var cls = require('../../src/cls.js');
-var agent = require('../..');
+var agent = require('../..')();
 var request = require('request');
 
 nock.disableNetConnect();
@@ -62,7 +62,7 @@ describe('tracewriter publishing', function() {
       }, 20);
     });
     process.nextTick(function() {
-      var privateAgent = agent.start({
+      var privateAgent = agent.startAgent({
         bufferSize: 1000,
         samplingRate: 0,
         onUncaughtException: 'flush'

--- a/test/standalone/test-trace-uncaught-exception.js
+++ b/test/standalone/test-trace-uncaught-exception.js
@@ -19,7 +19,7 @@
 var assert = require('assert');
 var nock = require('nock');
 var cls = require('../../src/cls.js');
-var agent = require('../..')();
+var agent = require('../..')().startAgent();
 var request = require('request');
 
 nock.disableNetConnect();

--- a/test/standalone/test-trace-uncaught-exception.js
+++ b/test/standalone/test-trace-uncaught-exception.js
@@ -19,7 +19,7 @@
 var assert = require('assert');
 var nock = require('nock');
 var cls = require('../../src/cls.js');
-var agent = require('../..')().startAgent();
+var agent = require('../..')();
 var request = require('request');
 
 nock.disableNetConnect();

--- a/test/standalone/test-trace-writer.js
+++ b/test/standalone/test-trace-writer.js
@@ -19,7 +19,7 @@
 var assert = require('assert');
 var nock = require('nock');
 var cls = require('../../src/cls.js');
-var agent = require('../..')();
+var agent = require('../..')().startAgent();
 var request = require('request');
 
 nock.disableNetConnect();

--- a/test/standalone/test-trace-writer.js
+++ b/test/standalone/test-trace-writer.js
@@ -19,7 +19,7 @@
 var assert = require('assert');
 var nock = require('nock');
 var cls = require('../../src/cls.js');
-var agent = require('../..')().startAgent();
+var agent = require('../..')();
 var request = require('request');
 
 nock.disableNetConnect();

--- a/test/standalone/test-trace-writer.js
+++ b/test/standalone/test-trace-writer.js
@@ -19,7 +19,7 @@
 var assert = require('assert');
 var nock = require('nock');
 var cls = require('../../src/cls.js');
-var agent = require('../..')();
+var trace = require('../..')();
 var request = require('request');
 
 nock.disableNetConnect();
@@ -51,7 +51,8 @@ describe('tracewriter publishing', function() {
           assert.equal(JSON.stringify(body), JSON.stringify(parsedOriginal));
           return true;
         }).reply(200);
-    var privateAgent = agent.startAgent({bufferSize: 2, samplingRate: 0}).private_();
+    var agent = trace.startAgent({bufferSize: 2, samplingRate: 0});
+    var privateAgent = agent.private_();
     privateAgent.traceWriter.request_ = request; // Avoid authing
     cls.getNamespace().run(function() {
       queueSpans(2, privateAgent);
@@ -72,7 +73,8 @@ describe('tracewriter publishing', function() {
           assert.equal(JSON.stringify(body), JSON.stringify(parsedOriginal));
           return true;
         }).reply(200);
-    var privateAgent = agent.startAgent({flushDelaySeconds: 0.01, samplingRate: -1}).private_();
+    var agent = trace.startAgent({flushDelaySeconds: 0.01, samplingRate: -1});
+    var privateAgent = agent.private_();
     privateAgent.traceWriter.request_ = request; // Avoid authing
     cls.getNamespace().run(function() {
       queueSpans(1, privateAgent);
@@ -93,7 +95,8 @@ describe('tracewriter publishing', function() {
           assert.equal(JSON.stringify(body), JSON.stringify(parsedOriginal));
           return true;
         }).replyWithError('Simulated Network Error');
-    var privateAgent = agent.startAgent({bufferSize: 2, samplingRate: -1}).private_();
+    var agent = trace.startAgent({bufferSize: 2, samplingRate: -1});
+    var privateAgent = agent.private_();
     privateAgent.traceWriter.request_ = request; // Avoid authing
     cls.getNamespace().run(function() {
       queueSpans(2, privateAgent);

--- a/test/standalone/test-trace-writer.js
+++ b/test/standalone/test-trace-writer.js
@@ -19,7 +19,7 @@
 var assert = require('assert');
 var nock = require('nock');
 var cls = require('../../src/cls.js');
-var agent = require('../..');
+var agent = require('../..')();
 var request = require('request');
 
 nock.disableNetConnect();
@@ -51,7 +51,7 @@ describe('tracewriter publishing', function() {
           assert.equal(JSON.stringify(body), JSON.stringify(parsedOriginal));
           return true;
         }).reply(200);
-    var privateAgent = agent.start({bufferSize: 2, samplingRate: 0}).private_();
+    var privateAgent = agent.startAgent({bufferSize: 2, samplingRate: 0}).private_();
     privateAgent.traceWriter.request_ = request; // Avoid authing
     cls.getNamespace().run(function() {
       queueSpans(2, privateAgent);
@@ -72,7 +72,7 @@ describe('tracewriter publishing', function() {
           assert.equal(JSON.stringify(body), JSON.stringify(parsedOriginal));
           return true;
         }).reply(200);
-    var privateAgent = agent.start({flushDelaySeconds: 0.01, samplingRate: -1}).private_();
+    var privateAgent = agent.startAgent({flushDelaySeconds: 0.01, samplingRate: -1}).private_();
     privateAgent.traceWriter.request_ = request; // Avoid authing
     cls.getNamespace().run(function() {
       queueSpans(1, privateAgent);
@@ -93,7 +93,7 @@ describe('tracewriter publishing', function() {
           assert.equal(JSON.stringify(body), JSON.stringify(parsedOriginal));
           return true;
         }).replyWithError('Simulated Network Error');
-    var privateAgent = agent.start({bufferSize: 2, samplingRate: -1}).private_();
+    var privateAgent = agent.startAgent({bufferSize: 2, samplingRate: -1}).private_();
     privateAgent.traceWriter.request_ = request; // Avoid authing
     cls.getNamespace().run(function() {
       queueSpans(2, privateAgent);

--- a/test/test-span-data.js
+++ b/test/test-span-data.js
@@ -21,12 +21,20 @@ if (!process.env.GCLOUD_PROJECT) {
   process.exit(1);
 }
 
-var agent = require('..')().startAgent({ samplingRate: 0 }).private_();
 var TraceLabels = require('../src/trace-labels.js');
 var assert = require('assert');
 var cls = require('../src/cls.js');
 
 describe('SpanData', function() {
+
+  var agent;
+  beforeEach(function() {
+    agent = require('..')().startAgent({ samplingRate: 0 }).private_();
+  });
+
+  afterEach(function() {
+    agent.stop();
+  });
 
   it('has correct default values', function() {
     cls.getNamespace().run(function() {

--- a/test/test-span-data.js
+++ b/test/test-span-data.js
@@ -21,7 +21,7 @@ if (!process.env.GCLOUD_PROJECT) {
   process.exit(1);
 }
 
-var agent = require('..').start({ samplingRate: 0 }).private_();
+var agent = require('..')().startAgent({ samplingRate: 0 }).private_();
 var TraceLabels = require('../src/trace-labels.js');
 var assert = require('assert');
 var cls = require('../src/cls.js');

--- a/test/test-trace-agent.js
+++ b/test/test-trace-agent.js
@@ -27,7 +27,12 @@ var assert = require('assert');
 var config = require('../config.js');
 var file = require('../src/trace-agent.js');
 var SpanData = require('../src/span-data.js');
-var agent = file.get(config);
+var agent = file.get(config, {
+  debug: function() {},
+  warn: function() {},
+  error: function() {},
+  info: function() {}
+});
 var constants = require('../src/constants.js');
 var cls = require('../src/cls.js');
 


### PR DESCRIPTION
Now this module exports a constructor.  In addition, the `start`
method has been renamed to `startAgent`.  These changes were made
to more closely align this module with the other Google Cloud API
Client Libraries via the `google-cloud` modules in [1].

[1]: https://github.com/GoogleCloudPlatform/google-cloud-node