### PR TITLE
Fix for external unit test failures

### DIFF
--- a/index.js
+++ b/index.js
@@ -124,14 +124,9 @@ var publicAgent = {
 
   start: function(projectConfig) {
     var config = initConfig(projectConfig);
-    
-    if (this.isActive()) { // already started.
-      if (config.forceNewAgent_) { // for testing only
-        agent.stop();
-        agent = phantomTraceAgent;
-      } else {
-        throw new Error('Cannot call start on an already started agent.');
-      }
+
+    if (this.isActive() && !config.forceNewAgent_) { // already started.
+      throw new Error('Cannot call start on an already started agent.');
     }
 
     if (!config.enabled) {

--- a/index.js
+++ b/index.js
@@ -124,9 +124,14 @@ var publicAgent = {
 
   start: function(projectConfig) {
     var config = initConfig(projectConfig);
-
-    if (this.isActive() && !config.forceNewAgent_) { // already started.
-      throw new Error('Cannot call start on an already started agent.');
+    
+    if (this.isActive()) { // already started.
+      if (config.forceNewAgent_) { // for testing only
+        agent.stop();
+        agent = phantomTraceAgent;
+      } else {
+        throw new Error('Cannot call start on an already started agent.');
+      }
     }
 
     if (!config.enabled) {

--- a/src/trace-agent.js
+++ b/src/trace-agent.js
@@ -75,6 +75,7 @@ TraceAgent.prototype.stop = function() {
   this.policy = new tracingPolicy.TraceNonePolicy();
   // Stop the trace writer from publishing any new traces.
   this.traceWriter.stop();
+  cls.destroyNamespace();
   this.namespace = null;
   traceAgent = null;
   if (this.config_.onUncaughtException !== 'ignore') {

--- a/src/trace-plugin-loader.js
+++ b/src/trace-plugin-loader.js
@@ -157,7 +157,7 @@ function deactivate() {
         }
       }
     }
-    plugins = {};
+    plugins = Object.create(null);
 
     // unhook module.load
     shimmer.unwrap(Module, '_load');

--- a/test/non-interference/express-e2e.js
+++ b/test/non-interference/express-e2e.js
@@ -57,24 +57,19 @@ cp.execFileSync('npm', ['install']);
 
 // Reformat tests to use newly installed express
 console.log('Reformating tests');
-var gcloud_require = 'require(\'' + path.join(__dirname, '..', '..') +
-    '\').start({ forceNewAgent_: true });';
 glob(test_glob, function(err, files) {
   error = error || err;
   for (var i = 0; i < files.length; i++) {
-    cp.execFileSync('sed', ['-i.bak', 's#\'use strict\';#' +
-        '\'use strict\';' + gcloud_require + '#g', files[i]]);
-    if (cp.spawnSync('grep', ['-q', gcloud_require, files[i]]).status) {
-      cp.execSync('echo "' + gcloud_require + '" | cat - ' + files[i] +
-          ' >' +  files[i] + '.instru.js' + '&& mv ' + files[i] +
-          '.instru.js' + ' ' + files[i]);
-    }
-    cp.execFileSync('sed', ['-i.bak', 's#require(\'\\.\\./\\?\')#require(\'express\')#',
+    cp.execFileSync('sed', ['-i', 's#require(\'\\.\\./\\?\')#require(\'express\')#',
         files[i]]);
   }
   // Run tests
   console.log('Running tests');
-  var results = cp.spawnSync('mocha', [test_glob]);
+  var results = cp.spawnSync('mocha', [
+    '--require',
+    path.join(__dirname, 'start-agent.js'),
+    test_glob
+  ]);
   console.log(results.output[1].toString() || results.output[2].toString());
   error = error || results.status;
 

--- a/test/non-interference/start-agent.js
+++ b/test/non-interference/start-agent.js
@@ -15,6 +15,20 @@
  */
 'use strict';
 
+var shimmer = require('shimmer');
+var agent = require('../../src/trace-agent.js');
+// Stub getTraceContext so that it always returns the same thing.
+shimmer.wrap(agent, 'get', function(original) {
+  return function() {
+    var privateAgent = original.apply(this, arguments);
+    shimmer.wrap(privateAgent, 'generateTraceContext', function() {
+      return function() {
+        return 'ffeeddccbbaa99887766554433221100/0?o=1';
+      };
+    });
+    return privateAgent;
+  };
+});
 require('../..').start({
   logLevel: 1,
   samplingRate: 0

--- a/test/non-interference/start-agent.js
+++ b/test/non-interference/start-agent.js
@@ -17,7 +17,13 @@
 
 var shimmer = require('shimmer');
 var agent = require('../../src/trace-agent.js');
-// Stub getTraceContext so that it always returns the same thing.
+// Stub generateTraceContext so that it always returns the same thing.
+// This is because web framework unit tests check that similar/identical
+// incoming requests yield the same outgoing headers (for example, express
+// tests that the same request body with either HEAD or GET method have the
+// same response headers).
+// This problem doesn't manifest when samplingRate is set to default, because
+// traces are almost never generated.
 shimmer.wrap(agent, 'get', function(original) {
   return function() {
     var privateAgent = original.apply(this, arguments);

--- a/test/non-interference/start-agent.js
+++ b/test/non-interference/start-agent.js
@@ -1,0 +1,21 @@
+/**
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+
+require('../..').start({
+  logLevel: 1,
+  samplingRate: 0
+});

--- a/test/test-unpatch.js
+++ b/test/test-unpatch.js
@@ -27,8 +27,6 @@ describe('index.js', function() {
   });
 
   afterEach(function() {
-    agent.private_().stop();
-    // 
     checkUnpatches.forEach(function(f) { f(); });
     checkUnpatches = [];
   });

--- a/test/test-unpatch.js
+++ b/test/test-unpatch.js
@@ -27,6 +27,7 @@ describe('index.js', function() {
   });
 
   afterEach(function() {
+    agent.private_().stop();
     checkUnpatches.forEach(function(f) { f(); });
     checkUnpatches = [];
   });


### PR DESCRIPTION
The combination of having a plugin for a certain module (for express, restify, presumably others) and changes in how the agent is started and stopped seem to produce failures in the unit tests for that module. This was observed specifically in express and restify (in the latter, the error code was not reported correctly). Note that these tests are only run on CI in Node v0.12, but the same issues arise in other Node versions.

This fix should resolve that, but in the meantime, I'm looking into why this is the case.