### PR TITLE
Add Support for redis 2.7

### DIFF
--- a/src/plugins/plugin-redis.js
+++ b/src/plugins/plugin-redis.js
@@ -183,7 +183,7 @@ function unwrapInstallStreamListeners(redis) {
 module.exports = [
   {
     file: '',
-    versions: '2.6',
+    versions: '>=2.6',
     patch: function(redis, api) {
       wrapCreateStream(redis, api);
       wrapInternalSendCommand(redis, api);
@@ -197,7 +197,7 @@ module.exports = [
   },
   {
     file: '',
-    versions: '>2.3.x <2.6',
+    versions: '>2.3 <2.6',
     patch: function(redis, api) {
       wrapSendCommand(redis, api);
       wrapCreateStream(redis, api);
@@ -211,7 +211,7 @@ module.exports = [
   },
   {
     file: '',
-    versions: '<=2.3.x',
+    versions: '<=2.3',
     patch: function(redis, api) {
       wrapSendCommand(redis, api);
       wrapInstallStreamListeners(redis, api);

--- a/test/plugins/fixtures/redis2.x/package.json
+++ b/test/plugins/fixtures/redis2.x/package.json
@@ -3,6 +3,6 @@
   "version": "1.0.0",
   "main": "index.js",
   "dependencies": {
-    "redis": "^2.2.5"
+    "redis": "^2.x"
   }
 }

--- a/test/plugins/test-trace-redis.js
+++ b/test/plugins/test-trace-redis.js
@@ -28,7 +28,7 @@ var RESULT_SIZE = 5;
 var assert = require('assert');
 var versions = {
   redis0: './fixtures/redis0.12',
-  // Our patches are different on redis <2.3, 2.3 - 2.6, and >2.6
+  // Our patches are different on redis <=2.3, >2.3 <2.6, and >=2.6
   redis2dot3: './fixtures/redis2.3',
   redis2dot4: './fixtures/redis2.4',
   redis2dotx: './fixtures/redis2.x',


### PR DESCRIPTION
The only change needed for this is expanding the semver condition range for the 2.6 patch to include 2.7 as well.