### PR TITLE
Add url field to hapi middleware options

### DIFF
--- a/src/plugins/plugin-hapi.js
+++ b/src/plugins/plugin-hapi.js
@@ -37,6 +37,7 @@ function createMiddleware(api) {
     var originalEnd = res.end;
     var options = {
       name: urlParse(req.url).pathname,
+      url: urlParse(req.url).pathname,
       traceContext: req.headers[api.constants.TRACE_CONTEXT_HEADER_NAME],
       skipFrames: 3
     };


### PR DESCRIPTION
Currently, the config ignoreUrls won't work when working with a Hapi server, since the url field does not exist when `runInRootSpan` is called.

See #446 