### PR TITLE
Test/fix sed sys variance

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,3 +1,4 @@
+
 {
   "name": "@google/cloud-trace",
   "version": "0.5.10",

--- a/package.json
+++ b/package.json
@@ -1,4 +1,3 @@
-
 {
   "name": "@google/cloud-trace",
   "version": "0.5.10",

--- a/test/non-interference/http-e2e.js
+++ b/test/non-interference/http-e2e.js
@@ -39,7 +39,9 @@ cp.execFileSync('git', ['clone', '--branch', process.version,
     'https://github.com/nodejs/node.git', '--depth', '1', node_dir]);
 fs.mkdirSync(path.join(node_dir, 'test', 'tmp'));
 console.log('Turning off global checks');
-cp.execFileSync('sed', ['-i', 's/exports.globalCheck = true/' +
+// The use of the -i flag as '-i.bak' to specify a backup extension of '.bak'
+// is needed to ensure that the command works on both Linux and OS X
+cp.execFileSync('sed', ['-i.bak', 's/exports.globalCheck = true/' +
     'exports.globalCheck = false/g', path.join(node_dir, 'test', 'common.js')]);
 var test_glob = semver.satisfies(process.version, '0.12.x') ?
     path.join(node_dir, 'test', 'simple', 'test-http*.js') :
@@ -66,7 +68,9 @@ glob(test_glob, function(err, files) {
       console.log('Skipped: ' + files[testCount]);
       continue;
     }
-    cp.execFileSync('sed', ['-i', 's#\'use strict\';#' +
+    // The use of the -i flag as '-i.bak' to specify a backup extension of 
+    // '.bak' is needed to ensure that the command works on both Linux and OS X
+    cp.execFileSync('sed', ['-i.bak', 's#\'use strict\';#' +
         '\'use strict\';' + gcloud_require + '#g', files[testCount]]);
     if (cp.spawnSync('grep', ['-q', gcloud_require, files[testCount]]).status) {
       cp.execSync('echo "' + gcloud_require + '" | cat - ' + files[testCount] +


### PR DESCRIPTION
`sed` was being used in the `http-e2e.js` test with the `-i` flag
to perform changes in-place.  However, this option has a different
syntax on OS X vs Linux.  As a fix, `-i.bak` is now used to
explicitly specify a backup extension works on both OS X and
Linux.

The command has been tested on OS X and Debian.