### PR TITLE
Plugin API: Additional comments, logging, handling no namespace

### DIFF
--- a/src/trace-plugin-interface.js
+++ b/src/trace-plugin-interface.js
@@ -35,7 +35,6 @@ function ChildSpan(agent, span) {
   this.agent_ = agent;
   this.span_ = span;
   this.serializedTraceContext_ = agent.generateTraceContext(span, true);
-  this.closed_ = false;
 }
 
 /**
@@ -51,10 +50,6 @@ ChildSpan.prototype.addLabel = function(key, value) {
  * Ends the underlying span. This function should only be called once.
  */
 ChildSpan.prototype.endSpan = function() {
-  if (this.closed_) {
-    this.agent_.logger.error('A span ended more than once.');
-  }
-  this.closed_ = true;
   this.span_.close();
 };
 
@@ -78,7 +73,6 @@ function Transaction(agent, context) {
   this.agent_ = agent;
   this.context_ = context;
   this.serializedTraceContext_ = agent.generateTraceContext(context, true);
-  this.closed_ = false;
 }
 
 /**
@@ -94,10 +88,6 @@ Transaction.prototype.addLabel = function(key, value) {
  * Ends the underlying span. This function should only be called once.
  */
 Transaction.prototype.endSpan = function() {
-  if (this.closed_) {
-    this.agent_.logger.error('A span ended more than once.');
-  }
-  this.closed_ = true;
   this.context_.close();
 };
 

--- a/src/trace-plugin-loader.js
+++ b/src/trace-plugin-loader.js
@@ -23,6 +23,7 @@ var semver = require('semver');
 var PluginAPI = require('./trace-plugin-interface.js');
 
 var plugins = Object.create(null);
+var activated = false;
 
 var logger;
 
@@ -85,9 +86,11 @@ function checkLoadedModules() {
 }
 
 function activate(agent) {
-  if (logger) {
+  if (activated) {
     logger.error('Plugins activated more than once.');
+    return;
   }
+  activated = true;
   logger = agent.logger;
 
   // Create a new object exposing functions to create trace spans and propagate
@@ -207,6 +210,7 @@ function deactivate() {
       }
     }
   }
+  activated = false;
 
   // unhook module.load
   shimmer.unwrap(Module, '_load');


### PR DESCRIPTION
I believe this is needed for some tests to pass since the agent might be started with no namespace. Also, added closed flag to be able to log errors if spans are ended multiple times.