### PR TITLE
Allow Manual Test Fixture Management

### DIFF
--- a/bin/clean-test-fixtures.sh
+++ b/bin/clean-test-fixtures.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+find test/plugins/fixtures/ -name node_modules -exec rm -Rv {} \; 2> /dev/null

--- a/bin/install-test-fixtures.sh
+++ b/bin/install-test-fixtures.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# Install framework deps
+for dir in test/plugins/fixtures/*/ ;
+do
+  echo -en "travis_fold:start:npm_install_${dir}\\r" | tr / _
+  pushd "${dir}"
+  if [ -d 'node_modules' ] ; then
+    echo "Skipping npm install in ${dir} since node_modules already exists"
+  else
+    echo "npm install in ${dir}"
+    npm install || exit 1
+  fi
+  popd
+  echo -en "travis_fold:end:npm_install_${dir}\\r" | tr / _
+done

--- a/bin/run-test.sh
+++ b/bin/run-test.sh
@@ -18,14 +18,7 @@ done
 # Lint
 jshint . || exit 1
 
-# Install framework deps
-for dir in test/plugins/fixtures/*/ ;
-do
-  echo -en "travis_fold:start:npm_install_${dir}\\r" | tr / _
-  echo "npm install in ${dir}"
-  (cd "${dir}"; npm install) || exit 1
-  echo -en "travis_fold:end:npm_install_${dir}\\r" | tr / _
-done
+./bin/install-test-fixtures.sh
 
 # Get test/coverage command
 counter=0


### PR DESCRIPTION
This change adds the `bin/install-test-fixtures.sh` and `clean-test-fixtures.sh` files.

In particular, `bin/run-test.sh` calls `bin/install-test-fixtures.sh` which only does an `npm install` on fixture directories that do not have a `node_modules` directory.

This should not alter how tests are run in the CI, but should make local testing faster.