### PR TITLE
Consolidate usage of `agent.private_()`

### DIFF
--- a/test/hooks/common.js
+++ b/test/hooks/common.js
@@ -208,6 +208,24 @@ function createChildSpan(agent, cb, duration) {
   };
 }
 
+function createRootSpanData(agent, name, traceId, parentId, skipFrames,
+                            spanKind) {
+  return agent.private_().createRootSpanData(name, traceId, parentId,
+                                             skipFrames, spanKind);
+}
+
+function getTraceWriter(agent) {
+  return agent.private_().traceWriter;
+}
+
+function getConfig(agent) {
+  return agent.private_().config();
+}
+
+function namespaceRun(agent, fn) {
+  return agent.private_().namespace.run(fn);
+}
+
 module.exports = {
   init: init,
   assertSpanDurationCorrect: assertSpanDurationCorrect,
@@ -221,6 +239,10 @@ module.exports = {
   runInTransaction: runInTransaction,
   getShouldTraceArgs: getShouldTraceArgs,
   replaceDebugLogger: replaceDebugLogger,
+  createRootSpanData: createRootSpanData,
+  getConfig: getConfig,
+  getTraceWriter: getTraceWriter,
+  namespaceRun: namespaceRun,
   serverWait: SERVER_WAIT,
   serverRes: SERVER_RES,
   serverPort: SERVER_PORT,

--- a/test/hooks/common.js
+++ b/test/hooks/common.js
@@ -21,7 +21,7 @@ if (!process.env.GCLOUD_PROJECT) {
 }
 
 // We want to disable publishing to avoid conflicts with production.
-require('../../src/trace-writer').publish_ = function() {};
+// require('../../src/trace-writer').publish_ = function() {};
 
 var cls = require('../../src/cls.js');
 
@@ -226,6 +226,10 @@ function namespaceRun(agent, fn) {
   return agent.private_().namespace.run(fn);
 }
 
+function stopAgent(agent) {
+  agent.private_().stop();
+}
+
 module.exports = {
   init: init,
   assertSpanDurationCorrect: assertSpanDurationCorrect,
@@ -243,6 +247,7 @@ module.exports = {
   getConfig: getConfig,
   getTraceWriter: getTraceWriter,
   namespaceRun: namespaceRun,
+  stopAgent: stopAgent,
   serverWait: SERVER_WAIT,
   serverRes: SERVER_RES,
   serverPort: SERVER_PORT,

--- a/test/hooks/common.js
+++ b/test/hooks/common.js
@@ -230,6 +230,11 @@ function stopAgent(agent) {
   agent.private_().stop();
 }
 
+function clearNamespace(agent) {
+  cls.destroyNamespace();
+  agent.private_().namespace = cls.createNamespace();
+}
+
 module.exports = {
   init: init,
   assertSpanDurationCorrect: assertSpanDurationCorrect,
@@ -244,6 +249,7 @@ module.exports = {
   getShouldTraceArgs: getShouldTraceArgs,
   replaceDebugLogger: replaceDebugLogger,
   createRootSpanData: createRootSpanData,
+  clearNamespace: clearNamespace,
   getConfig: getConfig,
   getTraceWriter: getTraceWriter,
   namespaceRun: namespaceRun,

--- a/test/hooks/common.js
+++ b/test/hooks/common.js
@@ -21,7 +21,7 @@ if (!process.env.GCLOUD_PROJECT) {
 }
 
 // We want to disable publishing to avoid conflicts with production.
-// require('../../src/trace-writer').publish_ = function() {};
+require('../../src/trace-writer').publish_ = function() {};
 
 var cls = require('../../src/cls.js');
 

--- a/test/hooks/test-hooks-interop-mongo-express.js
+++ b/test/hooks/test-hooks-interop-mongo-express.js
@@ -40,12 +40,12 @@ describe('mongodb + express', function() {
   var oldDebug;
   var mongoose;
   before(function() {
-    agent = require('../..').start().get().private_();
+    agent = require('../..').start();
     mongoose = require('./fixtures/mongoose4');
-    oldDebug = agent.logger.debug;
-    agent.logger.debug = function(error) {
-      assert(error.indexOf('mongo') === -1, error);
-    };
+    oldDebug = common.replaceDebugLogger(agent,
+      function(error) {
+        assert(error.indexOf('mongo') === -1, error);
+    });
   });
 
   after(function() {
@@ -70,7 +70,7 @@ describe('mongodb + express', function() {
       http.get({port: common.serverPort}, function(res) {
         server.close();
         common.cleanTraces(agent);
-        agent.logger.debug = oldDebug;
+        common.replaceDebugLogger(agent, oldDebug);
         done();
       });
     });

--- a/test/hooks/test-trace-connect.js
+++ b/test/hooks/test-trace-connect.js
@@ -28,7 +28,7 @@ describe('test-trace-connect', function() {
   var agent;
   var connect;
   before(function() {
-    agent = require('../..').start({ samplingRate: 0 }).private_();
+    agent = require('../..').start({ samplingRate: 0 });
     connect = require('./fixtures/connect3');
     // Mute stderr to satiate appveyor
     write = process.stderr.write;

--- a/test/hooks/test-trace-express.js
+++ b/test/hooks/test-trace-express.js
@@ -28,7 +28,7 @@ describe('test-trace-express', function() {
   var agent;
   var express;
   before(function() {
-    agent = require('../..').start({ samplingRate: 0 }).private_();
+    agent = require('../..').start({ samplingRate: 0 });
     express = require('./fixtures/express4');
 
     // Mute stderr to satiate appveyor

--- a/test/hooks/test-trace-grpc.js
+++ b/test/hooks/test-trace-grpc.js
@@ -200,8 +200,10 @@ Object.keys(versions).forEach(function(version) {
   describe(version, function() {
     before(function() {
       // It is necessary for the samplingRate to be 0 for the tests to succeed
-      agent = require('../..').start({ samplingRate: 0 }).private_();
-      agent.config_.enhancedDatabaseReporting = true;
+      agent = require('../..').start({
+        samplingRate: 0,
+        enhancedDatabaseReporting: true
+      });
 
       common = require('./common.js');
       common.init(agent);

--- a/test/hooks/test-trace-hapi.js
+++ b/test/hooks/test-trace-hapi.js
@@ -41,7 +41,7 @@ describe('hapi', function() {
   var agent;
 
   before(function() {
-    agent = require('../..').start({ samplingRate: 0 }).private_();
+    agent = require('../..').start({ samplingRate: 0 });
   });
 
   Object.keys(versions).forEach(function(version) {

--- a/test/hooks/test-trace-http.js
+++ b/test/hooks/test-trace-http.js
@@ -19,7 +19,7 @@ var common = require('./common.js');
 var constants = require('../../src/constants.js');
 var TraceLabels = require('../../src/trace-labels.js');
 
-var agent = require('../..').start({ samplingRate: 0 }).private_();
+var agent = require('../..').start({ samplingRate: 0 });
 
 var assert = require('assert');
 

--- a/test/hooks/test-trace-mongodb.js
+++ b/test/hooks/test-trace-mongodb.js
@@ -39,7 +39,7 @@ describe('mongodb', function() {
       samplingRate: 0,
       enhancedDatabaseReporting: true,
       databaseResultReportingSize: RESULT_SIZE
-    }).private_();
+    });
   });
 
   Object.keys(versions).forEach(function(version) {

--- a/test/hooks/test-trace-mongoose.js
+++ b/test/hooks/test-trace-mongoose.js
@@ -30,7 +30,7 @@ describe('test-trace-mongoose', function() {
   var mongoose;
   var Simple;
   before(function() {
-    agent = require('../..').start({ samplingRate: 0 }).private_();
+    agent = require('../..').start({ samplingRate: 0 });
 
     mongoose = require('./fixtures/mongoose4');
     mongoose.Promise = global.Promise;

--- a/test/hooks/test-trace-mysql.js
+++ b/test/hooks/test-trace-mysql.js
@@ -36,7 +36,7 @@ describe('test-trace-mysql', function() {
     agent = require('../..').start({
       enhancedDatabaseReporting: true,
       databaseResultReportingSize: RESULT_SIZE
-    }).private_();
+    });
     mysql = require('./fixtures/mysql2');
     pool = mysql.createPool({
       host     : 'localhost',

--- a/test/hooks/test-trace-redis.js
+++ b/test/hooks/test-trace-redis.js
@@ -42,7 +42,7 @@ describe('redis', function() {
       samplingRate: 0,
       enhancedDatabaseReporting: true,
       databaseResultReportingSize: RESULT_SIZE
-    }).private_();
+    });
   });
 
   var client;

--- a/test/hooks/test-trace-restify.js
+++ b/test/hooks/test-trace-restify.js
@@ -32,7 +32,7 @@ describe('restify', function() {
   var agent;
 
   before(function() {
-    agent = require('../..').start({ samplingRate: 0 }).private_();
+    agent = require('../..').start({ samplingRate: 0 });
   });
 
   var server;

--- a/test/performance/express/express-performance-runner.js
+++ b/test/performance/express/express-performance-runner.js
@@ -19,9 +19,10 @@
 if (process.argv[2] === '-i') {
   process.env.GCLOUD_TRACE_ENABLED = true;
   process.env.GCLOUD_TRACE_EXCLUDE_HTTP = true;
-  var traceAgent = require('../../..').start().private_();
+  var common = require('../../hooks/common.js');
+  var agent = require('../../..').start();
   // We want to drop all spans and avoid network ops
-  traceAgent.traceWriter.writeSpan = function() {};
+  common.getTraceWriter(agent).writeSpan = function() {};
 }
 
 var express = require('express');

--- a/test/performance/http/http-performance-runner.js
+++ b/test/performance/http/http-performance-runner.js
@@ -16,12 +16,14 @@
 
 'use strict';
 
-var traceAgent;
+var common;
+var agent;
 if (process.argv[2] === '-i') {
   process.env.GCLOUD_TRACE_ENABLED = true;
-  traceAgent = require('../../..').start().private_();
+  common = require('../../hooks/common.js');
+  agent = require('../../..').start();
   // We want to drop all spans and avoid network ops
-  traceAgent.traceWriter.writeSpan = function() {};
+  common.getTraceWriter(agent).writeSpan = function() {};
 }
 
 var http = require('http');
@@ -36,7 +38,7 @@ var smileyServer = http.createServer(function(req, res) {
 var runInTransaction = function(fn) {
   var cls = require('../../../src/cls.js');
   cls.getNamespace().run(function() {
-    var span = traceAgent.createRootSpanData('outer');
+    var span = common.createRootSpanData(agent, 'outer');
     fn(function() {
       span.close();
     });
@@ -65,7 +67,7 @@ var work = function(endTransaction) {
   }
 };
 
-if (traceAgent) {
+if (agent) {
   work = runInTransaction.bind(null, work);
 }
 

--- a/test/performance/restify/restify-performance-runner.js
+++ b/test/performance/restify/restify-performance-runner.js
@@ -19,9 +19,10 @@
 if (process.argv[2] === '-i') {
   process.env.GCLOUD_TRACE_ENABLED = true;
   process.env.GCLOUD_TRACE_EXCLUDE_HTTP = true;
-  var traceAgent = require('../../..').start().private_();
+  var common = require('../../hooks/common.js');
+  var agent = require('../../..').start();
   // We want to drop all spans and avoid network ops
-  traceAgent.traceWriter.writeSpan = function() {};
+  common.getTraceWriter(agent).writeSpan = function() {};
 }
 
 var restify = require('restify');

--- a/test/test-agent-metadata.js
+++ b/test/test-agent-metadata.js
@@ -19,16 +19,14 @@
 var proxyquire  = require('proxyquire');
 var assert = require('assert');
 var nock = require('nock');
-var common = require('./hooks/common.js');
 var traceLabels = require('../src/trace-labels.js');
 
 nock.disableNetConnect();
 
-delete process.env.GCLOUD_PROJECT;
-
 describe('agent interaction with metadata service', function() {
   var agent;
   var trace;
+  var common;
 
   before(function() {
     // Setup: Monkeypatch gcp-metadata to not ask for retries at all.
@@ -40,7 +38,9 @@ describe('agent interaction with metadata service', function() {
         }, callback);
       }
     });
+    common = require('./hooks/common.js');
     trace = require('..');
+    delete process.env.GCLOUD_PROJECT;
   });
 
   it('should stop when the project number cannot be acquired', function(done) {

--- a/test/test-agent-metadata.js
+++ b/test/test-agent-metadata.js
@@ -19,6 +19,7 @@
 var proxyquire  = require('proxyquire');
 var assert = require('assert');
 var nock = require('nock');
+var common = require('./hooks/common.js');
 var traceLabels = require('../src/trace-labels.js');
 
 nock.disableNetConnect();
@@ -93,7 +94,7 @@ describe('agent interaction with metadata service', function() {
     agent = trace.start({logLevel: 0, forceNewAgent_: true});
     setTimeout(function() {
       assert.ok(agent.isActive());
-      assert.equal(agent.private_().config().projectId, '1234');
+      assert.equal(common.getConfig(agent).projectId, '1234');
       scope.done();
       done();
     }, 500);
@@ -121,8 +122,8 @@ describe('agent interaction with metadata service', function() {
 
     agent = trace.start({projectId: '0', logLevel: 0, forceNewAgent_: true});
     setTimeout(function() {
-      agent.private_().namespace.run(function() {
-        var spanData = agent.private_().createRootSpanData('name', 5, 0);
+      common.namespaceRun(agent, function() {
+        var spanData = common.createRootSpanData(agent, 'name', 5, 0);
         spanData.close();
         assert.equal(spanData.span.labels[traceLabels.GCE_HOSTNAME], 'host');
         scope.done();
@@ -140,8 +141,8 @@ describe('agent interaction with metadata service', function() {
 
     agent = trace.start({projectId: '0', logLevel: 0, forceNewAgent_: true});
     setTimeout(function() {
-      agent.private_().namespace.run(function() {
-        var spanData = agent.private_().createRootSpanData('name', 5, 0);
+      common.namespaceRun(agent, function() {
+        var spanData = common.createRootSpanData(agent, 'name', 5, 0);
         spanData.close();
         assert.equal(spanData.span.labels[traceLabels.GCE_INSTANCE_ID], 1729);
         scope.done();
@@ -154,8 +155,8 @@ describe('agent interaction with metadata service', function() {
     nock.disableNetConnect();
     agent = trace.start({projectId: '0', logLevel: 0, forceNewAgent_: true});
     setTimeout(function() {
-      agent.private_().namespace.run(function() {
-        var spanData = agent.private_().createRootSpanData('name', 5, 0);
+      common.namespaceRun(agent, function() {
+        var spanData = common.createRootSpanData(agent, 'name', 5, 0);
         spanData.close();
         assert(spanData.span.labels[traceLabels.GCE_HOSTNAME],
             require('os').hostname());
@@ -171,8 +172,8 @@ describe('agent interaction with metadata service', function() {
     process.env.GAE_MINOR_VERSION = '91992';
     agent = trace.start({projectId: '0', logLevel: 0, forceNewAgent_: true});
     setTimeout(function() {
-      agent.private_().namespace.run(function() {
-        var spanData = agent.private_().createRootSpanData('name', 5, 0);
+      common.namespaceRun(agent, function() {
+        var spanData = common.createRootSpanData(agent, 'name', 5, 0);
         spanData.close();
         assert.equal(spanData.span.labels[traceLabels.GAE_MODULE_NAME], 'foo');
         assert.equal(spanData.span.labels[traceLabels.GAE_MODULE_VERSION],
@@ -190,8 +191,8 @@ describe('agent interaction with metadata service', function() {
     process.env.GAE_MINOR_VERSION = '81818';
     agent = trace.start({projectId: '0', logLevel: 0, forceNewAgent_: true});
     setTimeout(function() {
-      agent.private_().namespace.run(function() {
-        var spanData = agent.private_().createRootSpanData('name', 5, 0);
+      common.namespaceRun(agent, function() {
+        var spanData = common.createRootSpanData(agent, 'name', 5, 0);
         spanData.close();
         assert.equal(spanData.span.labels[traceLabels.GAE_MODULE_NAME],
           'default');
@@ -216,8 +217,8 @@ describe('agent interaction with metadata service', function() {
       delete process.env.GAE_MODULE_NAME;
       agent = trace.start({projectId: '0', logLevel: 0, forceNewAgent_: true});
       setTimeout(function() {
-        agent.private_().namespace.run(function() {
-          var spanData = agent.private_().createRootSpanData('name', 5, 0);
+        common.namespaceRun(agent, function() {
+          var spanData = common.createRootSpanData(agent, 'name', 5, 0);
           spanData.close();
           assert.equal(spanData.span.labels[traceLabels.GAE_MODULE_NAME],
             'host');
@@ -238,8 +239,8 @@ describe('agent interaction with metadata service', function() {
       delete process.env.GAE_MODULE_NAME;
       agent = trace.start({projectId: '0', logLevel: 0, forceNewAgent_: true});
       setTimeout(function() {
-        agent.private_().namespace.run(function() {
-          var spanData = agent.private_().createRootSpanData('name', 5, 0);
+        common.namespaceRun(agent, function() {
+          var spanData = common.createRootSpanData(agent, 'name', 5, 0);
           spanData.close();
           scope.done();
           assert.equal(spanData.span.labels[traceLabels.GAE_MODULE_NAME],

--- a/test/test-config-credentials.js
+++ b/test/test-config-credentials.js
@@ -19,10 +19,11 @@ var path = require('path');
 var assert = require('assert');
 var nock = require('nock');
 var cls = require('../src/cls.js');
+var common = require('./hooks/common.js');
 
-var queueSpans = function(n, privateAgent) {
+var queueSpans = function(n, agent) {
   for (var i = 0; i < n; i++) {
-    privateAgent.createRootSpanData('name', 1, 0).close();
+    common.createRootSpanData(agent, 'name', 1, 0).close();
   }
 };
 
@@ -58,7 +59,7 @@ describe('test-config-credentials', function() {
         return true;
       }).reply(200);
     cls.getNamespace().run(function() {
-      queueSpans(2, agent.private_());
+      queueSpans(2, agent);
     });
   });
 
@@ -90,7 +91,7 @@ describe('test-config-credentials', function() {
         return true;
       }).reply(200);
     cls.getNamespace().run(function() {
-      queueSpans(2, agent.private_());
+      queueSpans(2, agent);
     });
   });
 
@@ -129,7 +130,7 @@ describe('test-config-credentials', function() {
         return true;
       }).reply(200);
     cls.getNamespace().run(function() {
-      queueSpans(2, agent.private_());
+      queueSpans(2, agent);
     });
   });
 });

--- a/test/test-default-ignore-ah-health.js
+++ b/test/test-default-ignore-ah-health.js
@@ -18,6 +18,8 @@
 var assert = require('assert');
 var http = require('http');
 
+var common = require('./hooks/common.js');
+
 describe('test-default-ignore-ah-health', function() {
   var agent;
   var express;
@@ -37,7 +39,7 @@ describe('test-default-ignore-ah-health', function() {
         res.on('data', function(data) { result += data; });
         res.on('end', function() {
           assert.equal(result, '🏥');
-          assert.equal(agent.private_().traceWriter.buffer_.length, 0);
+          assert.equal(common.getTraceWriter(agent).buffer_.length, 0);
           server.close();
           done();
         });

--- a/test/test-env-log-level.js
+++ b/test/test-env-log-level.js
@@ -21,14 +21,16 @@ process.env.GCLOUD_TRACE_LOGLEVEL = 4;
 var assert = require('assert');
 var trace = require('..');
 
+var common = require('./hooks/common.js');
+
 describe('should respect environment variables', function() {
   it('should respect GCLOUD_TRACE_LOGLEVEL', function() {
     var agent = trace.start({forceNewAgent_: true});
-    assert.equal(agent.private_().config_.logLevel, 4);
+    assert.equal(common.getConfig(agent).logLevel, 4);
   });
 
   it('should prefer env to config', function() {
     var agent = trace.start({logLevel: 2, forceNewAgent_: true});
-    assert.equal(agent.private_().config_.logLevel, 4);
+    assert.equal(common.getConfig(agent).logLevel, 4);
   });
 });

--- a/test/test-env-project-id.js
+++ b/test/test-env-project-id.js
@@ -21,14 +21,16 @@ process.env.GCLOUD_PROJECT = 1729;
 var assert = require('assert');
 var trace = require('..');
 
+var common = require('./hooks/common.js');
+
 describe('should respect environment variables', function() {
   it('should respect GCLOUD_PROJECT', function() {
     var agent = trace.start({forceNewAgent_: true});
-    assert.equal(agent.private_().config_.projectId, 1729);
+    assert.equal(common.getConfig(agent).projectId, 1729);
   });
 
   it('should prefer env to config', function() {
     var agent = trace.start({projectId: 1927, forceNewAgent_: true});
-    assert.equal(agent.private_().config_.projectId, 1729);
+    assert.equal(common.getConfig(agent).projectId, 1729);
   });
 });

--- a/test/test-grpc-context.js
+++ b/test/test-grpc-context.js
@@ -54,15 +54,15 @@ Object.keys(versions).forEach(function(version) {
   var grpc;
   describe('express + ' + version, function() {
     before(function(done) {
-      agent = require('..').start({ samplingRate: 0 }).private_();
+      agent = require('..').start({ samplingRate: 0 });
       express = require('./hooks/fixtures/express4');
       grpc = require(versions[version]);
 
-      agent.logger.debug = function(error, uri) {
+      common.replaceDebugLogger(agent, function(error, uri) {
         if (error.indexOf('http') !== -1) {
           assert.notStrictEqual(uri.indexOf('localhost'), -1);
         }
-      };
+      });
 
       var proto = grpc.load(protoFile).nodetest;
       var app = express();

--- a/test/test-hooks-sample-warning.js
+++ b/test/test-hooks-sample-warning.js
@@ -31,22 +31,20 @@ describe('express + dbs', function() {
   var agent;
 
   before(function() {
-    agent = require('..').start({ samplingRate: 0 }).private_();
+    agent = require('..').start({ samplingRate: 0 });
   });
 
   beforeEach(function() {
-    oldDebug = agent.logger.debug;
-    var newDebug = function(error) {
+    oldDebug = common.replaceDebugLogger(agent, function(error) {
       if (error.indexOf('redis') !== -1 || error.indexOf('mongo') !== -1 ||
           error.indexOf('http') !== -1 || error.indexOf('mysql') !== -1) {
         debugCount++;
       }
-    };
-    agent.logger.debug = newDebug;
+    });
   });
 
   afterEach(function() {
-    agent.logger.newDebug = oldDebug;
+    common.replaceDebugLogger(agent, oldDebug);
     debugCount = 0;
   });
 

--- a/test/test-ignore-url-express.js
+++ b/test/test-ignore-url-express.js
@@ -18,6 +18,8 @@
 var assert = require('assert');
 var http = require('http');
 
+var common = require('./hooks/common.js');
+
 describe('test-ignore-urls', function() {
   var agent;
   var express;
@@ -40,7 +42,7 @@ describe('test-ignore-urls', function() {
         res.on('data', function(data) { result += data; });
         res.on('end', function() {
           assert.equal(result, 'hi');
-          assert.equal(agent.private_().traceWriter.buffer_.length, 0);
+          assert.equal(common.getTraceWriter(agent).buffer_.length, 0);
           server.close();
           done();
         });

--- a/test/test-mysql-pool.js
+++ b/test/test-mysql-pool.js
@@ -27,7 +27,7 @@ if (semver.satisfies(process.version, '>=4')) {
     var Hapi;
     before(function() {
       agent = require('..').start({ samplingRate: 0,
-                                       enhancedDatabaseReporting: true }).private_();
+                                       enhancedDatabaseReporting: true });
       Hapi = require('./hooks/fixtures/hapi13');
     });
 

--- a/test/test-trace-cluster.js
+++ b/test/test-trace-cluster.js
@@ -23,7 +23,7 @@ describe('test-trace-cluster', function() {
   var agent;
   var express;
   before(function() {
-    agent = require('..').start({samplingRate: 0}).private_();
+    agent = require('..').start({samplingRate: 0});
     express = require('./hooks/fixtures/express4');
   });
 

--- a/test/test-trace-gcloud.js
+++ b/test/test-trace-gcloud.js
@@ -26,7 +26,7 @@ describe('test-trace-gcloud', function() {
   var agent;
   before(function() {
     agent = require('..').start({ samplingRate: 0,
-      enhancedDatabaseReporting: true }).private_();
+      enhancedDatabaseReporting: true });
   });
 
   // This does a gcloud.datastore.get() request that makes a gRPC 'lookup' call.

--- a/test/test-trace-header-context.js
+++ b/test/test-trace-header-context.js
@@ -30,9 +30,7 @@ describe('test-trace-header-context', function() {
   });
 
   afterEach(function() {
-    // TODO: Investigate why this is needed on Node v0.12
-    cls.destroyNamespace();
-    agent.private_().namespace = cls.createNamespace();
+    common.clearNamespace(agent);
   });
 
   it('should work with string url', function(done) {

--- a/test/test-trace-header-context.js
+++ b/test/test-trace-header-context.js
@@ -16,7 +16,7 @@
 'use strict';
 
 var common = require('./hooks/common.js');
-//var cls = require('../src/cls.js');
+var cls = require('../src/cls.js');
 var http = require('http');
 var assert = require('assert');
 var constants = require('../src/constants.js');
@@ -27,6 +27,12 @@ describe('test-trace-header-context', function() {
   before(function() {
     agent = require('..').start({ samplingRate: 0 });
     express = require('./hooks/fixtures/express4');
+  });
+
+  afterEach(function() {
+    // TODO: Investigate why this is needed on Node v0.12
+    cls.destroyNamespace();
+    agent.private_().namespace = cls.createNamespace();
   });
 
   it('should work with string url', function(done) {

--- a/test/test-trace-header-context.js
+++ b/test/test-trace-header-context.js
@@ -16,7 +16,6 @@
 'use strict';
 
 var common = require('./hooks/common.js');
-var cls = require('../src/cls.js');
 var http = require('http');
 var assert = require('assert');
 var constants = require('../src/constants.js');

--- a/test/test-trace-header-context.js
+++ b/test/test-trace-header-context.js
@@ -16,7 +16,7 @@
 'use strict';
 
 var common = require('./hooks/common.js');
-var cls = require('../src/cls.js');
+//var cls = require('../src/cls.js');
 var http = require('http');
 var assert = require('assert');
 var constants = require('../src/constants.js');
@@ -25,14 +25,8 @@ describe('test-trace-header-context', function() {
   var agent;
   var express;
   before(function() {
-    agent = require('..').start({ samplingRate: 0 }).private_();
+    agent = require('..').start({ samplingRate: 0 });
     express = require('./hooks/fixtures/express4');
-  });
-
-  afterEach(function() {
-    // TODO: Investigate why this is needed
-    cls.destroyNamespace();
-    agent.namespace = cls.createNamespace();
   });
 
   it('should work with string url', function(done) {

--- a/test/test-trace-koa.js
+++ b/test/test-trace-koa.js
@@ -27,7 +27,7 @@ describe('test-trace-koa', function() {
   var agent;
   var koa;
   before(function() {
-    agent = require('..').start().private_();
+    agent = require('..').start();
     koa = require('./hooks/fixtures/koa1');
   });
 

--- a/test/test-trace-options-sampling.js
+++ b/test/test-trace-options-sampling.js
@@ -28,7 +28,7 @@ describe('express + mongo with trace options header + sampling', function() {
   var agent;
   var express;
   before(function() {
-    agent = require('..').start({ samplingRate: 1 }).private_();
+    agent = require('..').start({ samplingRate: 1 });
     express = require('./hooks/fixtures/express4');
   });
 

--- a/test/test-trace-options.js
+++ b/test/test-trace-options.js
@@ -29,7 +29,7 @@ describe('express + mongo with trace options header', function() {
   var agent;
   var express;
   before(function() {
-    agent = require('..').start({ samplingRate: 0 }).private_();
+    agent = require('..').start({ samplingRate: 0 });
     express = require('./hooks/fixtures/express4');
   });
 

--- a/test/test-trace-writer.js
+++ b/test/test-trace-writer.js
@@ -19,6 +19,7 @@
 var assert = require('assert');
 var nock = require('nock');
 var cls = require('../src/cls.js');
+var common = require('./hooks/common.js');
 var trace = require('..');
 var request = require('request');
 
@@ -29,9 +30,9 @@ var path = '/v1/projects/0/traces';
 
 process.env.GCLOUD_PROJECT = 0;
 
-var queueSpans = function(n, privateAgent) {
+var queueSpans = function(n, agent) {
   for (var i = 0; i < n; i++) {
-    privateAgent.createRootSpanData('name', 1, 0).close();
+    common.createRootSpanData(agent, 'name', 1, 0).close();
   }
 };
 
@@ -56,11 +57,11 @@ describe('tracewriter publishing', function() {
       samplingRate: 0,
       forceNewAgent_: true
     });
-    var privateAgent = agent.private_();
-    privateAgent.traceWriter.request_ = request; // Avoid authing
+    var traceWriter = common.getTraceWriter(agent);
+    traceWriter.request_ = request; // Avoid authing
     cls.getNamespace().run(function() {
-      queueSpans(2, privateAgent);
-      buf = privateAgent.traceWriter.buffer_;
+      queueSpans(2, agent);
+      buf = traceWriter.buffer_;
       setTimeout(function() {
         scope.done();
         done();
@@ -81,11 +82,11 @@ describe('tracewriter publishing', function() {
       samplingRate: -1,
       forceNewAgent_: true
     });
-    var privateAgent = agent.private_();
-    privateAgent.traceWriter.request_ = request; // Avoid authing
+    var traceWriter = common.getTraceWriter(agent);
+    traceWriter.request_ = request; // Avoid authing
     cls.getNamespace().run(function() {
-      queueSpans(1, privateAgent);
-      buf = privateAgent.traceWriter.buffer_;
+      queueSpans(1, agent);
+      buf = traceWriter.buffer_;
       setTimeout(function() {
         scope.done();
         done();
@@ -106,11 +107,11 @@ describe('tracewriter publishing', function() {
       samplingRate: -1,
       forceNewAgent_: true
     });
-    var privateAgent = agent.private_();
-    privateAgent.traceWriter.request_ = request; // Avoid authing
+    var traceWriter = common.getTraceWriter(agent);
+    traceWriter.request_ = request; // Avoid authing
     cls.getNamespace().run(function() {
-      queueSpans(2, privateAgent);
-      buf = privateAgent.traceWriter.buffer_;
+      queueSpans(2, agent);
+      buf = traceWriter.buffer_;
       setTimeout(function() {
         scope.done();
         done();

--- a/test/test-unpatch.js
+++ b/test/test-unpatch.js
@@ -19,6 +19,8 @@
 var assert = require('assert');
 var trace = require('..');
 
+var common = require('./hooks/common.js');
+
 describe('index.js', function() {
   var agent;
   var checkUnpatches = [];
@@ -27,7 +29,7 @@ describe('index.js', function() {
   });
 
   afterEach(function() {
-    agent.private_().stop();
+    common.stopAgent(agent);
     checkUnpatches.forEach(function(f) { f(); });
     checkUnpatches = [];
   });


### PR DESCRIPTION
With this PR, `agent.private_()` is only used directly in `common.js`.  Thus, tests only use functionality provided through `agent.private_()` through functions exposed through `common.js`.