### PR TITLE
Plugin loader throws for plugins with glaring issues

### DIFF
--- a/src/trace-plugin-loader.js
+++ b/src/trace-plugin-loader.js
@@ -51,14 +51,17 @@ function checkLoadedModules() {
 
 function checkPatch(patch) {
   if (!patch.patch && !patch.intercept) {
-    throw new Error('Plugin patch for ' + patch + ' doesn\'t patch ' +
+    throw new Error('Plugin for ' + patch.file + ' doesn\'t patch ' +
       'anything.');
   } else if (patch.patch && patch.intercept) {
-    throw new Error('Plugin patch for ' + patch.file + ' has ' +
+    throw new Error('Plugin for ' + patch.file + ' has ' +
       'both intercept and patch functions.');
   } else if (patch.unpatch && patch.intercept) {
-    logger.warn('Plugin patch for ' + patch.file + ': unpatch is not ' +
-      'compatible with intercept.');
+    logger.warn('Plugin for ' + patch.file + ': unpatch is not compatible ' +
+      'with intercept.');
+  } else if (patch.patch && !patch.unpatch) {
+    logger.warn('Plugin for ' + patch.file + ': patch method given without ' +
+      'accompanying unpatch.');
   }
 }
 

--- a/src/trace-plugin-loader.js
+++ b/src/trace-plugin-loader.js
@@ -49,6 +49,19 @@ function checkLoadedModules() {
   }
 }
 
+function checkPatch(patch) {
+  if (!patch.patch && !patch.intercept) {
+    throw new Error('Plugin patch for ' + patch + ' doesn\'t patch ' +
+      'anything.');
+  } else if (patch.patch && patch.intercept) {
+    throw new Error('Plugin patch for ' + patch.file + ' has ' +
+      'both intercept and patch functions.');
+  } else if (patch.unpatch && patch.intercept) {
+    logger.warn('Plugin patch for ' + patch.file + ': unpatch is not ' +
+      'compatible with intercept.');
+  }
+}
+
 function activate(agent) {
   if (activated) {
     logger.error('Plugins activated more than once.');
@@ -93,6 +106,7 @@ function activate(agent) {
               unpatch: patch.unpatch,
               intercept: patch.intercept
             };
+            checkPatch(patchSet[file]);
           }
         });
         if (Object.keys(patchSet).length === 0) {

--- a/test/test-plugin-loader.js
+++ b/test/test-plugin-loader.js
@@ -312,4 +312,38 @@ describe('Trace Plugin Loader', function() {
     assert(require('module-k') === moduleExports,
       'Module exports the same thing as before');
   });
+
+  /**
+   * Loads plugins with bad patches and ensures that they throw/log
+   */
+  it('throws and warns for serious problems', function() {
+    addModuleMock('module-k', '1.0.0', {});
+    addModuleMock('module-k-plugin-noop', '', [{}]);
+    addModuleMock('module-k-plugin-pi', '', [{
+      patch: function() {},
+      intercept: function() { return 'intercepted'; }
+    }]);
+    addModuleMock('module-k-plugin-upi', '', [{
+      unpatch: function() {},
+      intercept: function() { return 'intercepted'; }
+    }]);
+    pluginLoader.activate(createFakeAgent({
+      'module-k': 'module-k-plugin-noop'
+    }))
+    assert.throws(function() { require('module-k'); },
+      'Loading patch object with no patch/intercept function throws');
+    pluginLoader.deactivate();
+    pluginLoader.activate(createFakeAgent({
+      'module-k': 'module-k-plugin-pi'
+    }))
+    assert.throws(function() { require('module-k'); },
+      'Loading patch object with both patch/intercept functions throws');
+    pluginLoader.deactivate();
+    pluginLoader.activate(createFakeAgent({
+      'module-k': 'module-k-plugin-upi'
+    }))
+    assert.strictEqual(require('module-k'), 'intercepted');
+    assert(logs.warn.indexOf('unpatch is not compatible with intercept') !== -1,
+      'Warn when plugin has both unpatch and intercept');
+  });
 });

--- a/test/test-plugin-loader.js
+++ b/test/test-plugin-loader.js
@@ -333,21 +333,21 @@ describe('Trace Plugin Loader', function() {
     
     pluginLoader.activate(createFakeAgent({
       'module-k': 'module-k-plugin-noop'
-    }))
+    }));
     assert.throws(function() { require('module-k'); },
       'Loading patch object with no patch/intercept function throws');
     pluginLoader.deactivate();
 
     pluginLoader.activate(createFakeAgent({
       'module-k': 'module-k-plugin-pi'
-    }))
+    }));
     assert.throws(function() { require('module-k'); },
       'Loading patch object with both patch/intercept functions throws');
     pluginLoader.deactivate();
 
     pluginLoader.activate(createFakeAgent({
       'module-k': 'module-k-plugin-upi'
-    }))
+    }));
     assert.strictEqual(require('module-k'), 'intercepted');
     assert(logs.warn.indexOf('unpatch is not compatible with intercept') !== -1,
       'Warn when plugin has both unpatch and intercept');
@@ -355,7 +355,7 @@ describe('Trace Plugin Loader', function() {
 
     pluginLoader.activate(createFakeAgent({
       'module-k': 'module-k-plugin-noup'
-    }))
+    }));
     assert.ok(require('module-k').patched);
     assert(logs.warn.indexOf('without accompanying unpatch') !== -1,
       'Warn when plugin has both patch and no unpatch');

--- a/test/test-plugin-loader.js
+++ b/test/test-plugin-loader.js
@@ -327,23 +327,37 @@ describe('Trace Plugin Loader', function() {
       unpatch: function() {},
       intercept: function() { return 'intercepted'; }
     }]);
+    addModuleMock('module-k-plugin-noup', '', [{
+      patch: function(m) { m.patched = true; }
+    }]);
+    
     pluginLoader.activate(createFakeAgent({
       'module-k': 'module-k-plugin-noop'
     }))
     assert.throws(function() { require('module-k'); },
       'Loading patch object with no patch/intercept function throws');
     pluginLoader.deactivate();
+
     pluginLoader.activate(createFakeAgent({
       'module-k': 'module-k-plugin-pi'
     }))
     assert.throws(function() { require('module-k'); },
       'Loading patch object with both patch/intercept functions throws');
     pluginLoader.deactivate();
+
     pluginLoader.activate(createFakeAgent({
       'module-k': 'module-k-plugin-upi'
     }))
     assert.strictEqual(require('module-k'), 'intercepted');
     assert(logs.warn.indexOf('unpatch is not compatible with intercept') !== -1,
       'Warn when plugin has both unpatch and intercept');
+    pluginLoader.deactivate();
+
+    pluginLoader.activate(createFakeAgent({
+      'module-k': 'module-k-plugin-noup'
+    }))
+    assert.ok(require('module-k').patched);
+    assert(logs.warn.indexOf('without accompanying unpatch') !== -1,
+      'Warn when plugin has both patch and no unpatch');
   });
 });


### PR DESCRIPTION
Throw for plugin patches
- with both `patch` and `intercept`
- with neither

Warn for plugin patches
- with `unpatch` and `intercept` (should this throw as well?)

Open to any thoughts regarding severity level.