### PR TITLE
Stop running google-gax unit test on v0.12

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ The agent will also automatic trace of the following kinds of RPCs:
 * [Redis](https://www.npmjs.com/package/redis) (versions 0.12 - 2)
 * [MySQL](https://www.npmjs.com/package/mysql) (version ^2.9)
 
-*Note: The latest versions of gRPC (versions 1.1 and up) have dropped support for Node.js <4.0. We do not officially support tracing gRPC on unsupported versions of Node.js.
+*Note: The latest versions of gRPC (versions 1.1 and up) have dropped support for Node.js <4.0. We do not support tracing gRPC on unsupported versions of Node.js.
 
 You can use the [Custom Tracing API](#custom-tracing-api) to trace other processes in your application.
 

--- a/README.md
+++ b/README.md
@@ -103,18 +103,20 @@ This is the trace list that shows a sampling of the incoming requests your appli
 
 The trace agent can do automatic tracing of the following web frameworks:
 * [express](https://www.npmjs.com/package/express) (version 4)
-* [gRPC](https://www.npmjs.com/package/grpc) server (version 1)
+* [gRPC](https://www.npmjs.com/package/grpc)* server (version 1)
 * [hapi](https://www.npmjs.com/package/hapi) (versions 8 - 16)
 * [koa](https://www.npmjs.com/package/koa) (version 1)
 * [restify](https://www.npmjs.com/package/restify) (versions 3 - 4)
 
 The agent will also automatic trace of the following kinds of RPCs:
 * Outbound HTTP requests through the `http` and `https` core modules
-* [gRPC](https://www.npmjs.com/package/grpc) client (version 1)
+* [gRPC](https://www.npmjs.com/package/grpc)* client (version 1)
 * [MongoDB-core](https://www.npmjs.com/package/mongodb-core) (version 1)
 * [Mongoose](https://www.npmjs.com/package/mongoose) (version 4)
 * [Redis](https://www.npmjs.com/package/redis) (versions 0.12 - 2)
 * [MySQL](https://www.npmjs.com/package/mysql) (version ^2.9)
+
+*Note: The latest versions of gRPC (versions 1.1 and up) have dropped support for Node.js <4.0. We do not officially support tracing gRPC on unsupported versions of Node.js.
 
 You can use the [Custom Tracing API](#custom-tracing-api) to trace other processes in your application.
 

--- a/bin/run-test.sh
+++ b/bin/run-test.sh
@@ -41,7 +41,8 @@ function run {
 # Run test/coverage
 for test in test/test-*.js test/plugins/*.js ;
 do
-  if [[ ! $(node --version) =~ v0\.12\..* || ! "${test}" =~ .*trace\-koa\.js ]]
+# not v0.12 or not koa = not (v0.12 and koa)
+  if [[ ! $(node --version) =~ v0\.12\..* || ! "${test}" =~ .*trace\-(koa|google\-gax)\.js ]]
   then
     run "${test}"
   fi


### PR DESCRIPTION
The `google-gax` plugin unit test doesn't work on Node v0.12 + gRPC v1.2, so this change stops it from running. I've also added a disclaimer in the README stating that in general, we won't officially provide support for modules that depend on gRPC (or gRPC itself) if the application is running on a version of Node that that version of gRPC does not support.