### PR TITLE
Update trace label names

### DIFF
--- a/src/trace-labels.js
+++ b/src/trace-labels.js
@@ -26,78 +26,78 @@ var TraceLabels = {};
  * @type {string} The well-known label for http status code.
  */
 TraceLabels.HTTP_RESPONSE_CODE_LABEL_KEY =
-    'trace.cloud.google.com/http/status_code';
+    '/http/status_code';
 
 
 /**
  * @type {string} The well-known label for http request url.
  */
-TraceLabels.HTTP_URL_LABEL_KEY = 'trace.cloud.google.com/http/url';
+TraceLabels.HTTP_URL_LABEL_KEY = '/http/url';
 
 
 /**
  * @type {string} The well-known label for http method.
  */
-TraceLabels.HTTP_METHOD_LABEL_KEY = 'trace.cloud.google.com/http/method';
+TraceLabels.HTTP_METHOD_LABEL_KEY = '/http/method';
 
 /**
  * @type {string} The well-known label for http response size.
  */
-TraceLabels.HTTP_RESPONSE_SIZE_LABEL_KEY = 'trace.cloud.google.com/http/response/size';
+TraceLabels.HTTP_RESPONSE_SIZE_LABEL_KEY = '/http/response/size';
 
 /**
  * @type {string} The well-known label for stack-traces
  */
-TraceLabels.STACK_TRACE_DETAILS_KEY = 'trace.cloud.google.com/stacktrace';
+TraceLabels.STACK_TRACE_DETAILS_KEY = '/stacktrace';
 
 /**
  * @type {string} The well-known label for network error name.
  */
-TraceLabels.ERROR_DETAILS_NAME = 'trace.cloud.google.com/error/name';
+TraceLabels.ERROR_DETAILS_NAME = '/error/name';
 
 /**
  * @type {string} The well-known label for network error message.
  */
-TraceLabels.ERROR_DETAILS_MESSAGE = 'trace.cloud.google.com/error/message';
+TraceLabels.ERROR_DETAILS_MESSAGE = '/error/message';
 
 /**
  * @type {string} The well-known label for the app version on AppEngine.
  */
-TraceLabels.GAE_VERSION = 'trace.cloud.google.com/gae/app/version';
+TraceLabels.GAE_VERSION = 'g.co/gae/app/version';
 
 /**
  * @type {string} The well-known label for the module name on AppEngine.
  */
-TraceLabels.GAE_MODULE_NAME = 'trace.cloud.google.com/gae/app/module';
+TraceLabels.GAE_MODULE_NAME = 'g.co/gae/app/module';
 
 /**
  * @type {string} The well-known label for the module version on AppEngine.
  */
-TraceLabels.GAE_MODULE_VERSION = 'trace.cloud.google.com/gae/app/module_version';
+TraceLabels.GAE_MODULE_VERSION = 'g.co/gae/app/module_version';
 
 /**
  * @type {string} The label for GCE instance id. This is not a label
  *   recognized by the trace API.
  */
-TraceLabels.GCE_INSTANCE_ID = 'trace.cloud.google.com/gce/instanceid';
+TraceLabels.GCE_INSTANCE_ID = 'g.co/gce/instanceid';
 
 /**
  * @type {string} The label for GCE hostname. This is not a label
  *   recognized by the trace API.
  */
-TraceLabels.GCE_HOSTNAME = 'trace.cloud.google.com/gce/hostname';
+TraceLabels.GCE_HOSTNAME = 'g.co/gce/hostname';
 
 /**
  * @type {string} The label for http request source ip. This is not a
  *   label recognized by the trace API.
  */
-TraceLabels.HTTP_SOURCE_IP = 'trace.cloud.google.com/http/source/ip';
+TraceLabels.HTTP_SOURCE_IP = '/http/source/ip';
 
 /**
  * @type {string} The well-known label for agent metadata.
  *   Values should have the form "<name> <version>".
  */
-TraceLabels.AGENT_DATA = 'trace.cloud.google.com/agent';
+TraceLabels.AGENT_DATA = '/agent';
 
 
 /**


### PR DESCRIPTION
The trace service recently changed the names of common labels to reduce
label key size. Updating these to use the new expected names.