### PR TITLE
Fix gRPC Server root span reference issue

### DIFF
--- a/src/hooks/userspace/hook-grpc.js
+++ b/src/hooks/userspace/hook-grpc.js
@@ -176,10 +176,11 @@ function wrapUnary(namespace, handlerSet, requestName) {
         // args[1] is the callback.
         // Here, we patch the callback so that the span is ended immediately
         // beforehand.
+        args = Array.prototype.slice.call(args);
         args[1] = function (err, result, trailer, flags) {
           if (agent.config_.enhancedDatabaseReporting) {
             if (err) {
-              rootContext.addLabel('error', err);
+              rootContext.addLabel('error', err); 
             } else {
               rootContext.addLabel('result', JSON.stringify(result));
             }
@@ -277,6 +278,7 @@ function wrapClientStream(namespace, handlerSet, requestName) {
         // args[1] is the callback.
         // Here, we patch the callback so that the span is ended immediately
         // beforehand.
+        args = Array.prototype.slice.call(args);
         args[1] = function (err, result, trailer, flags) {
           if (agent.config_.enhancedDatabaseReporting) {
             if (err) {

--- a/src/hooks/userspace/hook-grpc.js
+++ b/src/hooks/userspace/hook-grpc.js
@@ -161,12 +161,12 @@ function sendMetadataWrapper(rootContext) {
  */
 function wrapUnary(namespace, handlerSet, requestName) {
   shimmer.wrap(handlerSet, 'func', function (func) {
-    return function funcTrace(call, callback) {
+    return function serverMethodTrace(call, callback) {
       var that = this;
       var args = arguments;
       // Running in the namespace here propagates context to func.
       return namespace.runAndReturn(function() {
-        var rootContext = startRootSpanForRequest(requestName);
+        var rootContext = startRootSpanForRequest(requestName, 5);
         if (agent.config_.enhancedDatabaseReporting) {
           shimmer.wrap(call, 'sendMetadata', sendMetadataWrapper(rootContext));
         }
@@ -205,12 +205,12 @@ function wrapUnary(namespace, handlerSet, requestName) {
  */
 function wrapServerStream(namespace, handlerSet, requestName) {
   shimmer.wrap(handlerSet, 'func', function (func) {
-    return function funcTrace(stream) {
+    return function serverMethodTrace(stream) {
       var that = this;
       var args = arguments;
       // Running in the namespace here propagates context to func.
       return namespace.runAndReturn(function() {
-        var rootContext = startRootSpanForRequest(requestName);
+        var rootContext = startRootSpanForRequest(requestName, 5);
         if (agent.config_.enhancedDatabaseReporting) {
           shimmer.wrap(stream, 'sendMetadata', sendMetadataWrapper(rootContext));
         }
@@ -258,12 +258,12 @@ function wrapServerStream(namespace, handlerSet, requestName) {
  */
 function wrapClientStream(namespace, handlerSet, requestName) {
   shimmer.wrap(handlerSet, 'func', function (func) {
-    return function funcTrace(stream, callback) {
+    return function serverMethodTrace(stream, callback) {
       var that = this;
       var args = arguments;
       // Running in the namespace here propagates context to func.
       return namespace.runAndReturn(function() {
-        var rootContext = startRootSpanForRequest(requestName);
+        var rootContext = startRootSpanForRequest(requestName, 5);
         if (agent.config_.enhancedDatabaseReporting) {
           shimmer.wrap(stream, 'sendMetadata', sendMetadataWrapper(rootContext));
         }
@@ -306,12 +306,12 @@ function wrapClientStream(namespace, handlerSet, requestName) {
  */
 function wrapBidi(namespace, handlerSet, requestName) {
   shimmer.wrap(handlerSet, 'func', function (func) {
-    return function funcTrace(stream) {
+    return function serverMethodTrace(stream) {
       var that = this;
       var args = arguments;
       // Running in the namespace here propagates context to func.
       return namespace.runAndReturn(function() {
-        var rootContext = startRootSpanForRequest(requestName);
+        var rootContext = startRootSpanForRequest(requestName, 5);
         if (agent.config_.enhancedDatabaseReporting) {
           shimmer.wrap(stream, 'sendMetadata', sendMetadataWrapper(rootContext));
         }
@@ -390,8 +390,8 @@ function serverRegisterWrap(register) {
  * @param {Object} req The request being processed.
  * @returns {!SpanData} The new initialized trace span data instance.
  */
-function startRootSpanForRequest(req) {
-  var rootContext = agent.createRootSpanData(req, null, null, 1);
+function startRootSpanForRequest(req, skipFrames) {
+  var rootContext = agent.createRootSpanData(req, null, null, skipFrames);
   return rootContext;
 }
 

--- a/src/hooks/userspace/hook-grpc.js
+++ b/src/hooks/userspace/hook-grpc.js
@@ -233,7 +233,7 @@ function wrapServerStream(namespace, handlerSet, requestName) {
           }
           endSpan();
         });
-        return func.apply(this, args);
+        return func.apply(that, args);
       });
     };
   });

--- a/test/hooks/common.js
+++ b/test/hooks/common.js
@@ -69,6 +69,14 @@ function getMatchingSpans(predicate) {
   return list;
 }
 
+function assertSpanDurationCorrect(span) {
+  var duration = Date.parse(span.endTime) - Date.parse(span.startTime);
+  assert(duration > SERVER_WAIT * (1 - FORGIVENESS),
+      'Duration was ' + duration + ', expected ' + SERVER_WAIT);
+  assert(duration < SERVER_WAIT * (1 + FORGIVENESS),
+      'Duration was ' + duration + ', expected ' + SERVER_WAIT);
+}
+
 /**
  * Verifies that the duration of the span captured
  * by the tracer matching the predicate `predicate`
@@ -86,11 +94,7 @@ function assertDurationCorrect(predicate) {
   // by the harness itself
   predicate = predicate || function(span) { return span.name !== 'outer'; };
   var span = getMatchingSpan(predicate);
-  var duration = Date.parse(span.endTime) - Date.parse(span.startTime);
-  assert(duration > SERVER_WAIT * (1 - FORGIVENESS),
-      'Duration was ' + duration + ', expected ' + SERVER_WAIT);
-  assert(duration < SERVER_WAIT * (1 + FORGIVENESS),
-      'Duration was ' + duration + ', expected ' + SERVER_WAIT);
+  assertSpanDurationCorrect(span);
 }
 
 function doRequest(method, done, tracePredicate, path) {
@@ -133,6 +137,7 @@ function createChildSpan(cb, duration) {
 }
 
 module.exports = {
+  assertSpanDurationCorrect: assertSpanDurationCorrect,
   assertDurationCorrect: assertDurationCorrect,
   cleanTraces: cleanTraces,
   getMatchingSpan: getMatchingSpan,

--- a/test/hooks/common.js
+++ b/test/hooks/common.js
@@ -114,12 +114,31 @@ function runInTransaction(fn) {
   });
 }
 
+// Creates a child span that closes after the given duration.
+// Also calls cb after that duration.
+// Returns a method which, when called, closes the child span
+// right away and cancels callback from being called after the duration.
+function createChildSpan(cb, duration) {
+  var span = agent.startSpan('inner');
+  var t = setTimeout(function() {
+    agent.endSpan(span);
+    if (cb) {
+      cb();
+    }
+  }, duration);
+  return function() {
+    agent.endSpan(span);
+    clearTimeout(t);
+  };
+}
+
 module.exports = {
   assertDurationCorrect: assertDurationCorrect,
   cleanTraces: cleanTraces,
   getMatchingSpan: getMatchingSpan,
   getMatchingSpans: getMatchingSpans,
   doRequest: doRequest,
+  createChildSpan: createChildSpan,
   getTraces: getTraces,
   runInTransaction: runInTransaction,
   serverWait: SERVER_WAIT,

--- a/test/hooks/test-trace-grpc.js
+++ b/test/hooks/test-trace-grpc.js
@@ -299,23 +299,23 @@ Object.keys(versions).forEach(function(version) {
                 common.assertSpanDurationCorrect(traces[1]);
                 setImmediate(prevNext);
               }
-            }
+            };
             first(callback);
             setTimeout(function() {
               second(callback);
             }, common.serverWait / 2);
           });
-        }
-      }
+        };
+      };
 
       // Define the gRPC calls.
-      var callUnary = function(cb) {
+      function callUnary(cb) {
         client.testUnary({n: 42}, function(err, result) {
           assert.ifError(err);
           cb();
         });
       }
-      var callClientStream = function(cb) {
+      function callClientStream(cb) {
         var stream = client.testClientStream(function(err, result) {
           assert.ifError(err);
           cb();
@@ -325,7 +325,7 @@ Object.keys(versions).forEach(function(version) {
         }
         stream.end();
       }
-      var callServerStream = function(cb) {
+      function callServerStream(cb) {
         var stream = client.testServerStream({n: 42});
         var sum = 0;
         stream.on('data', function(data) {
@@ -333,7 +333,7 @@ Object.keys(versions).forEach(function(version) {
         });
         stream.on('status', cb);
       }
-      var callBidi = function(cb) {
+      function callBidi(cb) {
         var stream = client.testBidiStream();
         var sum = 0;
         stream.on('data', function(data) {


### PR DESCRIPTION
Calling gRPC server functions would clobber references to root span objects (causing them to either never end, or end at the wrong time) because they are stored in the scope of the patching function (`wrapUnary`, `wrapClientStream`, etc.).

This change fixes that by putting a reference to the root span in the scope of the `func` handler, so a root span can exist per gRPC call.

In addition, unit tests were added/modified:
- to ensure that interleaved gRPC call traces don't interfere with one another.
- to ensure that context is being propagated correctly to call handlers, by creating child spans in these handlers.
- to ensure that gRPC server call traces include the correct subset of stack frames.