### PR TITLE
Follow-Up Fixes for gRPC

### DIFF
--- a/test/hooks/common.js
+++ b/test/hooks/common.js
@@ -29,7 +29,7 @@ var shouldTrace = agent.shouldTrace;
 agent.shouldTrace = function() {
   agent._shouldTraceArgs.push([].slice.call(arguments, 0));
   return shouldTrace.apply(this, arguments);
-}
+};
 
 var cls = require('../../src/cls.js');
 
@@ -145,10 +145,6 @@ function createChildSpan(cb, duration) {
     agent.endSpan(span);
     clearTimeout(t);
   };
-}
-
-function getAndResetShouldTraceArguments() {
-  return shouldTraceArgs;
 }
 
 module.exports = {

--- a/test/hooks/test-trace-grpc.js
+++ b/test/hooks/test-trace-grpc.js
@@ -19,6 +19,7 @@ var common = require('./common.js');
 require('../..').private_().config_.enhancedDatabaseReporting = true;
 var assert = require('assert');
 var traceLabels = require('../../src/trace-labels.js');
+var findIndex = require('lodash.findindex');
 
 var versions = {
   grpc1: require('./fixtures/grpc1')
@@ -148,6 +149,56 @@ Object.keys(versions).forEach(function(version) {
         grpc.credentials.createInsecure());
   }
 
+  function callUnary(cb) {
+    client.testUnary({n: 42}, function(err, result) {
+      assert.ifError(err);
+      assert.strictEqual(result.n, 42);
+      cb();
+    });
+  }
+
+  function callClientStream(cb) {
+    var stream = client.testClientStream(function(err, result) {
+      assert.ifError(err);
+      assert.strictEqual(result.n, 45);
+      cb();
+    });
+    for (var i = 0; i < 10; ++i) {
+      stream.write({n: i});
+    }
+    stream.end();
+  }
+
+  function callServerStream(cb) {
+    var stream = client.testServerStream({n: 42});
+    var sum = 0;
+    stream.on('data', function(data) {
+      sum += data.n;
+    });
+    stream.on('status', function(status) {
+      assert.strictEqual(status.code, grpc.status.OK);
+      assert.strictEqual(sum, 45);
+      cb();
+    });
+  }
+
+  function callBidi(cb) {
+    var stream = client.testBidiStream();
+    var sum = 0;
+    stream.on('data', function(data) {
+      sum += data.n;
+    });
+    for (var i = 0; i < 10; ++i) {
+      stream.write({n: i});
+    }
+    stream.end();
+    stream.on('status', function(status) {
+      assert.strictEqual(status.code, grpc.status.OK);
+      assert.strictEqual(sum, 45);
+      cb();
+    });
+  }
+
   describe(version, function() {
     before(function() {
       var proto = grpc.load(protoFile).nodetest;
@@ -165,10 +216,8 @@ Object.keys(versions).forEach(function(version) {
 
     it('should accurately measure time for unary requests', function(done) {
       common.runInTransaction(function(endTransaction) {
-        client.testUnary({n: 42}, function(err, result) {
+        callUnary(function() {
           endTransaction();
-          assert.ifError(err);
-          assert.strictEqual(result.n, 42);
           var assertTraceProperties = function(predicate) {
             var trace = common.getMatchingSpan(predicate);
             assert(trace);
@@ -180,6 +229,7 @@ Object.keys(versions).forEach(function(version) {
           assertTraceProperties(grpcServerOuterPredicate);
           // Check that a child span was created in gRPC root span 
           assert(common.getMatchingSpan(grpcServerInnerPredicate));
+          // var shouldTraceArgs = common.getShouldTraceArgs();
           done();
         });
       });
@@ -187,10 +237,8 @@ Object.keys(versions).forEach(function(version) {
 
     it('should accurately measure time for client streaming requests', function(done) {
       common.runInTransaction(function(endTransaction) {
-        var stream = client.testClientStream(function(err, result) {
+        callClientStream(function() {
           endTransaction();
-          assert.ifError(err);
-          assert.strictEqual(result.n, 45);
           var assertTraceProperties = function(predicate) {
             var trace = common.getMatchingSpan(predicate);
             assert(trace);
@@ -203,24 +251,13 @@ Object.keys(versions).forEach(function(version) {
           assert(common.getMatchingSpan(grpcServerInnerPredicate));
           done();
         });
-        for (var i = 0; i < 10; ++i) {
-          stream.write({n: i});
-        }
-        stream.end();
       });
     });
 
     it('should accurately measure time for server streaming requests', function(done) {
       common.runInTransaction(function(endTransaction) {
-        var stream = client.testServerStream({n: 42});
-        var sum = 0;
-        stream.on('data', function(data) {
-          sum += data.n;
-        });
-        stream.on('status', function(status) {
+        callServerStream(function() {
           endTransaction();
-          assert.strictEqual(status.code, grpc.status.OK);
-          assert.strictEqual(sum, 45);
           var assertTraceProperties = function(predicate) {
             var trace = common.getMatchingSpan(predicate);
             assert(trace);
@@ -241,19 +278,8 @@ Object.keys(versions).forEach(function(version) {
 
     it('should accurately measure time for bidi streaming requests', function(done) {
       common.runInTransaction(function(endTransaction) {
-        var stream = client.testBidiStream();
-        var sum = 0;
-        stream.on('data', function(data) {
-          sum += data.n;
-        });
-        for (var i = 0; i < 10; ++i) {
-          stream.write({n: i});
-        }
-        stream.end();
-        stream.on('status', function(status) {
+        callBidi(function() {
           endTransaction();
-          assert.strictEqual(status.code, grpc.status.OK);
-          assert.strictEqual(sum, 45);
           var assertTraceProperties = function(predicate) {
             var trace = common.getMatchingSpan(predicate);
             assert(trace);
@@ -272,12 +298,41 @@ Object.keys(versions).forEach(function(version) {
     });
 
     it('should not break if no parent transaction', function(done) {
-      client.testUnary({n: 42}, function(err, result) {
-        assert.ifError(err);
-        assert.strictEqual(result.n, 42);
+      callUnary(function() {
         assert.strictEqual(common.getMatchingSpans(grpcClientPredicate).length, 0);
         done();
       });
+    });
+
+    it('should respect the tracing policy', function(done) {
+      var next = function() {
+        var args = common.getShouldTraceArgs();
+        assert.strictEqual(args.length, 4,
+          'expected one call for each of four gRPC method types but got ' +
+          args.length + ' instead');
+        for (var i = 0; i < args.length; i++) {
+          assert.strictEqual(args[i].length, 1);
+        }
+        var prefix = 'grpc:/nodetest.Tester/Test';
+        assert.notStrictEqual(findIndex(args, function(arg) {
+          return arg[0] === prefix + 'Unary';
+        }, -1));
+        assert.notStrictEqual(findIndex(args, function(arg) {
+          return arg[0] === prefix + 'ClientStream';
+        }, -1));
+        assert.notStrictEqual(findIndex(args, function(arg) {
+          return arg[0] === prefix + 'ServerStream';
+        }, -1));
+        assert.notStrictEqual(findIndex(args, function(arg) {
+          return arg[0] === prefix + 'BidiStream';
+        }, -1));
+        done();
+      }
+      next = callUnary.bind(null, next);
+      next = callClientStream.bind(null, next);
+      next = callServerStream.bind(null, next);
+      next = callBidi.bind(null, next);
+      next();
     });
 
     it('should not let root spans interfere with one another', function(done) {
@@ -312,44 +367,6 @@ Object.keys(versions).forEach(function(version) {
           });
         };
       };
-
-      // Define the gRPC calls.
-      function callUnary(cb) {
-        client.testUnary({n: 42}, function(err, result) {
-          assert.ifError(err);
-          cb();
-        });
-      }
-      function callClientStream(cb) {
-        var stream = client.testClientStream(function(err, result) {
-          assert.ifError(err);
-          cb();
-        });
-        for (var i = 0; i < 10; ++i) {
-          stream.write({n: i});
-        }
-        stream.end();
-      }
-      function callServerStream(cb) {
-        var stream = client.testServerStream({n: 42});
-        var sum = 0;
-        stream.on('data', function(data) {
-          sum += data.n;
-        });
-        stream.on('status', cb);
-      }
-      function callBidi(cb) {
-        var stream = client.testBidiStream();
-        var sum = 0;
-        stream.on('data', function(data) {
-          sum += data.n;
-        });
-        for (var i = 0; i < 10; ++i) {
-          stream.write({n: i});
-        }
-        stream.end();
-        stream.on('status', cb);
-      }
 
       // Call queueCallTogether with every possible pair of gRPC calls.
       var methods = [ callUnary, callClientStream, callServerStream, callBidi ];

--- a/test/hooks/test-trace-grpc.js
+++ b/test/hooks/test-trace-grpc.js
@@ -327,7 +327,7 @@ Object.keys(versions).forEach(function(version) {
           return arg[0] === prefix + 'BidiStream';
         }, -1));
         done();
-      }
+      };
       next = callUnary.bind(null, next);
       next = callClientStream.bind(null, next);
       next = callServerStream.bind(null, next);


### PR DESCRIPTION
* Slight `wrap`-function doc change to reflect previous changes
* Comments summarizing start and end span points
* Check `agent.shouldTrace` to determine whether span should actually be started
* Renamed `func` object to `serverMethod` internally (less confusion)
* No longer dealing with `arguments` - `apply` calls changed to `call` with actual arguments
* Collapse consecutive `if` statements with identical conditions
* `switch` instead of `if...else if` statement for picking `wrap` function