### PR TITLE
Add docker start/stop script for DB unit tests

### DIFF
--- a/bin/docker-trace.sh
+++ b/bin/docker-trace.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+COMMAND=$1
+if [ $COMMAND = 'start' ]; then
+  docker run -p 127.0.0.1:27017:27017 -d mongo
+  docker run -p 127.0.0.1:6379:6379 -d redis
+  docker run -p 127.0.0.1:3306:3306 -e MYSQL_ROOT_PASSWORD='Password12!' -e MYSQL_DATABASE=test -d mysql
+fi
+if [ $COMMAND = 'stop' ]; then
+  docker stop `docker ps | sed -En 's/([a-f0-9]+)[[:space:]]+(redis|mongo|mysql).*/\1/p'`
+fi

--- a/bin/docker-trace.sh
+++ b/bin/docker-trace.sh
@@ -1,10 +1,18 @@
 #!/bin/bash
-COMMAND=$1
-if [ $COMMAND = 'start' ]; then
-  docker run -p 127.0.0.1:27017:27017 -d mongo
-  docker run -p 127.0.0.1:6379:6379 -d redis
-  docker run -p 127.0.0.1:3306:3306 -e MYSQL_ROOT_PASSWORD='Password12!' -e MYSQL_DATABASE=test -d mysql
+if [ ! -z $1 ]; then
+  COMMAND=$1
+  if [ $COMMAND = 'start' ]; then
+    docker run --name trace-test-mongo -p 127.0.0.1:27017:27017 -d mongo &&\
+    docker run --name trace-test-redis -p 127.0.0.1:6379:6379 -d redis &&\
+    docker run --name trace-test-mysql -p 127.0.0.1:3306:3306 -e MYSQL_ROOT_PASSWORD='Password12!' -e MYSQL_DATABASE=test -d mysql
+    exit $?
+  elif [ $COMMAND = 'stop' ]; then
+    docker stop trace-test-mongo
+    docker stop trace-test-redis
+    docker stop trace-test-mysql
+    exit $?
+  fi
 fi
-if [ $COMMAND = 'stop' ]; then
-  docker stop `docker ps | sed -En 's/([a-f0-9]+)[[:space:]]+(redis|mongo|mysql).*/\1/p'`
-fi
+
+echo 'Usage: docker-trace.sh [start|stop]'
+exit 1


### PR DESCRIPTION
This change adds a script to run docker containers to support local unit testing. It's not needed on any CI.

`./bin/docker-trace.sh start` starts docker containers listening locally for mongoDB, redis, and MySQL connections.

`./bin/docker-trace.sh stop` stops them (though, in a somewhat unsafe way).