### PR TITLE
Plugin API: Add createChildSpan

### DIFF
--- a/src/trace-plugin-interface.js
+++ b/src/trace-plugin-interface.js
@@ -121,23 +121,6 @@ Transaction.prototype.createChildSpan = function(options, fn) {
 };
 
 /**
- * Runs the given function in a child span, passing it an object that
- * exposes an interface for adding labels and closing the span.
- * @param {object} options An object that specifies options for how the child
- * span is created and propogated. @see Transaction.prototype.createChildSpan
- * @param {function(ChildSpan)} fn A function that will be called exactly
- * once, with a ChildSpan object exposing an interface operating on the child
- * span.
- * @returns The return value of calling fn.
- */
-Transaction.prototype.runInChildSpan = function(options, fn) {
-  options = options || {};
-  var childContext = this.agent_.startSpan(options.name, {},
-    options.skipFrames ? options.skipFrames + 1 : 1);
-  return fn(new ChildSpan(this.agent_, childContext));
-};
-
-/**
  * PluginAPI constructor. Don't call directly - a plugin object will be passed to
  * plugin themselves
  * TODO(kjin): Should be called something else
@@ -240,31 +223,6 @@ PluginAPI.prototype.createChildSpan = function(options, fn) {
     this.logger_.warn(options.name + ': Attempted to create child span ' +
       'without root');
     return null;
-  }
-};
-
-/**
- * Convenience method which obtains a Transaction object with getTransaction()
- * and calls its runInChildSpan function on the given arguments. If there is
- * no current Transaction object, the provided function will be called with
- * null as an argument.
- * @param {object} options An object that specifies options for how the child
- * span is created and propogated. @see Transaction.prototype.runInChildSpan
- * @param {function(?Transaction)} fn A function that will be called exactly
- * once. @see Transaction.prototype.runInChildSpan
- * @returns The return value of calling fn.
- */
-PluginAPI.prototype.runInChildSpan = function(options, fn) {
-  var transaction = this.getTransaction();
-  if (transaction) {
-    options = options || {};
-    var childContext = transaction.agent_.startSpan(options.name, {},
-      options.skipFrames ? options.skipFrames + 1 : 1);
-    return fn(new ChildSpan(transaction.agent_, childContext));
-  } else {
-    this.logger_.warn(options.name + ': Attempted to run in child span ' +
-      'without root');
-    return fn(null);
   }
 };
 

--- a/src/trace-plugin-interface.js
+++ b/src/trace-plugin-interface.js
@@ -101,7 +101,7 @@ Transaction.prototype.getTraceContext = function() {
 };
 
 /**
- * Runs the given function in a child span nested in the underlying root span
+ * Creates a child span nested in the underlying root span
  * of this transaction.
  * @param {object} options An object that specifies options for how the child
  * span is created and propogated.

--- a/src/trace-plugin-interface.js
+++ b/src/trace-plugin-interface.js
@@ -101,8 +101,8 @@ Transaction.prototype.getTraceContext = function() {
 };
 
 /**
- * Runs the given function in a child span, passing it an object that
- * exposes an interface for adding labels and closing the span.
+ * Runs the given function in a child span nested in the underlying root span
+ * of this transaction.
  * @param {object} options An object that specifies options for how the child
  * span is created and propogated.
  * @param {string} options.name The name to apply to the child span.
@@ -111,6 +111,20 @@ Transaction.prototype.getTraceContext = function() {
  * @param {?number} options.skipFrames The number of stack frames to skip when
  * collecting call stack information for the child span, starting from the top;
  * this should be set to avoid including frames in the plugin. Defaults to 0.
+ * @returns A new ChildSpan object.
+ */
+Transaction.prototype.createChildSpan = function(options, fn) {
+  options = options || {};
+  var childContext = this.agent_.startSpan(options.name, {},
+    options.skipFrames ? options.skipFrames + 1 : 1);
+  return new ChildSpan(this.agent_, childContext);
+};
+
+/**
+ * Runs the given function in a child span, passing it an object that
+ * exposes an interface for adding labels and closing the span.
+ * @param {object} options An object that specifies options for how the child
+ * span is created and propogated. @see Transaction.prototype.createChildSpan
  * @param {function(ChildSpan)} fn A function that will be called exactly
  * once, with a ChildSpan object exposing an interface operating on the child
  * span.

--- a/src/trace-plugin-interface.js
+++ b/src/trace-plugin-interface.js
@@ -101,26 +101,6 @@ Transaction.prototype.getTraceContext = function() {
 };
 
 /**
- * Creates a child span nested in the underlying root span
- * of this transaction.
- * @param {object} options An object that specifies options for how the child
- * span is created and propogated.
- * @param {string} options.name The name to apply to the child span.
- * @param {?string} options.traceContext The serialized form of an object that
- * contains information about an existing trace context.
- * @param {?number} options.skipFrames The number of stack frames to skip when
- * collecting call stack information for the child span, starting from the top;
- * this should be set to avoid including frames in the plugin. Defaults to 0.
- * @returns A new ChildSpan object.
- */
-Transaction.prototype.createChildSpan = function(options, fn) {
-  options = options || {};
-  var childContext = this.agent_.startSpan(options.name, {},
-    options.skipFrames ? options.skipFrames + 1 : 1);
-  return new ChildSpan(this.agent_, childContext);
-};
-
-/**
  * PluginAPI constructor. Don't call directly - a plugin object will be passed to
  * plugin themselves
  * TODO(kjin): Should be called something else
@@ -212,13 +192,13 @@ PluginAPI.prototype.runInRootSpan = function(options, fn) {
  * span is created and propogated. @see Transaction.prototype.createChildSpan
  * @returns A new ChildSpan object, or null if there is no active root span.
  */
-PluginAPI.prototype.createChildSpan = function(options, fn) {
+PluginAPI.prototype.createChildSpan = function(options) {
   var transaction = this.getTransaction();
   if (transaction) {
     options = options || {};
-    var childContext = transaction.agent_.startSpan(options.name, {},
+    var childContext = this.agent_.startSpan(options.name, {},
       options.skipFrames ? options.skipFrames + 1 : 1);
-    return new ChildSpan(transaction.agent_, childContext);
+    return new ChildSpan(this.agent_, childContext);
   } else {
     this.logger_.warn(options.name + ': Attempted to create child span ' +
       'without root');


### PR DESCRIPTION
Introduces `Transaction.prototype.createChildSpan` (and `api.prototype.createChildSpan`). Would like to rip out `runInChildSpan` if possible, it no longer has a reason to be used.