### PR TITLE
pass valid TestRequest message in grpc test

### DIFF
--- a/test/test-grpc-context.js
+++ b/test/test-grpc-context.js
@@ -84,7 +84,7 @@ Object.keys(versions).forEach(function(version) {
 
       app.get('/server', function(req, res) {
         var httpRequester = requestAndSendHTTPStatus(res, 11);
-        var stream = client.testServerStream();
+        var stream = client.testServerStream({n: 3});
         stream.on('data', httpRequester);
         stream.on('status', httpRequester);
       });


### PR DESCRIPTION
gRPC 1.3 now throws on undefined.

Fixes: https://github.com/GoogleCloudPlatform/cloud-trace-nodejs/issues/473