### PR TITLE
drop dependency on dummy counter module

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
   },
   "dependencies": {
     "@google-cloud/common": "^0.12.0",
-    "counter_google-cloud_trace-agent": "^0.1.0",
     "continuation-local-storage": "^3.1.4",
     "extend": "^3.0.0",
     "gcp-metadata": "^0.1.0",


### PR DESCRIPTION
Now that npm has download stats for scoped modules, we no longer need this.