### PR TITLE
Bugfix for creating root spans through plugin API

### DIFF
--- a/src/trace-plugin-interface.js
+++ b/src/trace-plugin-interface.js
@@ -195,7 +195,7 @@ PluginAPI.prototype.createChildSpan = function(options) {
   var rootSpan = this.getRootSpan();
   if (rootSpan) {
     options = options || {};
-    var childContext = this.agent_.startSpan(options.name, {},
+    var childContext = this.agent_.startSpan(options.name || options.url, {},
       options.skipFrames ? options.skipFrames + 1 : 1);
     return new ChildSpan(this.agent_, childContext);
   } else {
@@ -249,10 +249,11 @@ function createRootSpan_(api, options, skipFrames) {
     incomingTraceContext = api.agent_.parseContextFromHeader(options.traceContext);
   }
   incomingTraceContext = incomingTraceContext || {};
-  if (options.url && !api.agent_.shouldTrace(options.url, incomingTraceContext.options)) {
+  if (!api.agent_.shouldTrace(options.url || '',
+        incomingTraceContext.options)) {
     return null;
   }
-  var rootContext = api.agent_.createRootSpanData(options.name,
+  var rootContext = api.agent_.createRootSpanData(options.name || options.url,
     incomingTraceContext.traceId,
     incomingTraceContext.spanId,
     skipFrames + 1);

--- a/src/trace-plugin-interface.js
+++ b/src/trace-plugin-interface.js
@@ -195,7 +195,7 @@ PluginAPI.prototype.createChildSpan = function(options) {
   var rootSpan = this.getRootSpan();
   if (rootSpan) {
     options = options || {};
-    var childContext = this.agent_.startSpan(options.name || options.url, {},
+    var childContext = this.agent_.startSpan(options.name, {},
       options.skipFrames ? options.skipFrames + 1 : 1);
     return new ChildSpan(this.agent_, childContext);
   } else {
@@ -253,7 +253,7 @@ function createRootSpan_(api, options, skipFrames) {
         incomingTraceContext.options)) {
     return null;
   }
-  var rootContext = api.agent_.createRootSpanData(options.name || options.url,
+  var rootContext = api.agent_.createRootSpanData(options.name,
     incomingTraceContext.traceId,
     incomingTraceContext.spanId,
     skipFrames + 1);


### PR DESCRIPTION
`shouldTrace` isn't being called unless `options.url` is defined. This fixes that, so that `shouldTrace` is always being called.

In addition, `options.url` is used in place of `options.name` if it's not defined. This makes it so that if a trace's name is its URL, both fields don't have to be supplied.