### PR TITLE
Plugins with falsey paths don't get loaded

### DIFF
--- a/config.js
+++ b/config.js
@@ -33,12 +33,16 @@ module.exports = {
     // `enhancedDatabaseReporting` is enabled.
     databaseResultReportingSize: 127,
 
-    // An object describing which modules to trace. To enable tracing for a
-    // module, add its name as a key under this object, as well as the
-    // require-friendly module path of the plugin that implements tracing for
-    // that module as the corresponding value. Relative paths are not accepted.
-    // An empty object means that no modules will be automatically traced at
-    // all.
+    // A list of trace plugins to load. Each field's key in this object is the
+    // name of the module to trace, and its value is the require-friendly path
+    // to the plugin.
+    // By default, all of the following plugins are loaded.
+    // Specifying a different object for this field in the configuration passed
+    // to the method that starts the trace agent will cause that object to be
+    // merged with this one.
+    // To disable a plugin in this list, you may override its path with a falsey
+    // value. Disabling any of the default plugins may cause unwanted behavior,
+    // so use caution.
     // This field is experimental.
     plugins: {
       'connect': path.join(__dirname, 'src/plugins/plugin-connect.js'),

--- a/config.js
+++ b/config.js
@@ -43,7 +43,6 @@ module.exports = {
     // To disable a plugin in this list, you may override its path with a falsey
     // value. Disabling any of the default plugins may cause unwanted behavior,
     // so use caution.
-    // This field is experimental.
     plugins: {
       'connect': path.join(__dirname, 'src/plugins/plugin-connect.js'),
       'express': path.join(__dirname, 'src/plugins/plugin-express.js'),

--- a/src/trace-plugin-loader.js
+++ b/src/trace-plugin-loader.js
@@ -59,6 +59,9 @@ function activate(agent) {
 
   var pluginConfig = agent.config().plugins;
   for (var moduleName in pluginConfig) {
+    if (!pluginConfig[moduleName]) {
+      continue;
+    }
     // Create a new object exposing functions to create trace spans and
     // propagate context. This relies on functions currently exposed by the
     // agent.

--- a/test/test-plugin-loader.js
+++ b/test/test-plugin-loader.js
@@ -276,7 +276,6 @@ describe('Trace Plugin Loader', function() {
    * show that patching isn't irreversible (and neither is unpatching)
    */
   it('can unpatch', function() {
-    // Unfortunately, intercepted modules cannot be patched.
     addModuleMock('module-j', '1.0.0', {
       getPatchMode: function() { return 'none'; }
     });
@@ -303,5 +302,14 @@ describe('Trace Plugin Loader', function() {
     }));
     assert.strictEqual(require('module-j').getPatchMode(), 'patch',
       'Patches still work after unpatching');
+  });
+
+  it('doesn\'t load plugins with falsey paths', function() {
+    var moduleExports = {};
+    addModuleMock('module-k', '1.0.0', moduleExports);
+    assert(require('module-k') === moduleExports);
+    pluginLoader.activate(createFakeAgent({ 'module-k': '' }));
+    assert(require('module-k') === moduleExports,
+      'Module exports the same thing as before');
   });
 });


### PR DESCRIPTION
This change seeks to introduce not loading a plugin if its path is falsey.

This would make it possible to stop built-in plugins from loading. While we have previously discussed that we don't necessarily know what use cases we are supporting with this, I can name one now: I want to be able to run per-plugin benchmarks, and it would be really neat to isolate a single plugin at a time.

I think falsey is the best approach here because we know for sure that it's not a valid path.

@GoogleCloudPlatform/node-team PTAL.