### PR TITLE
The module now exports a constructor

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ This module provides Stackdriver Trace support for Node.js applications. [Stackd
 
 3. Include and start the library *as the very first action in your application*:
 
-        require('@google/cloud-trace').start();
+        require('@google/cloud-trace')().startAgent();
 
   If you use `--require` in your start up command, make sure that the trace agent is --required first.
 
@@ -47,7 +47,7 @@ If you are running somewhere other than the Google Cloud Platform, see [running 
 
 See [the default configuration](config.js) for a list of possible configuration options. These options can be passed to the agent through the object argument to the start command shown above:
 
-        require('@google/cloud-trace').start({samplingRate: 500});
+        require('@google/cloud-trace')().startAgent({samplingRate: 500});
 
 Alternatively, you can provide configuration through a config file. This can be useful if you want to load our module using `--require` on the command line instead of editing your main script. You can start by copying the default config file and modifying it to suit your needs. The `GCLOUD_DIAGNOSTICS_CONFIG` environment variable should point to your configuration file.
 
@@ -142,7 +142,7 @@ For any of the web frameworks listed above (`express`, `hapi`, and `restify`), a
 The API is exposed by the `agent` returned by a call to `start`:
 
 ```javascript
-  var agent = require('@google/cloud-trace').start();
+  var agent = require('@google/cloud-trace')().startAgent();
 ```
 
 For child spans, you can either use the `startSpan` and `endSpan` API, or use the `runInSpan` function that uses a callback-style. For root spans, you must use `runInRootSpan`.

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ This module provides Stackdriver Trace support for Node.js applications. [Stackd
 
 3. Include and start the library *as the very first action in your application*:
 
-        require('@google/cloud-trace')().startAgent();
+        var agent = require('@google/cloud-trace')().startAgent();
 
   If you use `--require` in your start up command, make sure that the trace agent is --required first.
 

--- a/bin/run-test.sh
+++ b/bin/run-test.sh
@@ -39,27 +39,11 @@ function run {
 }
 
 # Run test/coverage
-run test/test-constants.js
-run test/test-span-data.js
+run `find test -name '*.js' -depth 1 -not -name test-trace-agent.js`
 run test/test-trace-agent.js
-run test/test-trace-policy.js
-run test/test-trace-span.js
-run test/test-trace.js
-run test/test-util.js
 
-run test/hooks/common.js
-run test/hooks/test-hooks-index.js
-run test/hooks/test-hooks-interop-mongo-express.js
-run test/hooks/test-trace-connect.js
+run `find test/hooks -name '*.js' -depth 1 -not -name test-trace-express.js`
 run test/hooks/test-trace-express.js
-run test/hooks/test-trace-grpc.js
-run test/hooks/test-trace-hapi.js
-run test/hooks/test-trace-http.js
-run test/hooks/test-trace-mongodb.js
-run test/hooks/test-trace-mongoose.js
-run test/hooks/test-trace-mysql.js
-run test/hooks/test-trace-redis.js
-run test/hooks/test-trace-restify.js
 
 for test in test/standalone/test-*.js ;
 do

--- a/bin/run-test.sh
+++ b/bin/run-test.sh
@@ -39,11 +39,8 @@ function run {
 }
 
 # Run test/coverage
-run `find test -maxdepth 1 -name '*.js' -not -name test-trace-agent.js`
-run test/test-trace-agent.js
-
-run test/hooks/*.js
-
+run test
+run test/hooks
 for test in test/standalone/test-*.js ;
 do
   if [[ ! $(node --version) =~ v0\.12\..* || ! "${test}" =~ .*trace\-koa\.js ]]

--- a/bin/run-test.sh
+++ b/bin/run-test.sh
@@ -39,10 +39,10 @@ function run {
 }
 
 # Run test/coverage
-run `find test -name '*.js' -depth 1 -not -name test-trace-agent.js`
+run `find test -maxdepth 1 -name '*.js' -not -name test-trace-agent.js`
 run test/test-trace-agent.js
 
-run `find test/hooks -name '*.js' -depth 1 -not -name test-trace-express.js`
+run `find test/hooks -maxdepth 1 -name '*.js' -not -name test-trace-express.js`
 run test/hooks/test-trace-express.js
 
 for test in test/standalone/test-*.js ;

--- a/bin/run-test.sh
+++ b/bin/run-test.sh
@@ -42,8 +42,7 @@ function run {
 run `find test -maxdepth 1 -name '*.js' -not -name test-trace-agent.js`
 run test/test-trace-agent.js
 
-run `find test/hooks -maxdepth 1 -name '*.js' -not -name test-trace-express.js`
-run test/hooks/test-trace-express.js
+run test/hooks/*.js
 
 for test in test/standalone/test-*.js ;
 do

--- a/bin/run-test.sh
+++ b/bin/run-test.sh
@@ -39,7 +39,12 @@ function run {
 }
 
 # Run test/coverage
-run test test/hooks
+run test
+for test in test/hooks/*.js ;
+do
+  run "${test}"
+done
+
 for test in test/standalone/test-*.js ;
 do
   if [[ ! $(node --version) =~ v0\.12\..* || ! "${test}" =~ .*trace\-koa\.js ]]

--- a/bin/run-test.sh
+++ b/bin/run-test.sh
@@ -40,7 +40,7 @@ function run {
 
 # Run test/coverage
 run test
-for test in test/hooks/*.js ;
+for test in test/hooks/*.js
 do
   run "${test}"
 done

--- a/bin/run-test.sh
+++ b/bin/run-test.sh
@@ -39,11 +39,27 @@ function run {
 }
 
 # Run test/coverage
-run test
-for test in test/hooks/*.js
-do
-  run "${test}"
-done
+run test/test-constants.js
+run test/test-span-data.js
+run test/test-trace-agent.js
+run test/test-trace-policy.js
+run test/test-trace-span.js
+run test/test-trace.js
+run test/test-util.js
+
+run test/hooks/common.js
+run test/hooks/test-hooks-index.js
+run test/hooks/test-hooks-interop-mongo-express.js
+run test/hooks/test-trace-connect.js
+run test/hooks/test-trace-express.js
+run test/hooks/test-trace-grpc.js
+run test/hooks/test-trace-hapi.js
+run test/hooks/test-trace-http.js
+run test/hooks/test-trace-mongodb.js
+run test/hooks/test-trace-mongoose.js
+run test/hooks/test-trace-mysql.js
+run test/hooks/test-trace-redis.js
+run test/hooks/test-trace-restify.js
 
 for test in test/standalone/test-*.js ;
 do

--- a/index.js
+++ b/index.js
@@ -94,6 +94,7 @@ var initConfig = function(projectConfig) {
  * The singleton public agent. This is the public API of the module.
  */
 var publicAgent = {
+  // FOR_TESTING_ONLY
   __DISABLE_START_CHECK__: false,
 
   _disableStartCheck: function() {
@@ -102,6 +103,10 @@ var publicAgent = {
   },
 
   isActive: function() {
+    // TODO: The use of agent.isRunning() is only needed because the
+    //       _private() function is used in testing.
+    //       Remove the _private() function so that agent.isRunning()
+    //       can be removed.
     return agent !== phantomTraceAgent && agent.isRunning();
   },
 
@@ -134,8 +139,7 @@ var publicAgent = {
       var message = 'Cannot call start on an already started agent.';
       if (this.__DISABLE_START_CHECK__) {
         console.log(message);
-      }
-      else {
+      } else {
         throw new Error(message);
       }
     }

--- a/index.js
+++ b/index.js
@@ -252,6 +252,7 @@ var publicAgent = {
  *
  * @param {object} options - [Configuration object](#/docs)
  */
+// TODO: Remove this constructor.
 function Trace(options) {
   if (!(this instanceof Trace)) {
     return new Trace(options);

--- a/index.js
+++ b/index.js
@@ -94,14 +94,6 @@ var initConfig = function(projectConfig) {
  * The singleton public agent. This is the public API of the module.
  */
 var publicAgent = {
-  // FOR_TESTING_ONLY
-  __DISABLE_START_CHECK__: false,
-
-  _disableStartCheck: function() {
-    this.__DISABLE_START_CHECK__ = true;
-    return this;
-  },
-
   isActive: function() {
     // TODO: The use of agent.isRunning() is only needed because the
     //       _private() function is used in testing.
@@ -135,16 +127,11 @@ var publicAgent = {
   },
 
   startAgent: function(projectConfig) {
-    if (this.isActive()) { // already started.
-      var message = 'Cannot call start on an already started agent.';
-      if (this.__DISABLE_START_CHECK__) {
-        console.log(message);
-      } else {
-        throw new Error(message);
-      }
-    }
-
     var config = initConfig(projectConfig);
+
+    if (this.isActive() && !config.forceNewAgent_) { // already started.
+      throw new Error('Cannot call start on an already started agent.');
+    }
 
     if (!config.enabled) {
       return this;

--- a/src/trace-agent.js
+++ b/src/trace-agent.js
@@ -69,6 +69,9 @@ TraceAgent.prototype.isRunning = function() {
  * Halts this agent and unpatches any patched modules.
  */
 TraceAgent.prototype.stop = function() {
+  // TODO: This property is only needed because of the way the tests are
+  //       implemented.  Change the tests so that this property is not
+  //       needed.
   this.running = false;
   hooks.deactivate();
   pluginLoader.deactivate();

--- a/src/trace-agent.js
+++ b/src/trace-agent.js
@@ -47,9 +47,8 @@ function TraceAgent(config, logger) {
   this.policy = tracingPolicy.createTracePolicy(config);
 
   if (config.onUncaughtException !== 'ignore') {
-    var that = this;
     this.unhandledException = function() {
-      that.traceWriter.flushBuffer_(that.config_.projectId);
+      traceAgent.traceWriter.flushBuffer_(traceAgent.config_.projectId);
       if (config.onUncaughtException === 'flushAndExit') {
         setTimeout(function() {
           process.exit(1);

--- a/test/fixtures/preloaded-agent.js
+++ b/test/fixtures/preloaded-agent.js
@@ -16,7 +16,8 @@
 'use strict';
 
 var assert = require('assert');
-var agent = require('../../');
+var agent = require('../../')();
 
 assert(agent.isActive());
+agent.get().stop();
 console.log('Preload test passed.');

--- a/test/fixtures/start-agent.js
+++ b/test/fixtures/start-agent.js
@@ -17,4 +17,4 @@
 
 process.env.GCLOUD_TRACE_LOGLEVEL = 4;
 require('glob'); // Load a module before agent
-require('../..').start();
+require('../..')().startAgent();

--- a/test/hooks/common.js
+++ b/test/hooks/common.js
@@ -20,16 +20,8 @@ if (!process.env.GCLOUD_PROJECT) {
   process.exit(1);
 }
 
-var config = { enhancedDatabaseReporting: true, samplingRate: 0 };
-var agent = require('../..').start(config).private_();
 // We want to disable publishing to avoid conflicts with production.
-agent.traceWriter.publish_ = function() {};
-agent._shouldTraceArgs = [];
-var shouldTrace = agent.shouldTrace;
-agent.shouldTrace = function() {
-  agent._shouldTraceArgs.push([].slice.call(arguments, 0));
-  return shouldTrace.apply(this, arguments);
-};
+require('../../src/trace-writer').publish_ = function() {};
 
 var cls = require('../../src/cls.js');
 
@@ -45,32 +37,66 @@ var SERVER_RES = '1729';
 var SERVER_KEY = fs.readFileSync(path.join(__dirname, 'fixtures', 'key.pem'));
 var SERVER_CERT = fs.readFileSync(path.join(__dirname, 'fixtures', 'cert.pem'));
 
+function init(agent) {
+  agent._shouldTraceArgs = [];
+  var shouldTrace = agent.shouldTrace;
+  agent.shouldTrace = function() {
+    agent._shouldTraceArgs.push([].slice.call(arguments, 0));
+    return shouldTrace.apply(this, arguments);
+  };
+}
+
 /**
  * Cleans the tracer state between test runs.
  */
-function cleanTraces() {
+function cleanTraces(agent) {
+  if (arguments.length !== 1) {
+    throw new Error('cleanTraces() expected 1 argument.  ' +
+      'Received: ' + arguments.length);
+  }
+
   agent.traceWriter.buffer_ = [];
   agent._shouldTraceArgs = [];
 }
 
-function getTraces() {
+function getTraces(agent) {
+  if (arguments.length !== 1) {
+    throw new Error('getTraces() expected 1 argument.  ' +
+      'Received: ' + arguments.length);
+  }
+
   return agent.traceWriter.buffer_.map(JSON.parse);
 }
 
-function getShouldTraceArgs() {
+function getShouldTraceArgs(agent) {
+  if (arguments.length !== 1) {
+    throw new Error('getSHouldTraceArgs() expected 1 argument.  ' +
+      'Received: ' + arguments.length);
+  }
+
   return agent._shouldTraceArgs;
 }
 
-function getMatchingSpan(predicate) {
-  var spans = getMatchingSpans(predicate);
+function getMatchingSpan(agent, predicate) {
+  if (arguments.length !== 2) {
+    throw new Error('getMatchingSpan() expected 2 arguments.  ' +
+      'Received: ' + arguments.length);
+  }
+
+  var spans = getMatchingSpans(agent, predicate);
   assert.equal(spans.length, 1,
     'predicate did not isolate a single span');
   return spans[0];
 }
 
-function getMatchingSpans(predicate) {
+function getMatchingSpans(agent, predicate) {
+  if (arguments.length !== 2) {
+    throw new Error('getMatchingSpans() expected 2 arguments.  ' +
+      'Received: ' + arguments.length);
+  }
+
   var list = [];
-  getTraces().forEach(function(trace) {
+  getTraces(agent).forEach(function(trace) {
     trace.spans.forEach(function(span) {
       if (predicate(span)) {
         list.push(span);
@@ -81,6 +107,11 @@ function getMatchingSpans(predicate) {
 }
 
 function assertSpanDurationCorrect(span) {
+  if (arguments.length !== 1) {
+    throw new Error('assertSpanDurationCorrect() expected 1 argument.  ' +
+      'Received: ' + arguments.length);
+  }
+
   var duration = Date.parse(span.endTime) - Date.parse(span.startTime);
   assert(duration > SERVER_WAIT * (1 - FORGIVENESS),
       'Duration was ' + duration + ', expected ' + SERVER_WAIT);
@@ -100,27 +131,42 @@ function assertSpanDurationCorrect(span) {
  *
  * @param {function(?)=} predicate
  */
-function assertDurationCorrect(predicate) {
+function assertDurationCorrect(agent, predicate) {
+  if (arguments.length !== 2) {
+    throw new Error('assertDurationCorrect() expected 2 arguments.  ' +
+      'Received: ' + arguments.length);
+  }
+
   // We assume that the tests never care about top level transactions created
   // by the harness itself
   predicate = predicate || function(span) { return span.name !== 'outer'; };
-  var span = getMatchingSpan(predicate);
+  var span = getMatchingSpan(agent, predicate);
   assertSpanDurationCorrect(span);
 }
 
-function doRequest(method, done, tracePredicate, path) {
+function doRequest(agent, method, done, tracePredicate, path) {
+  if (arguments.length < 4) {
+    throw new Error('doRequest() expected at least 4 arguments.  ' +
+      'Received: ' + arguments.length);
+  }
+
   http.get({port: SERVER_PORT, method: method, path: path || '/'}, function(res) {
     var result = '';
     res.on('data', function(data) { result += data; });
     res.on('end', function() {
       assert.equal(SERVER_RES, result);
-      assertDurationCorrect(tracePredicate);
+      assertDurationCorrect(agent, tracePredicate);
       done();
     });
   });
 }
 
-function runInTransaction(fn) {
+function runInTransaction(agent, fn) {
+  if (arguments.length !== 2) {
+    throw new Error('runInTransaction() expected 2 arguments.  ' +
+      'Received: ' + arguments.length);
+  }
+
   cls.getNamespace().run(function() {
     var spanData = agent.createRootSpanData('outer');
     fn(function() {
@@ -133,7 +179,12 @@ function runInTransaction(fn) {
 // Also calls cb after that duration.
 // Returns a method which, when called, closes the child span
 // right away and cancels callback from being called after the duration.
-function createChildSpan(cb, duration) {
+function createChildSpan(agent, cb, duration) {
+  if (arguments.length !== 3) {
+    throw new Error('createChildSpan() expected 3 arguments.  ' +
+      'Received: ' + arguments.length);
+  }
+
   var span = agent.startSpan('inner');
   var t = setTimeout(function() {
     agent.endSpan(span);
@@ -148,6 +199,7 @@ function createChildSpan(cb, duration) {
 }
 
 module.exports = {
+  init: init,
   assertSpanDurationCorrect: assertSpanDurationCorrect,
   assertDurationCorrect: assertDurationCorrect,
   cleanTraces: cleanTraces,

--- a/test/hooks/common.js
+++ b/test/hooks/common.js
@@ -132,8 +132,8 @@ function assertSpanDurationCorrect(span) {
  * @param {function(?)=} predicate
  */
 function assertDurationCorrect(agent, predicate) {
-  if (arguments.length !== 2) {
-    throw new Error('assertDurationCorrect() expected 2 arguments.  ' +
+  if (arguments.length === 0) {
+    throw new Error('assertDurationCorrect() expected at lest one argument.  ' +
       'Received: ' + arguments.length);
   }
 

--- a/test/hooks/test-hooks-interop-mongo-express.js
+++ b/test/hooks/test-hooks-interop-mongo-express.js
@@ -22,6 +22,14 @@
 //   ex) docker run -p 27017:27017 -d mongo
 var common = require('./common.js');
 
+// TODO: Determine why this test succeeds but causes the
+//       test-trace-express.js test to fail if either of
+//       (1) or (2) are changed below.
+
+// (1) express needs to be required before the agent is
+//     started for this test and test-trace-express.js
+//     to both pass.
+var express = require('./fixtures/express4');
 var assert = require('assert');
 var http = require('http');
 
@@ -30,11 +38,9 @@ var server;
 describe('mongodb + express', function() {
   var agent;
   var oldDebug;
-  var express;
   var mongoose;
   before(function() {
     agent = require('../..')().startAgent().get().private_();
-    express = require('./fixtures/express4');
     mongoose = require('./fixtures/mongoose4');
     oldDebug = agent.logger.debug;
     agent.logger.debug = function(error) {
@@ -43,6 +49,10 @@ describe('mongodb + express', function() {
   });
 
   after(function() {
+    // (2) express needs to be deleted from the require cache
+    //     for this test and test-trace-express.js to both
+    //     pass.
+    delete require.cache[require.resolve('./fixtures/express4')];
     agent.stop();
   });
 

--- a/test/hooks/test-trace-connect.js
+++ b/test/hooks/test-trace-connect.js
@@ -20,13 +20,16 @@ var http = require('http');
 var assert = require('assert');
 var constants = require('../../src/constants.js');
 var common = require('./common.js');
-var connect = require('./fixtures/connect3');
 
 var server;
 var write;
 
 describe('test-trace-connect', function() {
+  var agent;
+  var connect;
   before(function() {
+    agent = require('../..')().startAgent({ samplingRate: 0 }).private_();
+    connect = require('./fixtures/connect3');
     // Mute stderr to satiate appveyor
     write = process.stderr.write;
     process.stderr.write = function(c, e, cb) {
@@ -39,10 +42,11 @@ describe('test-trace-connect', function() {
 
   after(function() {
     process.stderr.write = write;
+    agent.stop();
   });
 
   afterEach(function() {
-    common.cleanTraces();
+    common.cleanTraces(agent);
     server.close();
   });
 
@@ -54,7 +58,7 @@ describe('test-trace-connect', function() {
       }, common.serverWait);
     });
     server = app.listen(common.serverPort, function() {
-      common.doRequest('GET', done, connectPredicate);
+      common.doRequest(agent, 'GET', done, connectPredicate);
     });
   });
 
@@ -71,7 +75,7 @@ describe('test-trace-connect', function() {
       }, common.serverWait / 2);
     });
     server = app.listen(common.serverPort, function() {
-      common.doRequest('GET', done, connectPredicate);
+      common.doRequest(agent, 'GET', done, connectPredicate);
     });
   });
 
@@ -84,7 +88,7 @@ describe('test-trace-connect', function() {
       }, common.serverWait);
     });
     server = app.listen(common.serverPort, function() {
-      common.doRequest('GET', done, connectPredicate);
+      common.doRequest(agent, 'GET', done, connectPredicate);
     });
   });
 
@@ -95,7 +99,7 @@ describe('test-trace-connect', function() {
     });
     server = app.listen(common.serverPort, function() {
       http.get({port: common.serverPort}, function(res) {
-        var labels = common.getMatchingSpan(connectPredicate).labels;
+        var labels = common.getMatchingSpan(agent, connectPredicate).labels;
         assert.equal(labels[traceLabels.HTTP_RESPONSE_CODE_LABEL_KEY], '200');
         assert.equal(labels[traceLabels.HTTP_METHOD_LABEL_KEY], 'GET');
         assert.equal(labels[traceLabels.HTTP_URL_LABEL_KEY], 'http://localhost:9042/');
@@ -112,7 +116,7 @@ describe('test-trace-connect', function() {
     });
     server = app.listen(common.serverPort, function() {
       http.get({port: common.serverPort}, function(res) {
-        var labels = common.getMatchingSpan(connectPredicate).labels;
+        var labels = common.getMatchingSpan(agent, connectPredicate).labels;
         var stackTrace = JSON.parse(labels[traceLabels.STACK_TRACE_DETAILS_KEY]);
         // Ensure that our middleware is on top of the stack
         assert.equal(stackTrace.stack_frame[0].method_name, 'middleware');
@@ -128,7 +132,7 @@ describe('test-trace-connect', function() {
     });
     server = app.listen(common.serverPort, function() {
       http.get({path: '/?a=b', port: common.serverPort}, function(res) {
-        var span = common.getMatchingSpan(connectPredicate);
+        var span = common.getMatchingSpan(agent, connectPredicate);
         assert.equal(span.name, '/');
         done();
       });
@@ -142,7 +146,7 @@ describe('test-trace-connect', function() {
     });
     server = app.listen(common.serverPort, function() {
       http.get({port: common.serverPort}, function(res) {
-        var labels = common.getMatchingSpan(connectPredicate).labels;
+        var labels = common.getMatchingSpan(agent, connectPredicate).labels;
         assert.equal(labels[traceLabels.HTTP_RESPONSE_CODE_LABEL_KEY], '500');
         done();
       });

--- a/test/hooks/test-trace-hapi.js
+++ b/test/hooks/test-trace-hapi.js
@@ -25,6 +25,7 @@ var semver = require('semver');
 
 var server;
 
+var agent = require('../..')().startAgent({ samplingRate: 0 }).private_();
 var versions = {
   hapi8: './fixtures/hapi8',
   hapi9: './fixtures/hapi9',
@@ -37,6 +38,7 @@ var versions = {
   hapi16: './fixtures/hapi16'
 };
 
+var count = 0;
 Object.keys(versions).forEach(function(version) {
   if (version.substring(4) > 10 && semver.satisfies(process.version, '<4')) {
     // v11 started using ES6 features (const)
@@ -44,8 +46,16 @@ Object.keys(versions).forEach(function(version) {
   }
   var hapi = require(versions[version]);
   describe(version, function() {
+    after(function() {
+      count++;
+
+      if (count === versions.length) {
+        agent.stop();
+      }
+    });
+
     afterEach(function(done) {
-      common.cleanTraces();
+      common.cleanTraces(agent);
       server.stop(done);
     });
 
@@ -62,7 +72,7 @@ Object.keys(versions).forEach(function(version) {
         }
       });
       server.start(function() {
-        common.doRequest('GET', done, hapiPredicate);
+        common.doRequest(agent, 'GET', done, hapiPredicate);
       });
     });
 
@@ -79,7 +89,7 @@ Object.keys(versions).forEach(function(version) {
         }
       });
       server.start(function() {
-        common.doRequest('POST', done, hapiPredicate);
+        common.doRequest(agent, 'POST', done, hapiPredicate);
       });
     });
 
@@ -99,7 +109,7 @@ Object.keys(versions).forEach(function(version) {
         handler: { custom: { val: common.serverRes } }
       });
       server.start(function() {
-        common.doRequest('GET', done, hapiPredicate);
+        common.doRequest(agent, 'GET', done, hapiPredicate);
       });
     });
 
@@ -128,7 +138,7 @@ Object.keys(versions).forEach(function(version) {
       }, function(err) {
         assert(!err);
         server.start(function() {
-          common.doRequest('GET', done, hapiPredicate);
+          common.doRequest(agent, 'GET', done, hapiPredicate);
         });
       });
     });
@@ -156,7 +166,7 @@ Object.keys(versions).forEach(function(version) {
       });
       server.start(function() {
         assert(afterSuccess);
-        common.doRequest('GET', done, hapiPredicate);
+        common.doRequest(agent, 'GET', done, hapiPredicate);
       });
     });
 
@@ -184,7 +194,7 @@ Object.keys(versions).forEach(function(version) {
           assert(extensionSuccess);
           done();
         };
-        common.doRequest('GET', cb, hapiPredicate);
+        common.doRequest(agent, 'GET', cb, hapiPredicate);
       });
     });
 
@@ -200,7 +210,7 @@ Object.keys(versions).forEach(function(version) {
       });
       server.start(function() {
         http.get({port: common.serverPort}, function(res) {
-          var labels = common.getMatchingSpan(hapiPredicate).labels;
+          var labels = common.getMatchingSpan(agent, hapiPredicate).labels;
           assert.equal(labels[traceLabels.HTTP_RESPONSE_CODE_LABEL_KEY], '200');
           assert.equal(labels[traceLabels.HTTP_METHOD_LABEL_KEY], 'GET');
           assert.equal(labels[traceLabels.HTTP_URL_LABEL_KEY], 'http://localhost:9042/');
@@ -222,7 +232,7 @@ Object.keys(versions).forEach(function(version) {
       });
       server.start(function() {
         http.get({port: common.serverPort}, function(res) {
-          var labels = common.getMatchingSpan(hapiPredicate).labels;
+          var labels = common.getMatchingSpan(agent, hapiPredicate).labels;
           var stackTrace = JSON.parse(labels[traceLabels.STACK_TRACE_DETAILS_KEY]);
           // Ensure that our middleware is on top of the stack
           assert.equal(stackTrace.stack_frame[0].method_name, 'middleware');
@@ -243,7 +253,7 @@ Object.keys(versions).forEach(function(version) {
       });
       server.start(function() {
         http.get({path: '/?a=b', port: common.serverPort}, function(res) {
-          var span = common.getMatchingSpan(hapiPredicate);
+          var span = common.getMatchingSpan(agent, hapiPredicate);
           assert.equal(span.name, '/');
           done();
         });

--- a/test/hooks/test-trace-hapi.js
+++ b/test/hooks/test-trace-hapi.js
@@ -25,7 +25,6 @@ var semver = require('semver');
 
 var server;
 
-var agent = require('../..')().startAgent({ samplingRate: 0 }).private_();
 var versions = {
   hapi8: './fixtures/hapi8',
   hapi9: './fixtures/hapi9',
@@ -38,20 +37,21 @@ var versions = {
   hapi16: './fixtures/hapi16'
 };
 
-var count = 0;
 Object.keys(versions).forEach(function(version) {
   if (version.substring(4) > 10 && semver.satisfies(process.version, '<4')) {
     // v11 started using ES6 features (const)
     return;
   }
-  var hapi = require(versions[version]);
   describe(version, function() {
-    after(function() {
-      count++;
+    var agent;
+    var hapi;
+    before(function() {
+      agent = require('../..')().startAgent({ samplingRate: 0 }).private_();
+      hapi = require(versions[version]);
+    });
 
-      if (count === versions.length) {
-        agent.stop();
-      }
+    after(function() {
+      agent.stop();
     });
 
     afterEach(function(done) {

--- a/test/hooks/test-trace-http.js
+++ b/test/hooks/test-trace-http.js
@@ -16,21 +16,31 @@
 'use strict';
 
 var common = require('./common.js');
-var agent = require('../..')().startAgent({ samplingRate: 0 }).private_();
 var constants = require('../../src/constants.js');
 var TraceLabels = require('../../src/trace-labels.js');
 
 var assert = require('assert');
-var http = require('http');
-
-var server = http.Server(function(req, res) {
-  setTimeout(function() {
-    res.writeHead(200);
-    res.end(common.serverRes);
-  }, common.serverWait);
-});
 
 describe('test-trace-http', function() {
+  var agent;
+  var http;
+  var server;
+  before(function() {
+    agent = require('../..')().startAgent({ samplingRate: 0 }).private_();
+    http = require('http');
+
+    server = http.Server(function(req, res) {
+      setTimeout(function() {
+        res.writeHead(200);
+        res.end(common.serverRes);
+      }, common.serverWait);
+    });
+  });
+
+  after(function() {
+    agent.stop();
+  });
+
   afterEach(function() {
     common.cleanTraces(agent);
     server.close();
@@ -241,6 +251,13 @@ describe('test-trace-http', function() {
 });
 
 describe('https', function() {
+  var agent;
+  var https;
+  before(function() {
+    agent = require('../..')().startAgent({ samplingRate: 0 }).private_();
+    https = require('https');
+  });
+
   after(function() {
     agent.stop();
   });
@@ -250,8 +267,6 @@ describe('https', function() {
   });
 
   it('should accurately measure https#get time with callback', function(done) {
-    var https = require('https');
-
     var options = {
       key: common.serverKey,
       cert: common.serverCert

--- a/test/hooks/test-trace-mongodb.js
+++ b/test/hooks/test-trace-mongodb.js
@@ -24,24 +24,23 @@ var common = require('./common.js');
 var traceLabels = require('../../src/trace-labels.js');
 var assert = require('assert');
 
-var agent = require('../..')().startAgent({ samplingRate: 0 }).private_();
 var versions = {
-  mongodb1: require('./fixtures/mongodb-core1'),
-  mongodb2: require('./fixtures/mongodb-core2')
+  mongodb1: './fixtures/mongodb-core1',
+  mongodb2: './fixtures/mongodb-core2'
 };
 
-var count = 0;
 Object.keys(versions).forEach(function(version) {
-  var mongodb = versions[version];
-  var server;
-
   describe(version, function() {
-    after(function() {
-      count++;
+    var agent;
+    var mongodb;
+    var server;
+    before(function() {
+      agent = require('../..')().startAgent({ samplingRate: 0 }).private_();
+      mongodb = require(versions[version]);
+    });
 
-      if (count === versions.length) {
-        agent.stop();
-      }
+    after(function() {
+      agent.stop();
     });
 
     beforeEach(function(done) {

--- a/test/hooks/test-trace-mysql.js
+++ b/test/hooks/test-trace-mysql.js
@@ -17,16 +17,8 @@
 
 var common = require('./common.js');
 var traceLabels = require('../../src/trace-labels.js');
-require('../..').private_().config_.enhancedDatabaseReporting = true;
 var assert = require('assert');
-var mysql = require('./fixtures/mysql2');
 
-var pool = mysql.createPool({
-  host     : 'localhost',
-  user     : 'root',
-  password : 'Password12!',
-  database : 'test'
-});
 var connection;
 
 var obj = {
@@ -35,6 +27,26 @@ var obj = {
 };
 
 describe('test-trace-mysql', function() {
+  var agent;
+  var mysql;
+  var pool;
+  before(function() {
+    agent = require('../..')().startAgent({
+      enhancedDatabaseReporting: true
+    }).private_();
+    mysql = require('./fixtures/mysql2');
+    pool = mysql.createPool({
+      host     : 'localhost',
+      user     : 'root',
+      password : 'Password12!',
+      database : 'test'
+    });
+  });
+
+  after(function() {
+    agent.stop();
+  });
+
   beforeEach(function(done) {
     pool.getConnection(function(err, conn) {
       assert(!err, 'Skipping: Failed to connect to mysql.');
@@ -44,7 +56,7 @@ describe('test-trace-mysql', function() {
           connection = conn;
           assert(!err);
           assert.equal(res.affectedRows, 1);
-          common.cleanTraces();
+          common.cleanTraces(agent);
           done();
         });
       });
@@ -55,20 +67,20 @@ describe('test-trace-mysql', function() {
     connection.query('DROP TABLE t', function(err) {
       assert(!err);
       connection.release();
-      common.cleanTraces();
+      common.cleanTraces(agent);
       done();
     });
   });
 
   it('should perform basic operations', function(done) {
-    common.runInTransaction(function(endRootSpan) {
+    common.runInTransaction(agent, function(endRootSpan) {
       connection.query('SELECT * FROM t', function(err, res) {
         endRootSpan();
         assert(!err);
         assert.equal(res.length, 1);
         assert.equal(res[0].k, 1);
         assert.equal(res[0].v, 'obj');
-        var spans = common.getMatchingSpans(function (span) {
+        var spans = common.getMatchingSpans(agent, function (span) {
           return span.name === 'mysql-query';
         });
         assert.equal(spans.length, 1);
@@ -79,11 +91,11 @@ describe('test-trace-mysql', function() {
   });
 
   it('should remove trace frames from stack', function(done) {
-    common.runInTransaction(function(endRootSpan) {
+    common.runInTransaction(agent, function(endRootSpan) {
       connection.query('SELECT * FROM t', function(err, res) {
         endRootSpan();
         assert(!err);
-        var spans = common.getMatchingSpans(function (span) {
+        var spans = common.getMatchingSpans(agent, function (span) {
           return span.name === 'mysql-query';
         });
         var labels = spans[0].labels;
@@ -97,7 +109,7 @@ describe('test-trace-mysql', function() {
   });
 
   it('should work with events', function(done) {
-    common.runInTransaction(function(endRootSpan) {
+    common.runInTransaction(agent, function(endRootSpan) {
       var query = connection.query('SELECT * FROM t');
       query.on('result', function(row) {
         assert.equal(row.k, 1);
@@ -105,7 +117,7 @@ describe('test-trace-mysql', function() {
       });
       query.on('end', function() {
         endRootSpan();
-        var spans = common.getMatchingSpans(function (span) {
+        var spans = common.getMatchingSpans(agent, function (span) {
           return span.name === 'mysql-query';
         });
         assert.equal(spans.length, 1);
@@ -116,11 +128,11 @@ describe('test-trace-mysql', function() {
   });
 
   it('should work without events or callback', function(done) {
-    common.runInTransaction(function(endRootSpan) {
+    common.runInTransaction(agent, function(endRootSpan) {
       connection.query('SELECT * FROM t');
       setTimeout(function() {
         endRootSpan();
-        var spans = common.getMatchingSpans(function (span) {
+        var spans = common.getMatchingSpans(agent, function (span) {
           return span.name === 'mysql-query';
         });
         assert.equal(spans.length, 1);
@@ -135,7 +147,7 @@ describe('test-trace-mysql', function() {
       k: 2,
       v: 'obj2'
     };
-    common.runInTransaction(function(endRootSpan) {
+    common.runInTransaction(agent, function(endRootSpan) {
       connection.beginTransaction(function(err) {
         assert(!err);
         connection.query('INSERT INTO t SET ?', obj2, function(err, res) {
@@ -157,7 +169,7 @@ describe('test-trace-mysql', function() {
                   assert.equal(res.length, 1);
                   assert.equal(res[0].k, 1);
                   assert.equal(res[0].v, 'obj');
-                  var spans = common.getMatchingSpans(function (span) {
+                  var spans = common.getMatchingSpans(agent, function (span) {
                     return span.name === 'mysql-query';
                   });
                   var expectedCmds = ['START TRANSACTION', 'INSERT INTO t SET ?',

--- a/test/hooks/test-trace-redis.js
+++ b/test/hooks/test-trace-redis.js
@@ -24,6 +24,7 @@ var common = require('./common.js');
 var traceLabels = require('../../src/trace-labels.js');
 
 var assert = require('assert');
+var agent = require('../..')().startAgent({ samplingRate: 0 }).private_();
 var versions = {
   redis0: require('./fixtures/redis0.12'),
   redis2dot3: require('./fixtures/redis2.3'),
@@ -32,34 +33,43 @@ var versions = {
   redisHiredis05: require('./fixtures/redis2.3-hiredis0.5')
 };
 
+var count = 0;
 var client;
 Object.keys(versions).forEach(function(version) {
   var redis = versions[version];
   describe(version, function() {
+    after(function() {
+      count++;
+
+      if (count === versions.length) {
+        agent.stop();
+      }
+    });
+
     beforeEach(function(done) {
       client = redis.createClient();
       client.on('error', function(err) {
         assert(false, 'redis error ' + err);
       });
       client.set('beforeEach', 42, function() {
-        common.cleanTraces();
+        common.cleanTraces(agent);
         done();
       });
     });
 
     afterEach(function(done) {
       client.quit(function() {
-        common.cleanTraces();
+        common.cleanTraces(agent);
         done();
       });
     });
 
     it('should accurately measure get time', function(done) {
-      common.runInTransaction(function(endTransaction) {
+      common.runInTransaction(agent, function(endTransaction) {
         client.get('beforeEach', function(err, n) {
           endTransaction();
           assert.equal(n, 42);
-          var trace = common.getMatchingSpan(redisPredicate.bind(null, 'redis-get'));
+          var trace = common.getMatchingSpan(agent, redisPredicate.bind(null, 'redis-get'));
           assert(trace);
           done();
         });
@@ -67,10 +77,10 @@ Object.keys(versions).forEach(function(version) {
     });
 
     it('should accurately measure set time', function(done) {
-      common.runInTransaction(function(endTransaction) {
+      common.runInTransaction(agent, function(endTransaction) {
         client.set('key', 'val', function(err) {
           endTransaction();
-          var trace = common.getMatchingSpan(redisPredicate.bind(null, 'redis-set'));
+          var trace = common.getMatchingSpan(agent, redisPredicate.bind(null, 'redis-set'));
           assert(trace);
           done();
         });
@@ -78,11 +88,11 @@ Object.keys(versions).forEach(function(version) {
     });
 
     it('should accurately measure hset time', function(done) {
-      common.runInTransaction(function(endTransaction) {
+      common.runInTransaction(agent, function(endTransaction) {
         // Test error case as hset requires 3 parameters
         client.hset('key', 'val', function(err) {
           endTransaction();
-          var trace = common.getMatchingSpan(redisPredicate.bind(null, 'redis-hset'));
+          var trace = common.getMatchingSpan(agent, redisPredicate.bind(null, 'redis-hset'));
           assert(trace);
           done();
         });
@@ -90,11 +100,11 @@ Object.keys(versions).forEach(function(version) {
     });
 
     it('should remove trace frames from stack', function(done) {
-      common.runInTransaction(function(endTransaction) {
+      common.runInTransaction(agent, function(endTransaction) {
         // Test error case as hset requires 3 parameters
         client.hset('key', 'val', function(err) {
           endTransaction();
-          var trace = common.getMatchingSpan(redisPredicate.bind(null, 'redis-hset'));
+          var trace = common.getMatchingSpan(agent, redisPredicate.bind(null, 'redis-hset'));
           var labels = trace.labels;
           var stackTrace = JSON.parse(labels[traceLabels.STACK_TRACE_DETAILS_KEY]);
           // Ensure that our patch is on top of the stack

--- a/test/hooks/test-trace-redis.js
+++ b/test/hooks/test-trace-redis.js
@@ -24,26 +24,26 @@ var common = require('./common.js');
 var traceLabels = require('../../src/trace-labels.js');
 
 var assert = require('assert');
-var agent = require('../..')().startAgent({ samplingRate: 0 }).private_();
 var versions = {
-  redis0: require('./fixtures/redis0.12'),
-  redis2dot3: require('./fixtures/redis2.3'),
-  redis2dotx: require('./fixtures/redis2.x'),
-  redisHiredis04: require('./fixtures/redis2.3-hiredis0.4'),
-  redisHiredis05: require('./fixtures/redis2.3-hiredis0.5')
+  redis0: './fixtures/redis0.12',
+  redis2dot3: './fixtures/redis2.3',
+  redis2dotx: './fixtures/redis2.x',
+  redisHiredis04: './fixtures/redis2.3-hiredis0.4',
+  redisHiredis05: './fixtures/redis2.3-hiredis0.5'
 };
 
-var count = 0;
 var client;
 Object.keys(versions).forEach(function(version) {
-  var redis = versions[version];
   describe(version, function() {
-    after(function() {
-      count++;
+    var agent;
+    var redis;
+    before(function() {
+      agent = require('../..')().startAgent({ samplingRate: 0 }).private_();
+      redis = require(versions[version]);
+    });
 
-      if (count === versions.length) {
-        agent.stop();
-      }
+    after(function() {
+      agent.stop();
     });
 
     beforeEach(function(done) {

--- a/test/hooks/test-trace-restify.js
+++ b/test/hooks/test-trace-restify.js
@@ -20,32 +20,25 @@ var http = require('http');
 var assert = require('assert');
 var constants = require('../../src/constants.js');
 var common = require('./common.js');
-var agent = require('../..')().startAgent({ samplingRate: 0 }).private_();
 var semver = require('semver');
 var versions = {
-  restify4: require('./fixtures/restify4')
+  restify4: './fixtures/restify4'
 };
 if (semver.satisfies(process.version, '<7')) {
-  versions.restify3 = require('./fixtures/restify3');
+  versions.restify3 = './fixtures/restify3';
 }
 
-var count = 0;
 var server;
 var write;
 
 Object.keys(versions).forEach(function(version) {
-  var restify = versions[version];
-
   describe(version, function() {
-    after(function() {
-      count++;
-
-      if (count === versions.length){
-        agent.stop();
-      }
-    });
-
+    var agent;
+    var restify;
     before(function() {
+      agent = require('../..')().startAgent({ samplingRate: 0 }).private_();
+      restify = require(versions[version]);
+
       // Mute stderr to satiate appveyor
       write = process.stderr.write;
       process.stderr.write = function(c, e, cb) {
@@ -57,6 +50,7 @@ Object.keys(versions).forEach(function(version) {
     });
     after(function() {
       process.stderr.write = write;
+      agent.stop();
     });
     afterEach(function() {
       common.cleanTraces(agent);

--- a/test/non-interference/express-e2e.js
+++ b/test/non-interference/express-e2e.js
@@ -48,7 +48,7 @@ process.chdir(express_dir);
 
 // Remove name to allow for cyclic dependency
 console.log('Updating express metadata');
-cp.execFileSync('sed', ['-i', 's/"express"/"e"/', 'package.json']);
+cp.execFileSync('sed', ['-i.bak', 's/"express"/"e"/', 'package.json']);
 
 // Install express as it's own dependency
 console.log('Installing express dependencies');
@@ -58,18 +58,18 @@ cp.execFileSync('npm', ['install']);
 // Reformat tests to use newly installed express
 console.log('Reformating tests');
 var gcloud_require = 'require(\'' + path.join(__dirname, '..', '..') +
-    '\').start();';
+    '\')().startAgent()._disableStartCheck();';
 glob(test_glob, function(err, files) {
   error = error || err;
   for (var i = 0; i < files.length; i++) {
-    cp.execFileSync('sed', ['-i', 's#\'use strict\';#' +
+    cp.execFileSync('sed', ['-i.bak', 's#\'use strict\';#' +
         '\'use strict\';' + gcloud_require + '#g', files[i]]);
     if (cp.spawnSync('grep', ['-q', gcloud_require, files[i]]).status) {
       cp.execSync('echo "' + gcloud_require + '" | cat - ' + files[i] +
           ' >' +  files[i] + '.instru.js' + '&& mv ' + files[i] +
           '.instru.js' + ' ' + files[i]);
     }
-    cp.execFileSync('sed', ['-i', 's#require(\'\\.\\./\\?\')#require(\'express\')#',
+    cp.execFileSync('sed', ['-i.bak', 's#require(\'\\.\\./\\?\')#require(\'express\')#',
         files[i]]);
   }
   // Run tests

--- a/test/non-interference/express-e2e.js
+++ b/test/non-interference/express-e2e.js
@@ -58,7 +58,7 @@ cp.execFileSync('npm', ['install']);
 // Reformat tests to use newly installed express
 console.log('Reformating tests');
 var gcloud_require = 'require(\'' + path.join(__dirname, '..', '..') +
-    '\')().startAgent()._disableStartCheck();';
+    '\')().startAgent({ forceNewAgent_: true });';
 glob(test_glob, function(err, files) {
   error = error || err;
   for (var i = 0; i < files.length; i++) {

--- a/test/non-interference/http-e2e.js
+++ b/test/non-interference/http-e2e.js
@@ -50,7 +50,7 @@ var test_glob = semver.satisfies(process.version, '0.12.x') ?
 // Run tests
 console.log('Running tests');
 var gcloud_require = 'require(\'' + path.join(__dirname, '..', '..') +
-    '\').start();';
+    '\')().startAgent();';
 glob(test_glob, function(err, files) {
   var errors = 0;
   var testCount;

--- a/test/non-interference/restify-e2e.js
+++ b/test/non-interference/restify-e2e.js
@@ -47,7 +47,7 @@ process.chdir(restify_dir);
 
 // Remove name to allow for cyclic dependency
 console.log('Updating restify metadata');
-cp.execFileSync('sed', ['-i', 's/"restify"/"r"/', 'package.json']);
+cp.execFileSync('sed', ['-i.bak', 's/"restify"/"r"/', 'package.json']);
 
 // Install restify as it's own dependency
 console.log('Installing restify dependencies');
@@ -57,17 +57,17 @@ cp.execFileSync('npm', ['install']);
 // Reformat tests to use newly installed restify
 console.log('Reformating tests');
 var gcloud_require = 'require(\'' + path.join(__dirname, '..', '..') +
-    '\').start();';
+    '\')().startAgent()._disableStartCheck();';
 glob(test_glob, function(err, files) {
   for (var i = 0; i < files.length; i++) {
-    cp.execFileSync('sed', ['-i', 's#\'use strict\';#' +
+    cp.execFileSync('sed', ['-i.bak', 's#\'use strict\';#' +
         '\'use strict\'; ' + gcloud_require + '#g', files[i]]);
     if (cp.spawnSync('grep', ['-q', gcloud_require, files[i]]).status) {
       cp.execSync('echo "' + gcloud_require + '" | cat - ' + files[i] +
           ' >' +  files[i] + '.instru.js' + '&& mv ' + files[i] +
           '.instru.js' + ' ' + files[i]);
     }
-    cp.execFileSync('sed', ['-i', 's#require(\'\\.\\./lib\')#require(\'restify\')#',
+    cp.execFileSync('sed', ['-i.bak', 's#require(\'\\.\\./lib\')#require(\'restify\')#',
         files[i]]);
   }
   // Run tests

--- a/test/non-interference/restify-e2e.js
+++ b/test/non-interference/restify-e2e.js
@@ -57,7 +57,7 @@ cp.execFileSync('npm', ['install']);
 // Reformat tests to use newly installed restify
 console.log('Reformating tests');
 var gcloud_require = 'require(\'' + path.join(__dirname, '..', '..') +
-    '\')().startAgent()._disableStartCheck();';
+    '\')().startAgent({ forceNewAgent_: true });';
 glob(test_glob, function(err, files) {
   for (var i = 0; i < files.length; i++) {
     cp.execFileSync('sed', ['-i.bak', 's#\'use strict\';#' +

--- a/test/performance/express/express-performance-runner.js
+++ b/test/performance/express/express-performance-runner.js
@@ -19,7 +19,7 @@
 if (process.argv[2] === '-i') {
   process.env.GCLOUD_TRACE_ENABLED = true;
   process.env.GCLOUD_TRACE_EXCLUDE_HTTP = true;
-  var traceAgent = require('../../..').start().private_();
+  var traceAgent = require('../../..')().startAgent().private_();
   // We want to drop all spans and avoid network ops
   traceAgent.traceWriter.writeSpan = function() {};
 }

--- a/test/performance/http/http-performance-runner.js
+++ b/test/performance/http/http-performance-runner.js
@@ -19,7 +19,7 @@
 var traceAgent;
 if (process.argv[2] === '-i') {
   process.env.GCLOUD_TRACE_ENABLED = true;
-  traceAgent = require('../../..').start().private_();
+  traceAgent = require('../../..')().startAgent().private_();
   // We want to drop all spans and avoid network ops
   traceAgent.traceWriter.writeSpan = function() {};
 }

--- a/test/performance/mongo/mongo-performance-runner.js
+++ b/test/performance/mongo/mongo-performance-runner.js
@@ -25,7 +25,7 @@
 var traceAgent;
 if (process.argv[2] === '-i') {
   process.env.GCLOUD_TRACE_ENABLED = true;
-  traceAgent = require('../../..').start().private_();
+  traceAgent = require('../../..')().startAgent().private_();
   // We want to drop all spans and avoid network ops
   traceAgent.traceWriter.writeSpan = function() {};
 }

--- a/test/performance/restify/restify-performance-runner.js
+++ b/test/performance/restify/restify-performance-runner.js
@@ -19,7 +19,7 @@
 if (process.argv[2] === '-i') {
   process.env.GCLOUD_TRACE_ENABLED = true;
   process.env.GCLOUD_TRACE_EXCLUDE_HTTP = true;
-  var traceAgent = require('../../..').start().private_();
+  var traceAgent = require('../../..')().startAgent().private_();
   // We want to drop all spans and avoid network ops
   traceAgent.traceWriter.writeSpan = function() {};
 }

--- a/test/standalone/test-agent-metadata.js
+++ b/test/standalone/test-agent-metadata.js
@@ -27,6 +27,7 @@ delete process.env.GCLOUD_PROJECT;
 
 describe('agent interaction with metadata service', function() {
   var agent;
+  var trace;
 
   before(function() {
     // Setup: Monkeypatch gcp-metadata to not ask for retries at all.
@@ -38,7 +39,7 @@ describe('agent interaction with metadata service', function() {
         }, callback);
       }
     });
-    agent = require('../..');
+    trace = require('../..')();
   });
 
   afterEach(function() {
@@ -52,7 +53,7 @@ describe('agent interaction with metadata service', function() {
                 .times(2)
                 .reply(404, 'foo');
 
-    agent.start({logLevel: 0});
+    agent = trace.startAgent({logLevel: 0});
     setTimeout(function() {
       assert.ok(!agent.isActive());
       scope.done();
@@ -66,7 +67,7 @@ describe('agent interaction with metadata service', function() {
                 .get('/computeMetadata/v1/project/project-id')
                 .times(2)
                 .reply(200, '1234');
-    agent.start({logLevel: 0});
+    agent = trace.startAgent({logLevel: 0});
     setTimeout(function() {
       assert.ok(agent.isActive());
       assert.equal(agent.private_().config().projectId, '1234');
@@ -78,13 +79,13 @@ describe('agent interaction with metadata service', function() {
   it('should not query metadata service when config.projectId is set',
     function() {
       nock.disableNetConnect();
-      agent.start({projectId: '0', logLevel: 0});
+      agent = trace.startAgent({projectId: '0', logLevel: 0});
     });
 
   it('should not query metadata service when env. var. is set', function() {
     nock.disableNetConnect();
     process.env.GCLOUD_PROJECT=0;
-    agent.start({logLevel: 0});
+    agent = trace.startAgent({logLevel: 0});
     delete process.env.GCLOUD_PROJECT;
   });
 
@@ -95,7 +96,7 @@ describe('agent interaction with metadata service', function() {
                 .times(1)
                 .reply(200, 'host');
 
-    agent.start({projectId: '0', logLevel: 0});
+    agent = trace.startAgent({projectId: '0', logLevel: 0});
     setTimeout(function() {
       agent.private_().namespace.run(function() {
         var spanData = agent.private_().createRootSpanData('name', 5, 0);
@@ -114,7 +115,7 @@ describe('agent interaction with metadata service', function() {
                 .times(1)
                 .reply(200, '1729');
 
-    agent.start({projectId: '0', logLevel: 0});
+    agent = trace.startAgent({projectId: '0', logLevel: 0});
     setTimeout(function() {
       agent.private_().namespace.run(function() {
         var spanData = agent.private_().createRootSpanData('name', 5, 0);
@@ -128,7 +129,7 @@ describe('agent interaction with metadata service', function() {
 
   it('shouldn\'t add id or hostname labels if not present', function(done) {
     nock.disableNetConnect();
-    agent.start({projectId: '0', logLevel: 0});
+    agent = trace.startAgent({projectId: '0', logLevel: 0});
     setTimeout(function() {
       agent.private_().namespace.run(function() {
         var spanData = agent.private_().createRootSpanData('name', 5, 0);
@@ -145,7 +146,7 @@ describe('agent interaction with metadata service', function() {
     process.env.GAE_MODULE_NAME = 'foo';
     process.env.GAE_MODULE_VERSION = '20151119t120000';
     process.env.GAE_MINOR_VERSION = '91992';
-    agent.start({projectId: '0', logLevel: 0});
+    agent = trace.startAgent({projectId: '0', logLevel: 0});
     setTimeout(function() {
       agent.private_().namespace.run(function() {
         var spanData = agent.private_().createRootSpanData('name', 5, 0);
@@ -164,7 +165,7 @@ describe('agent interaction with metadata service', function() {
     process.env.GAE_MODULE_NAME = 'default';
     process.env.GAE_MODULE_VERSION = '20151119t130000';
     process.env.GAE_MINOR_VERSION = '81818';
-    agent.start({projectId: '0', logLevel: 0});
+    agent = trace.startAgent({projectId: '0', logLevel: 0});
     setTimeout(function() {
       agent.private_().namespace.run(function() {
         var spanData = agent.private_().createRootSpanData('name', 5, 0);
@@ -190,7 +191,7 @@ describe('agent interaction with metadata service', function() {
                   .reply(200, 'host');
 
       delete process.env.GAE_MODULE_NAME;
-      agent.start({projectId: '0', logLevel: 0});
+      agent = trace.startAgent({projectId: '0', logLevel: 0});
       setTimeout(function() {
         agent.private_().namespace.run(function() {
           var spanData = agent.private_().createRootSpanData('name', 5, 0);
@@ -212,7 +213,7 @@ describe('agent interaction with metadata service', function() {
                   .reply(404);
 
       delete process.env.GAE_MODULE_NAME;
-      agent.start({projectId: '0', logLevel: 0});
+      agent = trace.startAgent({projectId: '0', logLevel: 0});
       setTimeout(function() {
         agent.private_().namespace.run(function() {
           var spanData = agent.private_().createRootSpanData('name', 5, 0);

--- a/test/standalone/test-agent-stopped.js
+++ b/test/standalone/test-agent-stopped.js
@@ -23,8 +23,7 @@ process.env.GCLOUD_PROJECT = 0;
 
 describe('express', function() {
   it('should not break if no project number is found', function(done) {
-    var agent = require('../..');
-    agent.start();
+    var agent = require('../..')().startAgent();
     var app = require('../hooks/fixtures/express4')();
     agent.stop();
     app.get('/', function (req, res) {
@@ -46,8 +45,7 @@ describe('express', function() {
 
 describe('hapi', function() {
   it('should not break if no project number is found', function(done) {
-    var agent = require('../..');
-    agent.start();
+    var agent = require('../..')().startAgent();
     var hapi = require('../hooks/fixtures/hapi8');
     var server = new hapi.Server();
     server.connection({ port: 8081 });
@@ -75,8 +73,7 @@ describe('hapi', function() {
 
 describe('restify', function() {
   it('should not break if no project number is found', function(done) {
-    var agent = require('../..');
-    agent.start();
+    var agent = require('../..')().startAgent();
     var restify = require('../hooks/fixtures/restify4');
     var server = restify.createServer();
     agent.stop();

--- a/test/standalone/test-agent-stopped.js
+++ b/test/standalone/test-agent-stopped.js
@@ -21,78 +21,83 @@ var http = require('http');
 
 process.env.GCLOUD_PROJECT = 0;
 
-describe('express', function() {
-  it('should not break if no project number is found', function(done) {
-    var agent = require('../..')().startAgent();
-    var app = require('../hooks/fixtures/express4')();
+describe('test-agent-stopped', function() {
+  var agent;
+  before(function() {
+    agent = require('../..')().startAgent();
+  });
+
+  after(function() {
     agent.stop();
-    app.get('/', function (req, res) {
-      res.send('hi');
-    });
-    var server = app.listen(8080, function() {
-      http.get('http://localhost:8080', function(res) {
-        var result = '';
-        res.on('data', function(data) { result += data; });
-        res.on('end', function() {
-          assert.equal('hi', result);
-          server.close();
-          done();
+  });
+
+  describe('express', function() {
+    it('should not break if no project number is found', function(done) {
+      var app = require('../hooks/fixtures/express4')();
+      app.get('/', function (req, res) {
+        res.send('hi');
+      });
+      var server = app.listen(8080, function() {
+        http.get('http://localhost:8080', function(res) {
+          var result = '';
+          res.on('data', function(data) { result += data; });
+          res.on('end', function() {
+            assert.equal('hi', result);
+            server.close();
+            done();
+          });
         });
       });
     });
   });
-});
 
-describe('hapi', function() {
-  it('should not break if no project number is found', function(done) {
-    var agent = require('../..')().startAgent();
-    var hapi = require('../hooks/fixtures/hapi8');
-    var server = new hapi.Server();
-    server.connection({ port: 8081 });
-    agent.stop();
-    server.route({
-      method: 'GET',
-      path: '/',
-      handler: function(req, reply) {
-        reply('hi');
-      }
-    });
-    server.start(function() {
-      http.get('http://localhost:8081', function(res) {
-        var result = '';
-        res.on('data', function(data) { result += data; });
-        res.on('end', function() {
-          assert.equal('hi', result);
-          server.stop();
-          done();
+  describe('hapi', function() {
+    it('should not break if no project number is found', function(done) {
+      var hapi = require('../hooks/fixtures/hapi8');
+      var server = new hapi.Server();
+      server.connection({ port: 8081 });
+      server.route({
+        method: 'GET',
+        path: '/',
+        handler: function(req, reply) {
+          reply('hi');
+        }
+      });
+      server.start(function() {
+        http.get('http://localhost:8081', function(res) {
+          var result = '';
+          res.on('data', function(data) { result += data; });
+          res.on('end', function() {
+            assert.equal('hi', result);
+            server.stop();
+            done();
+          });
         });
       });
     });
   });
-});
 
-describe('restify', function() {
-  it('should not break if no project number is found', function(done) {
-    var agent = require('../..')().startAgent();
-    var restify = require('../hooks/fixtures/restify4');
-    var server = restify.createServer();
-    agent.stop();
-    server.get('/', function (req, res, next) {
-      res.writeHead(200, {
-        'Content-Type': 'text/plain'
+  describe('restify', function() {
+    it('should not break if no project number is found', function(done) {
+      var restify = require('../hooks/fixtures/restify4');
+      var server = restify.createServer();
+      server.get('/', function (req, res, next) {
+        res.writeHead(200, {
+          'Content-Type': 'text/plain'
+        });
+        res.write('hi');
+        res.end();
+        return next();
       });
-      res.write('hi');
-      res.end();
-      return next();
-    });
-    server.listen(8082, function() {
-      http.get('http://localhost:8082', function(res) {
-        var result = '';
-        res.on('data', function(data) { result += data; });
-        res.on('end', function() {
-          assert.equal('hi', result);
-          server.close();
-          done();
+      server.listen(8082, function() {
+        http.get('http://localhost:8082', function(res) {
+          var result = '';
+          res.on('data', function(data) { result += data; });
+          res.on('end', function() {
+            assert.equal('hi', result);
+            server.close();
+            done();
+          });
         });
       });
     });

--- a/test/standalone/test-config-credentials.js
+++ b/test/standalone/test-config-credentials.js
@@ -36,7 +36,7 @@ describe('test-config-credentials', function() {
       samplingRate: 0,
       keyFilename: path.join('test', 'fixtures', 'gcloud-credentials.json')
     };
-    var agent = require('../..').start(config);
+    var agent = require('../..')().startAgent(config);
     nock.disableNetConnect();
     var scope = nock('https://accounts.google.com')
       .intercept('/o/oauth2/token', 'POST', function(body) {
@@ -68,7 +68,7 @@ describe('test-config-credentials', function() {
       samplingRate: 0,
       credentials: require('../fixtures/gcloud-credentials.json')
     };
-    var agent = require('../..').start(config);
+    var agent = require('../..')().startAgent(config);
     nock.disableNetConnect();
     var scope = nock('https://accounts.google.com')
       .intercept('/o/oauth2/token', 'POST', function(body) {
@@ -107,7 +107,7 @@ describe('test-config-credentials', function() {
       credentials: correctCredentials,
       keyFilename: path.join('test', 'fixtures', 'gcloud-credentials.json')
     };
-    var agent = require('../..').start(config);
+    var agent = require('../..')().startAgent(config);
     nock.disableNetConnect();
     var scope = nock('https://accounts.google.com')
       .intercept('/o/oauth2/token', 'POST', function(body) {

--- a/test/standalone/test-default-ignore-ah-health.js
+++ b/test/standalone/test-default-ignore-ah-health.js
@@ -15,13 +15,21 @@
  */
 'use strict';
 
-var agent = require('../..')().startAgent({samplingRate: 0});
-
 var assert = require('assert');
 var http = require('http');
-var express = require('../hooks/fixtures/express4');
 
 describe('test-default-ignore-ah-health', function() {
+  var agent;
+  var express;
+  before(function() {
+    agent = require('../..')().startAgent({samplingRate: 0});
+    express = require('../hooks/fixtures/express4');
+  });
+
+  after(function() {
+    agent.stop();
+  });
+
   it('should ignore /_ah/health traces by default', function(done) {
     var app = express();
     app.get('/_ah/health', function (req, res) {

--- a/test/standalone/test-default-ignore-ah-health.js
+++ b/test/standalone/test-default-ignore-ah-health.js
@@ -15,7 +15,7 @@
  */
 'use strict';
 
-var agent = require('../..').start({samplingRate: 0});
+var agent = require('../..')().startAgent({samplingRate: 0});
 
 var assert = require('assert');
 var http = require('http');

--- a/test/standalone/test-env-log-level.js
+++ b/test/standalone/test-env-log-level.js
@@ -19,17 +19,17 @@
 process.env.GCLOUD_TRACE_LOGLEVEL = 4;
 
 var assert = require('assert');
-var agent = require('../..');
+var trace = require('../..')();
 
 describe('should respect environment variables', function() {
   it('should respect GCLOUD_TRACE_LOGLEVEL', function() {
-    agent.start();
+    var agent = trace.startAgent();
     assert.equal(agent.private_().config_.logLevel, 4);
     agent.stop();
   });
 
   it('should prefer env to config', function() {
-    agent.start({logLevel: 2});
+    var agent = trace.startAgent({logLevel: 2});
     assert.equal(agent.private_().config_.logLevel, 4);
     agent.stop();
   });

--- a/test/standalone/test-env-project-id.js
+++ b/test/standalone/test-env-project-id.js
@@ -19,17 +19,17 @@
 process.env.GCLOUD_PROJECT = 1729;
 
 var assert = require('assert');
-var agent = require('../..');
+var trace = require('../..')();
 
 describe('should respect environment variables', function() {
   it('should respect GCLOUD_PROJECT', function() {
-    agent.start();
+    var agent = trace.startAgent();
     assert.equal(agent.private_().config_.projectId, 1729);
     agent.stop();
   });
 
   it('should prefer env to config', function() {
-    agent.start({projectId: 1927});
+    var agent = trace.startAgent({projectId: 1927});
     assert.equal(agent.private_().config_.projectId, 1729);
     agent.stop();
   });

--- a/test/standalone/test-grpc-context.js
+++ b/test/standalone/test-grpc-context.js
@@ -15,9 +15,10 @@
  */
 'use strict';
 
-var agent = require('../..').start({ samplingRate: 0 }).private_();
-
 var common = require('../hooks/common.js');
+
+var agent = require('../..')().startAgent({ samplingRate: 0 }).private_();
+
 var assert = require('assert');
 var express = require('../hooks/fixtures/express4');
 var http = require('http');
@@ -148,57 +149,57 @@ Object.keys(versions).forEach(function(version) {
     });
 
     afterEach(function() {
-      common.cleanTraces();
+      common.cleanTraces(agent);
     });
 
     it('grpc should preserve context for unary requests', function(done) {
       http.get({port: common.serverPort, path: '/unary'}, function(res) {
-        assert.strictEqual(common.getTraces().length, 2);
+        assert.strictEqual(common.getTraces(agent).length, 2);
         // gRPC Server: 1 root span, 1 http span.
-        assert.strictEqual(common.getTraces()[0].spans.length, 2);
-        assert.strictEqual(common.getTraces()[0].spans[0].kind, 'RPC_SERVER');
+        assert.strictEqual(common.getTraces(agent)[0].spans.length, 2);
+        assert.strictEqual(common.getTraces(agent)[0].spans[0].kind, 'RPC_SERVER');
         // gRPC Client: 1 root span from express, 1 gRPC span, 1 http span.
-        assert.strictEqual(common.getTraces()[1].spans.length, 3);
+        assert.strictEqual(common.getTraces(agent)[1].spans.length, 3);
         done();
       });
     });
 
     it('grpc should preserve context for client requests', function(done) {
       http.get({port: common.serverPort, path: '/client'}, function(res) {
-        assert.strictEqual(common.getTraces().length, 2);
+        assert.strictEqual(common.getTraces(agent).length, 2);
         // gRPC Server: 1 root span, 11 http spans (10 from 'data' listeners,
         // 1 from 'end' listener).
-        assert.strictEqual(common.getTraces()[0].spans.length, 12);
-        assert.strictEqual(common.getTraces()[0].spans[0].kind, 'RPC_SERVER');
+        assert.strictEqual(common.getTraces(agent)[0].spans.length, 12);
+        assert.strictEqual(common.getTraces(agent)[0].spans[0].kind, 'RPC_SERVER');
         // gRPC Client: 1 root span from express, 1 gRPC span, 1 http span.
-        assert.strictEqual(common.getTraces()[1].spans.length, 3);
+        assert.strictEqual(common.getTraces(agent)[1].spans.length, 3);
         done();
       });
     });
 
     it('grpc should preserve context for server requests', function(done) {
       http.get({port: common.serverPort, path: '/server'}, function(res) {
-        assert.strictEqual(common.getTraces().length, 2);
+        assert.strictEqual(common.getTraces(agent).length, 2);
         // gRPC Server: 1 root span, 1 http span.
-        assert.strictEqual(common.getTraces()[0].spans.length, 2);
-        assert.strictEqual(common.getTraces()[0].spans[0].kind, 'RPC_SERVER');
+        assert.strictEqual(common.getTraces(agent)[0].spans.length, 2);
+        assert.strictEqual(common.getTraces(agent)[0].spans[0].kind, 'RPC_SERVER');
         // gRPC Client: 1 root span from express, 1 gRPC span, and 11 http spans
         // (10 from 'data' listeners and 1 from the 'status' listener).
-        assert.strictEqual(common.getTraces()[1].spans.length, 13);
+        assert.strictEqual(common.getTraces(agent)[1].spans.length, 13);
         done();
       });
     });
 
     it('grpc should preserve context for bidi requests', function(done) {
       http.get({port: common.serverPort, path: '/bidi'}, function(res) {
-        assert.strictEqual(common.getTraces().length, 2);
+        assert.strictEqual(common.getTraces(agent).length, 2);
         // gRPC Server: 1 root span, 11 http spans (10 from 'data' listeners,
         // 1 from 'end' listener).
-        assert.strictEqual(common.getTraces()[0].spans.length, 12);
-        assert.strictEqual(common.getTraces()[0].spans[0].kind, 'RPC_SERVER');
+        assert.strictEqual(common.getTraces(agent)[0].spans.length, 12);
+        assert.strictEqual(common.getTraces(agent)[0].spans[0].kind, 'RPC_SERVER');
         // gRPC Client: 1 root span from express, 1 gRPC span, and 11 http spans
         // (10 from 'data' listeners and 1 from the 'status' listener).
-        assert.strictEqual(common.getTraces()[1].spans.length, 13);
+        assert.strictEqual(common.getTraces(agent)[1].spans.length, 13);
         done();
       });
     });

--- a/test/standalone/test-hooks-no-project-num.js
+++ b/test/standalone/test-hooks-no-project-num.js
@@ -35,7 +35,7 @@ describe('should not break without project num', function() {
     process.stderr.write = write;
   });
   it('mongo', function(done) {
-    var agent = require('../..').start();
+    var agent = require('../..')().startAgent();
     var mongoose = require('../hooks/fixtures/mongoose4');
     var Simple = mongoose.model('Simple', new mongoose.Schema({
       f1: String,
@@ -54,7 +54,7 @@ describe('should not break without project num', function() {
   });
 
   it('redis', function(done) {
-    var agent = require('../..').start();
+    var agent = require('../..')().startAgent();
     var redis = require('../hooks/fixtures/redis2.3');
     var client = redis.createClient();
     client.set('i', 1, function() {
@@ -67,7 +67,7 @@ describe('should not break without project num', function() {
 
   it('express', function(done) {
     var http = require('http');
-    var agent = require('../..').start();
+    var agent = require('../..')().startAgent();
     var express = require('../hooks/fixtures/express4');
     var app = express();
     var server;
@@ -84,7 +84,7 @@ describe('should not break without project num', function() {
 
   it('restify', function(done) {
     var http = require('http');
-    var agent = require('../..').start();
+    var agent = require('../..')().startAgent();
     var restify = require('../hooks/fixtures/restify4');
     var server = restify.createServer();
     server.get('/', function (req, res, next) {
@@ -104,7 +104,7 @@ describe('should not break without project num', function() {
 
   it('hapi', function(done) {
     var http = require('http');
-    var agent = require('../..').start();
+    var agent = require('../..')().startAgent();
     var hapi = require('../hooks/fixtures/hapi8');
     var server = new hapi.Server();
     server.connection({ port: 8081 });
@@ -124,7 +124,7 @@ describe('should not break without project num', function() {
   });
 
   it('http', function(done) {
-    var agent = require('../..').start();
+    var agent = require('../..')().startAgent();
     var req = require('http').get({ port: 8081 });
     req.on('error', function() {
       agent.stop();
@@ -133,7 +133,7 @@ describe('should not break without project num', function() {
   });
 
   it('mysql', function(done) {
-    var agent = require('../..').start();
+    var agent = require('../..')().startAgent();
     var mysql = require('../hooks/fixtures/mysql2');
     var pool = mysql.createPool({
       host     : 'localhost',

--- a/test/standalone/test-hooks-no-project-num.js
+++ b/test/standalone/test-hooks-no-project-num.js
@@ -20,133 +20,130 @@ delete process.env.GCLOUD_PROJECT;
 var assert = require('assert');
 var write;
 
-describe('should not break without project num', function() {
+describe('test-hooks-no-project-num', function(){
+  var agent;
   before(function() {
-    // Mute stderr to satiate appveyor
-    write = process.stderr.write;
-    process.stderr.write = function(c, e, cb) {
-      assert(c.indexOf('DeprecationWarning') !== -1);
-      if (cb) {
-        cb();
-      }
-    };
+    agent = require('../..')().startAgent();
   });
+
   after(function() {
-    process.stderr.write = write;
+    agent.stop();
   });
-  it('mongo', function(done) {
-    var agent = require('../..')().startAgent();
-    var mongoose = require('../hooks/fixtures/mongoose4');
-    var Simple = mongoose.model('Simple', new mongoose.Schema({
-      f1: String,
-      f2: Boolean,
-      f3: Number
-    }));
-    mongoose.connect('mongodb://localhost:27017/testdb', function(err) {
-      assert(!err, 'Skipping: error connecting to mongo at localhost:27017.');
-      Simple.find({}, function(err, results) {
-        mongoose.connection.close(function(err) {
-          agent.stop();
+
+  describe('should not break without project num', function() {
+    before(function() {
+      // Mute stderr to satiate appveyor
+      write = process.stderr.write;
+      process.stderr.write = function(c, e, cb) {
+        assert(c.indexOf('DeprecationWarning') !== -1);
+        if (cb) {
+          cb();
+        }
+      };
+    });
+    after(function() {
+      process.stderr.write = write;
+    });
+    it('mongo', function(done) {
+      var mongoose = require('../hooks/fixtures/mongoose4');
+      var Simple = mongoose.model('Simple', new mongoose.Schema({
+        f1: String,
+        f2: Boolean,
+        f3: Number
+      }));
+      mongoose.connect('mongodb://localhost:27017/testdb', function(err) {
+        assert(!err, 'Skipping: error connecting to mongo at localhost:27017.');
+        Simple.find({}, function(err, results) {
+          mongoose.connection.close(function(err) {
+            done();
+          });
+        });
+      });
+    });
+
+    it('redis', function(done) {
+      var redis = require('../hooks/fixtures/redis2.3');
+      var client = redis.createClient();
+      client.set('i', 1, function() {
+        client.quit(function() {
           done();
         });
       });
     });
-  });
 
-  it('redis', function(done) {
-    var agent = require('../..')().startAgent();
-    var redis = require('../hooks/fixtures/redis2.3');
-    var client = redis.createClient();
-    client.set('i', 1, function() {
-      client.quit(function() {
-        agent.stop();
+    it('express', function(done) {
+      var http = require('http');
+      var express = require('../hooks/fixtures/express4');
+      var app = express();
+      var server;
+      app.get('/', function (req, res) {
+        res.send('hi');
+        server.close();
+        done();
+      });
+      server = app.listen(8081, function() {
+        http.get({ port: 8081 });
+      });
+    });
+
+    it('restify', function(done) {
+      var http = require('http');
+      var restify = require('../hooks/fixtures/restify4');
+      var server = restify.createServer();
+      server.get('/', function (req, res, next) {
+        res.writeHead(200, {
+          'Content-Type': 'text/plain'
+        });
+        res.write('hi');
+        res.end();
+        server.close();
+        done();
+      });
+      server.listen(8081, function() {
+        http.get({ port: 8081 });
+      });
+    });
+
+    it('hapi', function(done) {
+      var http = require('http');
+      var hapi = require('../hooks/fixtures/hapi8');
+      var server = new hapi.Server();
+      server.connection({ port: 8081 });
+      server.route({
+        method: 'GET',
+        path: '/',
+        handler: function(req, reply) {
+          reply('hi');
+          server.stop();
+          done();
+        }
+      });
+      server.start(function() {
+        http.get({ port: 8081 });
+      });
+    });
+
+    it('http', function(done) {
+      var req = require('http').get({ port: 8081 });
+      req.on('error', function() {
         done();
       });
     });
-  });
 
-  it('express', function(done) {
-    var http = require('http');
-    var agent = require('../..')().startAgent();
-    var express = require('../hooks/fixtures/express4');
-    var app = express();
-    var server;
-    app.get('/', function (req, res) {
-      res.send('hi');
-      server.close();
-      agent.stop();
-      done();
-    });
-    server = app.listen(8081, function() {
-      http.get({ port: 8081 });
-    });
-  });
-
-  it('restify', function(done) {
-    var http = require('http');
-    var agent = require('../..')().startAgent();
-    var restify = require('../hooks/fixtures/restify4');
-    var server = restify.createServer();
-    server.get('/', function (req, res, next) {
-      res.writeHead(200, {
-        'Content-Type': 'text/plain'
+    it('mysql', function(done) {
+      var mysql = require('../hooks/fixtures/mysql2');
+      var pool = mysql.createPool({
+        host     : 'localhost',
+        user     : 'root',
+        password : 'Password12!',
+        database : 'test'
       });
-      res.write('hi');
-      res.end();
-      server.close();
-      agent.stop();
-      done();
-    });
-    server.listen(8081, function() {
-      http.get({ port: 8081 });
-    });
-  });
-
-  it('hapi', function(done) {
-    var http = require('http');
-    var agent = require('../..')().startAgent();
-    var hapi = require('../hooks/fixtures/hapi8');
-    var server = new hapi.Server();
-    server.connection({ port: 8081 });
-    server.route({
-      method: 'GET',
-      path: '/',
-      handler: function(req, reply) {
-        reply('hi');
-        server.stop();
-        agent.stop();
-        done();
-      }
-    });
-    server.start(function() {
-      http.get({ port: 8081 });
-    });
-  });
-
-  it('http', function(done) {
-    var agent = require('../..')().startAgent();
-    var req = require('http').get({ port: 8081 });
-    req.on('error', function() {
-      agent.stop();
-      done();
-    });
-  });
-
-  it('mysql', function(done) {
-    var agent = require('../..')().startAgent();
-    var mysql = require('../hooks/fixtures/mysql2');
-    var pool = mysql.createPool({
-      host     : 'localhost',
-      user     : 'root',
-      password : 'Password12!',
-      database : 'test'
-    });
-    pool.getConnection(function(err, conn) {
-      assert(!err, 'Skipping: Failed to connect to mysql.');
-      conn.query('SHOW TABLES', function(err, result) {
-        conn.release();
-        agent.stop();
-        done();
+      pool.getConnection(function(err, conn) {
+        assert(!err, 'Skipping: Failed to connect to mysql.');
+        conn.query('SHOW TABLES', function(err, result) {
+          conn.release();
+          done();
+        });
       });
     });
   });

--- a/test/standalone/test-hooks-sample-warning.js
+++ b/test/standalone/test-hooks-sample-warning.js
@@ -20,36 +20,38 @@
 //   ex) docker -d
 // Run a mongo image binding the mongo port
 //   ex) docker run -p 27017:27017 -d mongo
-var agent = require('../..').start({ samplingRate: 0 }).private_();
-
 var common = require('../hooks/common.js');
 
 var assert = require('assert');
-var express = require('../hooks/fixtures/express4');
 var http = require('http');
-var mongoose = require('../hooks/fixtures/mongoose4');
-var redis = require('../hooks/fixtures/redis2.3');
-var mysql = require('../hooks/fixtures/mysql2');
-var debugCount = 0;
-var oldDebug = agent.logger.debug;
-var newDebug = function(error) {
-  if (error.indexOf('redis') !== -1 || error.indexOf('mongo') !== -1 ||
-      error.indexOf('http') !== -1 || error.indexOf('mysql') !== -1) {
-    debugCount++;
-  }
-};
 
 describe('express + dbs', function() {
+  var debugCount = 0;
+  var oldDebug;
+  var agent;
+
   beforeEach(function() {
+    agent = require('../..')().startAgent({ samplingRate: 0 }).private_();
+    oldDebug = agent.logger.debug;
+    var newDebug = function(error) {
+      if (error.indexOf('redis') !== -1 || error.indexOf('mongo') !== -1 ||
+          error.indexOf('http') !== -1 || error.indexOf('mysql') !== -1) {
+        debugCount++;
+      }
+    };
     agent.logger.debug = newDebug;
   });
 
   afterEach(function() {
     agent.logger.newDebug = oldDebug;
     debugCount = 0;
+    agent.stop();
   });
 
   it('mongo should not warn', function(done) {
+    var mongoose = require('../hooks/fixtures/mongoose4');
+    var express = require('../hooks/fixtures/express4');
+
     var app = express();
     app.get('/', function (req, res) {
       mongoose.connect('mongodb://localhost:27017/testdb', function(err) {
@@ -64,7 +66,7 @@ describe('express + dbs', function() {
       http.get({port: common.serverPort}, function(res) {
         http.get({port: common.serverPort}, function(res) {
           server.close();
-          common.cleanTraces();
+          common.cleanTraces(agent);
           assert.equal(debugCount, 2);
           done();
         });
@@ -73,6 +75,9 @@ describe('express + dbs', function() {
   });
 
   it('redis should not warn', function(done) {
+    var redis = require('../hooks/fixtures/redis2.3');
+    var express = require('../hooks/fixtures/express4');
+
     var app = express();
     app.get('/', function (req, res) {
       var client = redis.createClient();
@@ -84,7 +89,7 @@ describe('express + dbs', function() {
       http.get({port: common.serverPort + 1}, function(res) {
         http.get({port: common.serverPort + 1}, function(res) {
           server.close();
-          common.cleanTraces();
+          common.cleanTraces(agent);
           assert.equal(debugCount, 2);
           done();
         });
@@ -93,6 +98,8 @@ describe('express + dbs', function() {
   });
 
   it('http should not warn', function(done) {
+    var express = require('../hooks/fixtures/express4');
+
     var app = express();
     app.get('/', function (req, res) {
       http.get('http://www.google.com/', function() {
@@ -103,7 +110,7 @@ describe('express + dbs', function() {
       http.get({port: common.serverPort + 2}, function(res) {
         http.get({port: common.serverPort + 2}, function(res) {
           server.close();
-          common.cleanTraces();
+          common.cleanTraces(agent);
           assert.equal(debugCount, 2);
           done();
         });
@@ -112,6 +119,9 @@ describe('express + dbs', function() {
   });
 
   it('mysql should not warn', function(done) {
+    var mysql = require('../hooks/fixtures/mysql2');
+    var express = require('../hooks/fixtures/express4');
+
     var app = express();
     app.get('/', function (req, res) {
       var pool = mysql.createPool({
@@ -132,7 +142,7 @@ describe('express + dbs', function() {
       http.get({port: common.serverPort + 3}, function(res) {
         http.get({port: common.serverPort + 3}, function(res) {
           server.close();
-          common.cleanTraces();
+          common.cleanTraces(agent);
           assert.equal(debugCount, 2);
           done();
         });

--- a/test/standalone/test-hooks-sample-warning.js
+++ b/test/standalone/test-hooks-sample-warning.js
@@ -30,8 +30,15 @@ describe('express + dbs', function() {
   var oldDebug;
   var agent;
 
-  beforeEach(function() {
+  before(function() {
     agent = require('../..')().startAgent({ samplingRate: 0 }).private_();
+  });
+
+  after(function() {
+    agent.stop();
+  });
+
+  beforeEach(function() {
     oldDebug = agent.logger.debug;
     var newDebug = function(error) {
       if (error.indexOf('redis') !== -1 || error.indexOf('mongo') !== -1 ||
@@ -45,7 +52,6 @@ describe('express + dbs', function() {
   afterEach(function() {
     agent.logger.newDebug = oldDebug;
     debugCount = 0;
-    agent.stop();
   });
 
   it('mongo should not warn', function(done) {

--- a/test/standalone/test-ignore-url-express.js
+++ b/test/standalone/test-ignore-url-express.js
@@ -15,7 +15,10 @@
  */
 'use strict';
 
-var agent = require('../..').start({ignoreUrls: ['/test'], samplingRate: 0});
+var agent = require('../..')().startAgent({
+  ignoreUrls: ['/test'],
+  samplingRate: 0
+});
 
 var assert = require('assert');
 var http = require('http');

--- a/test/standalone/test-ignore-url-express.js
+++ b/test/standalone/test-ignore-url-express.js
@@ -15,16 +15,24 @@
  */
 'use strict';
 
-var agent = require('../..')().startAgent({
-  ignoreUrls: ['/test'],
-  samplingRate: 0
-});
-
 var assert = require('assert');
 var http = require('http');
-var express = require('../hooks/fixtures/express4');
 
 describe('test-ignore-urls', function() {
+  var agent;
+  var express;
+  before(function() {
+    agent = require('../..')().startAgent({
+      ignoreUrls: ['/test'],
+      samplingRate: 0
+    });
+    express = require('../hooks/fixtures/express4');
+  });
+
+  after(function() {
+    agent.stop();
+  });
+
   it('should not trace ignored urls', function(done) {
     var app = express();
     app.get('/test', function (req, res) {

--- a/test/standalone/test-index.js
+++ b/test/standalone/test-index.js
@@ -53,20 +53,18 @@ describe('index.js', function() {
       assert.throws(trace.startAgent, Error);
   });
 
-  it('should by default be set to throw an error if '+
-     '`startAgent` is called on an active agent',
-     function() {
-       assert.strictEqual(agent.__DISABLE_START_CHECK__, false);
-  });
-
   it('can be allowed to let `startAgent` be called multiple times ' +
      'without a call to `stop`',
      function() {
-       agent._disableStartCheck();
-       assert.strictEqual(agent.__DISABLE_START_CHECK__, true);
+       agent.stop();
        // If the disabling of the start check failed, the following
        // line will throw an error
-       agent.startAgent();
+       agent.startAgent({
+         forceNewAgent_: true
+       });
+       agent.startAgent({
+         forceNewAgent_: true
+       });
      }
   );
 

--- a/test/standalone/test-index.js
+++ b/test/standalone/test-index.js
@@ -44,11 +44,13 @@ describe('index.js', function() {
     function() {
       agent.stop();
       assert.throws(agent.get, Error);
+      assert.throws(trace.get, Error);
   });
 
   it('should throw an error if `startAgent` is called on an active agent',
     function() {
       assert.throws(agent.startAgent, Error);
+      assert.throws(trace.startAgent, Error);
   });
 
   it('should by default be set to throw an error if '+
@@ -70,8 +72,10 @@ describe('index.js', function() {
 
   it('should report if it is active', function() {
     assert.strictEqual(agent.isActive(), true);
+    assert.strictEqual(trace.isActive(), true);
     agent.stop();
     assert.strictEqual(agent.isActive(), false);
+    assert.strictEqual(trace.isActive(), false);
   });
 
   it('should be harmless to stop before a start', function() {

--- a/test/standalone/test-index.js
+++ b/test/standalone/test-index.js
@@ -36,6 +36,44 @@ describe('index.js', function() {
     agent.stop();
   });
 
+  it('should get the agent with `Trace.get`', function() {
+    assert.strictEqual(agent, trace.get());
+  });
+
+  it('should throw an error if `get` is called on an inactive agent',
+    function() {
+      agent.stop();
+      assert.throws(agent.get, Error);
+  });
+
+  it('should throw an error if `startAgent` is called on an active agent',
+    function() {
+      assert.throws(agent.startAgent, Error);
+  });
+
+  it('should by default be set to throw an error if '+
+     '`startAgent` is called on an active agent',
+     function() {
+       assert.strictEqual(agent.__DISABLE_START_CHECK__, false);
+  });
+
+  it('can be allowed to let `startAgent` be called multiple times ' +
+     'without a call to `stop`',
+     function() {
+       agent._disableStartCheck();
+       assert.strictEqual(agent.__DISABLE_START_CHECK__, true);
+       // If the disabling of the start check failed, the following
+       // line will throw an error
+       agent.startAgent();
+     }
+  );
+
+  it('should report if it is active', function() {
+    assert.strictEqual(agent.isActive(), true);
+    agent.stop();
+    assert.strictEqual(agent.isActive(), false);
+  });
+
   it('should be harmless to stop before a start', function() {
     agent.stop();
     agent.stop();

--- a/test/standalone/test-invalid-project-id.js
+++ b/test/standalone/test-invalid-project-id.js
@@ -19,14 +19,15 @@
 delete process.env.GCLOUD_PROJECT;
 
 var assert = require('assert');
-var agent = require('../..');
 
 describe('index.js', function() {
   it('should complain when config.projectId is not a string or number', function() {
-    agent.start({projectId: '0', enabled: true, logLevel: 0});
+    var agent = require('../..')().startAgent({projectId: '0', enabled: true, logLevel: 0});
     assert(agent.isActive());
     agent.stop();
-    agent.start({projectId: {test: false}, enabled: true, logLevel: 0});
+    
+    agent = require('../..')().startAgent({projectId: {test: false}, enabled: true, logLevel: 0});
     assert(!agent.isActive());
+    agent.stop();
   });
 });

--- a/test/standalone/test-mysql-pool.js
+++ b/test/standalone/test-mysql-pool.js
@@ -22,8 +22,19 @@ var semver = require('semver');
 
 // hapi 13 and hapi-plugin-mysql uses const
 if (semver.satisfies(process.version, '>=4')) {
-  var Hapi = require('../hooks/fixtures/hapi13');
   describe('test-trace-mysql', function() {
+    var agent;
+    var Hapi;
+    before(function() {
+      agent = require('../..')().startAgent({ samplingRate: 0,
+                                              enhancedDatabaseReporting: true }).private_();
+      Hapi = require('../hooks/fixtures/hapi13');
+    });
+
+    after(function() {
+      agent.stop();
+    });
+
     it('should work with connection pool access', function(done) {
       var server = new Hapi.Server();
       server.connection({ port: common.serverPort });
@@ -52,7 +63,7 @@ if (semver.satisfies(process.version, '>=4')) {
             var result = '';
             res.on('data', function(data) { result += data; });
             res.on('end', function() {
-              var spans = common.getMatchingSpans(function (span) {
+              var spans = common.getMatchingSpans(agent, function (span) {
                 return span.name === 'mysql-query';
               });
               assert.equal(spans.length, 1);

--- a/test/standalone/test-no-self-tracing.js
+++ b/test/standalone/test-no-self-tracing.js
@@ -34,7 +34,7 @@ describe('test-no-self-tracing', function() {
                 .get('/computeMetadata/v1/instance/hostname').reply(200)
                 .get('/computeMetadata/v1/instance/id').reply(200)
                 .get('/computeMetadata/v1/project/project-id').reply(200);
-    var agent = require('../..').start();
+    var agent = require('../..')().startAgent();
     require('http'); // Must require http to force patching of the module
     var oldDebug = agent.private_().logger.debug;
     agent.private_().logger.debug = newDebug;
@@ -53,7 +53,7 @@ describe('test-no-self-tracing', function() {
                 .get('/computeMetadata/v1/instance/id').reply(200);
     var apiScope = nock('https://cloudtrace.googleapis.com')
                 .patch('/v1/projects/0/traces').reply(200);
-    var agent = require('../..').start({ projectId: '0', bufferSize: 1 });
+    var agent = require('../..')().startAgent({ projectId: '0', bufferSize: 1 });
     agent.private_().traceWriter.request_ = request;
     require('http'); // Must require http to force patching of the module
     var oldDebug = agent.private_().logger.debug;

--- a/test/standalone/test-trace-cluster.js
+++ b/test/standalone/test-trace-cluster.js
@@ -18,9 +18,19 @@
 
 var common = require('../hooks/common.js');
 var cluster = require('cluster');
-var express = require('../hooks/fixtures/express4');
 
 describe('test-trace-cluster', function() {
+  var agent;
+  var express;
+  before(function() {
+    agent = require('../..')().startAgent({samplingRate: 0}).private_();
+    express = require('../hooks/fixtures/express4');
+  });
+
+  after(function() {
+    agent.stop();
+  });
+
   it('should not interfere with express span', function(done) {
     if (cluster.isMaster) {
       cluster.fork();
@@ -41,7 +51,7 @@ describe('test-trace-cluster', function() {
           server.close();
           done();
         };
-        common.doRequest('GET', finalize, expressPredicate);
+        common.doRequest(agent, 'GET', finalize, expressPredicate);
       });
     }
   });

--- a/test/standalone/test-trace-header-context.js
+++ b/test/standalone/test-trace-header-context.js
@@ -34,6 +34,7 @@ describe('test-trace-header-context', function() {
   });
 
   afterEach(function() {
+    // TODO: Investigate why this is needed
     cls.destroyNamespace();
     agent.namespace = cls.createNamespace();
   });

--- a/test/standalone/test-trace-header-context.js
+++ b/test/standalone/test-trace-header-context.js
@@ -16,18 +16,26 @@
 'use strict';
 
 var common = require('../hooks/common.js');
+var cls = require('../../src/cls.js');
 var http = require('http');
 var assert = require('assert');
-var express = require('../hooks/fixtures/express4');
 var constants = require('../../src/constants.js');
 
 describe('test-trace-header-context', function() {
-  beforeEach(function() {
-    require('../..').start();
+  var agent;
+  var express;
+  before(function() {
+    agent = require('../..')().startAgent({ samplingRate: 0 }).private_();
+    express = require('../hooks/fixtures/express4');
+  });
+
+  after(function() {
+    agent.stop();
   });
 
   afterEach(function() {
-    require('../..').stop();
+    cls.destroyNamespace();
+    agent.namespace = cls.createNamespace();
   });
 
   it('should work with string url', function(done) {
@@ -40,14 +48,14 @@ describe('test-trace-header-context', function() {
     app.get('/self', function(req, res) {
       assert(req.headers[constants.TRACE_CONTEXT_HEADER_NAME]);
       res.send(common.serverRes);
-      var traces = common.getTraces();
+      var traces = common.getTraces(agent);
       assert.equal(traces.length, 2);
       assert.equal(traces[0].spans.length, 2);
       assert.equal(traces[1].spans.length, 1);
       assert.equal(traces[0].spans[0].name, '/');
       assert.equal(traces[0].spans[1].name, 'localhost');
       assert.equal(traces[1].spans[0].name, '/self');
-      common.cleanTraces();
+      common.cleanTraces(agent);
       server.close();
       done();
     });
@@ -66,14 +74,14 @@ describe('test-trace-header-context', function() {
     app.get('/self', function(req, res) {
       assert(req.headers[constants.TRACE_CONTEXT_HEADER_NAME]);
       res.send(common.serverRes);
-      var traces = common.getTraces();
+      var traces = common.getTraces(agent);
       assert.equal(traces.length, 2);
       assert.equal(traces[0].spans.length, 2);
       assert.equal(traces[1].spans.length, 1);
       assert.equal(traces[0].spans[0].name, '/');
       assert.equal(traces[0].spans[1].name, 'localhost');
       assert.equal(traces[1].spans[0].name, '/self');
-      common.cleanTraces();
+      common.cleanTraces(agent);
       server.close();
       done();
     });
@@ -98,14 +106,14 @@ describe('test-trace-header-context', function() {
         req.headers[constants.TRACE_CONTEXT_HEADER_NAME].slice(8),
         ';o=1');
       res.send(common.serverRes);
-      var traces = common.getTraces();
+      var traces = common.getTraces(agent);
       assert.equal(traces.length, 2);
       assert.equal(traces[0].spans.length, 2);
       assert.equal(traces[1].spans.length, 1);
       assert.equal(traces[0].spans[0].name, '/');
       assert.equal(traces[0].spans[1].name, 'localhost');
       assert.equal(traces[1].spans[0].name, '/self');
-      common.cleanTraces();
+      common.cleanTraces(agent);
       server.close();
       done();
     });

--- a/test/standalone/test-trace-koa.js
+++ b/test/standalone/test-trace-koa.js
@@ -16,7 +16,6 @@
 'use strict';
 
 var common = require('../hooks/common.js');
-var koa = require('../hooks/fixtures/koa1');
 var http = require('http');
 var assert = require('assert');
 var constants = require('../../src/constants.js');
@@ -25,9 +24,20 @@ var TraceLabels = require('../../src/trace-labels.js');
 var server;
 
 describe('test-trace-koa', function() {
+  var agent;
+  var koa;
+  before(function() {
+    agent = require('../..')().startAgent().private_();
+    koa = require('../hooks/fixtures/koa1');
+  });
+
   afterEach(function() {
-    common.cleanTraces();
+    common.cleanTraces(agent);
     server.close();
+  });
+
+  after(function() {
+    agent.stop();
   });
 
   it('should accurately measure get time, get', function(done) {
@@ -40,7 +50,7 @@ describe('test-trace-koa', function() {
       };
     });
     server = app.listen(common.serverPort, function() {
-      common.doRequest('GET', done, koaPredicate);
+      common.doRequest(agent, 'GET', done, koaPredicate);
     });
   });
 
@@ -65,7 +75,7 @@ describe('test-trace-koa', function() {
             TraceLabels.HTTP_SOURCE_IP,
             TraceLabels.HTTP_RESPONSE_CODE_LABEL_KEY
           ];
-          var span = common.getMatchingSpan(koaPredicate);
+          var span = common.getMatchingSpan(agent, koaPredicate);
           expectedKeys.forEach(function(key) {
             assert(span.labels[key]);
           });
@@ -86,7 +96,7 @@ describe('test-trace-koa', function() {
     });
     server = app.listen(common.serverPort, function() {
       http.get({port: common.serverPort}, function(res) {
-        var labels = common.getMatchingSpan(koaPredicate).labels;
+        var labels = common.getMatchingSpan(agent, koaPredicate).labels;
         var stackTrace = JSON.parse(labels[TraceLabels.STACK_TRACE_DETAILS_KEY]);
         // Ensure that our middleware is on top of the stack
         assert.equal(stackTrace.stack_frame[0].method_name, 'middleware');
@@ -106,7 +116,7 @@ describe('test-trace-koa', function() {
     });
     server = app.listen(common.serverPort, function() {
       http.get({path: '/?a=b', port: common.serverPort}, function(res) {
-        var name = common.getMatchingSpan(koaPredicate).name;
+        var name = common.getMatchingSpan(agent, koaPredicate).name;
         assert.equal(name, '/');
         done();
       });

--- a/test/standalone/test-trace-uncaught-exception.js
+++ b/test/standalone/test-trace-uncaught-exception.js
@@ -43,8 +43,8 @@ var formatBuffer = function(buffer) {
 
 describe('tracewriter publishing', function() {
 
-  var agent;
   it('should publish on unhandled exception', function(done) {
+    var agent;
     process.removeAllListeners('uncaughtException'); // Remove mocha handler
     var buf;
     var scope = nock(uri)

--- a/test/standalone/test-trace-uncaught-exception.js
+++ b/test/standalone/test-trace-uncaught-exception.js
@@ -19,7 +19,7 @@
 var assert = require('assert');
 var nock = require('nock');
 var cls = require('../../src/cls.js');
-var agent = require('../..');
+var trace = require('../..')();
 var request = require('request');
 
 nock.disableNetConnect();
@@ -43,6 +43,7 @@ var formatBuffer = function(buffer) {
 
 describe('tracewriter publishing', function() {
 
+  var agent;
   it('should publish on unhandled exception', function(done) {
     process.removeAllListeners('uncaughtException'); // Remove mocha handler
     var buf;
@@ -62,11 +63,12 @@ describe('tracewriter publishing', function() {
       }, 20);
     });
     process.nextTick(function() {
-      var privateAgent = agent.start({
+      agent = trace.startAgent({
         bufferSize: 1000,
         samplingRate: 0,
         onUncaughtException: 'flush'
-      }).private_();
+      });
+      var privateAgent = agent.private_();
       privateAgent.traceWriter.request_ = request; // Avoid authing
       cls.getNamespace().run(function() {
         queueSpans(2, privateAgent);

--- a/test/standalone/test-trace-writer.js
+++ b/test/standalone/test-trace-writer.js
@@ -19,7 +19,7 @@
 var assert = require('assert');
 var nock = require('nock');
 var cls = require('../../src/cls.js');
-var agent = require('../..');
+var trace = require('../..')();
 var request = require('request');
 
 nock.disableNetConnect();
@@ -51,7 +51,8 @@ describe('tracewriter publishing', function() {
           assert.equal(JSON.stringify(body), JSON.stringify(parsedOriginal));
           return true;
         }).reply(200);
-    var privateAgent = agent.start({bufferSize: 2, samplingRate: 0}).private_();
+    var agent = trace.startAgent({bufferSize: 2, samplingRate: 0});
+    var privateAgent = agent.private_();
     privateAgent.traceWriter.request_ = request; // Avoid authing
     cls.getNamespace().run(function() {
       queueSpans(2, privateAgent);
@@ -72,7 +73,8 @@ describe('tracewriter publishing', function() {
           assert.equal(JSON.stringify(body), JSON.stringify(parsedOriginal));
           return true;
         }).reply(200);
-    var privateAgent = agent.start({flushDelaySeconds: 0.01, samplingRate: -1}).private_();
+    var agent = trace.startAgent({flushDelaySeconds: 0.01, samplingRate: -1});
+    var privateAgent = agent.private_();
     privateAgent.traceWriter.request_ = request; // Avoid authing
     cls.getNamespace().run(function() {
       queueSpans(1, privateAgent);
@@ -93,7 +95,8 @@ describe('tracewriter publishing', function() {
           assert.equal(JSON.stringify(body), JSON.stringify(parsedOriginal));
           return true;
         }).replyWithError('Simulated Network Error');
-    var privateAgent = agent.start({bufferSize: 2, samplingRate: -1}).private_();
+    var agent = trace.startAgent({bufferSize: 2, samplingRate: -1});
+    var privateAgent = agent.private_();
     privateAgent.traceWriter.request_ = request; // Avoid authing
     cls.getNamespace().run(function() {
       queueSpans(2, privateAgent);

--- a/test/test-span-data.js
+++ b/test/test-span-data.js
@@ -21,12 +21,20 @@ if (!process.env.GCLOUD_PROJECT) {
   process.exit(1);
 }
 
-var agent = require('..').start({ samplingRate: 0 }).private_();
 var TraceLabels = require('../src/trace-labels.js');
 var assert = require('assert');
 var cls = require('../src/cls.js');
 
 describe('SpanData', function() {
+
+  var agent;
+  beforeEach(function() {
+    agent = require('..')().startAgent({ samplingRate: 0 }).private_();
+  });
+
+  afterEach(function() {
+    agent.stop();
+  });
 
   it('has correct default values', function() {
     cls.getNamespace().run(function() {

--- a/test/test-trace-agent.js
+++ b/test/test-trace-agent.js
@@ -27,12 +27,7 @@ var assert = require('assert');
 var config = require('../config.js');
 var file = require('../src/trace-agent.js');
 var SpanData = require('../src/span-data.js');
-var agent = file.get(config, {
-  debug: function() {},
-  warn: function() {},
-  error: function() {},
-  info: function() {}
-});
+var agent = file.get(config);
 var constants = require('../src/constants.js');
 var cls = require('../src/cls.js');
 

--- a/test/test-trace-agent.js
+++ b/test/test-trace-agent.js
@@ -24,10 +24,10 @@ if (!process.env.GCLOUD_PROJECT) {
 }
 
 var emptyLogger = {
-  warn: function() {},
-  info: function() {},
-  error: function() {},
-  debug: function() {}
+  warn: console.warn,
+  info: console.info,
+  error: console.error,
+  debug: console.log
 };
 
 var assert = require('assert');
@@ -45,8 +45,9 @@ describe('Trace Agent', function() {
   it('should return the same object on repeated application', function() {
     // TODO: This line will silently fail if a logger is not supplied as
     //       the second argument.
+    var agent1 = file.get(config, emptyLogger);
     var agent2 = file.get(config, emptyLogger);
-    assert.strictEqual(agent, agent2);
+    assert.strictEqual(agent1, agent2);
   });
 
   describe('isTraceAgentRequest', function() {

--- a/test/test-trace-agent.js
+++ b/test/test-trace-agent.js
@@ -23,18 +23,29 @@ if (!process.env.GCLOUD_PROJECT) {
   process.exit(1);
 }
 
+var emptyLogger = {
+  warn: function() {},
+  info: function() {},
+  error: function() {},
+  debug: function() {}
+};
+
 var assert = require('assert');
 var config = require('../config.js');
 var file = require('../src/trace-agent.js');
 var SpanData = require('../src/span-data.js');
-var agent = file.get(config);
+// TODO: This line will silently fail if a logger is not supplied as
+//       the second argument.
+var agent = file.get(config, emptyLogger);
 var constants = require('../src/constants.js');
 var cls = require('../src/cls.js');
 
 describe('Trace Agent', function() {
 
   it('should return the same object on repeated application', function() {
-    var agent2 = file.get(config);
+    // TODO: This line will silently fail if a logger is not supplied as
+    //       the second argument.
+    var agent2 = file.get(config, emptyLogger);
     assert.strictEqual(agent, agent2);
   });
 

--- a/test/test-trace-agent.js
+++ b/test/test-trace-agent.js
@@ -27,7 +27,12 @@ var assert = require('assert');
 var config = require('../config.js');
 var file = require('../src/trace-agent.js');
 var SpanData = require('../src/span-data.js');
-var agent = file.get(config);
+var agent = file.get(config, {
+  debug: function() {},
+  warn: function() {},
+  error: function() {},
+  info: function() {}
+});
 var constants = require('../src/constants.js');
 var cls = require('../src/cls.js');
 


### PR DESCRIPTION
Now this module exports a constructor.  In addition, the `start`
method has been renamed to `startAgent`, and the agent must be
stopped before it can be started again.

These changes were made to more closely align this module with
the other Google Cloud API Client Libraries via the
`google-cloud` modules in [1].

[1]: https://github.com/GoogleCloudPlatform/google-cloud-node