### PR TITLE
Update deps

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ sudo: false
 language: node_js
 
 node_js:
-  - "0.12"
   - "4"
   - "6"
   - "7"

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This module provides Stackdriver Trace support for Node.js applications. [Stackd
 
 ## Prerequisites
 
-1. Your application will need to be using Node.js version 0.12 or greater.
+1. Your application will need to be using Node.js version 4.0 or greater.
 1. You will need a project in the [Google Developers Console][cloud-console]. Your application can run anywhere, but the trace data is associated with a particular project.
 1. [Enable the Trace API](https://console.cloud.google.com/flows/enableapi?apiid=cloudtrace) for your project.
 

--- a/bin/run-test.sh
+++ b/bin/run-test.sh
@@ -50,5 +50,3 @@ fi
 
 # Run non-interference tests
 node test/non-interference/http-e2e.js || exit 1
-node test/non-interference/express-e2e.js || exit 1
-node test/non-interference/restify-e2e.js || exit 1

--- a/package.json
+++ b/package.json
@@ -32,15 +32,14 @@
     "nock": "^9.0.0",
     "proxyquire": "^1.4.0",
     "request": "^2.61.0",
-    "retry-request": "^1.3.2",
     "timekeeper": "^1.0.0",
     "tmp": "0.0.31"
   },
   "dependencies": {
-    "@google-cloud/common": "^0.12.0",
+    "@google-cloud/common": "^0.13.2",
     "continuation-local-storage": "^3.1.4",
     "extend": "^3.0.0",
-    "gcp-metadata": "^0.1.0",
+    "gcp-metadata": "^0.2.0",
     "is": "^3.2.0",
     "lodash.findindex": "^4.4.0",
     "lodash.isequal": "^4.0.0",

--- a/test/fixtures/preloaded-agent.js
+++ b/test/fixtures/preloaded-agent.js
@@ -21,3 +21,6 @@ var agent = require('../../');
 assert(agent.get().isActive());
 
 console.log('Preload test passed.');
+// Exit explicitly since the process is being held open by retries to the
+// metadata service.
+process.exit(0);

--- a/test/fixtures/start-agent.js
+++ b/test/fixtures/start-agent.js
@@ -18,3 +18,6 @@
 process.env.GCLOUD_TRACE_LOGLEVEL = 4;
 require('glob'); // Load a module before agent
 require('../..').start();
+// Exit explicitly since the process is being held open by retries to the
+// metadata service.
+process.exit(0);

--- a/test/non-interference/http-e2e.js
+++ b/test/non-interference/http-e2e.js
@@ -49,7 +49,16 @@ var test_glob = semver.satisfies(process.version, '0.12.x') ?
 
 // Run tests
 console.log('Running tests');
-var gcloud_require = 'require(\'' + path.join(__dirname, '..', '..') +
+var gcloud_require =
+    'var proxyquire = require(\'' +
+    path.join(__dirname, '../../node_modules/proxyquire') +
+    '\');' +
+    'proxyquire(\'' +
+    path.join(__dirname, '../../node_modules/gcp-metadata') +
+    '\', { \'retry-request\': require(\'' +
+    path.join(__dirname, '../../node_modules/request') +
+    '\')});' +
+    'require(\'' + path.join(__dirname, '../..') +
     '\').start();';
 glob(test_glob, function(err, files) {
   var errors = 0;

--- a/test/plugins/common.js
+++ b/test/plugins/common.js
@@ -20,6 +20,12 @@ if (!process.env.GCLOUD_PROJECT) {
   process.exit(1);
 }
 
+var proxyquire  = require('proxyquire');
+// Monkeypatch gcp-metadata to not ask for retries at all.
+proxyquire('gcp-metadata', {
+  'retry-request': require('request')
+});
+
 // We want to disable publishing to avoid conflicts with production.
 require('../../src/trace-writer').publish_ = function() {};
 

--- a/test/test-agent-metadata.js
+++ b/test/test-agent-metadata.js
@@ -16,20 +16,9 @@
 
 'use strict';
 
-var proxyquire  = require('proxyquire');
 var assert = require('assert');
 var nock = require('nock');
-var retryRequest = require('retry-request');
 var traceLabels = require('../src/trace-labels.js');
-
-// Monkeypatch gcp-metadata to not ask for retries at all.
-proxyquire('gcp-metadata', {
-  'retry-request': function(requestOps, callback) {
-    return retryRequest(requestOps, {
-      retries: 0
-    }, callback);
-  }
-});
 
 var common = require('./plugins/common.js');
 var trace = require('..');

--- a/test/test-agent-stopped.js
+++ b/test/test-agent-stopped.js
@@ -16,23 +16,14 @@
 
 'use strict';
 
+require('./plugins/common.js');
 var assert = require('assert');
 var http = require('http');
 var nock = require('nock');
-var proxyquire  = require('proxyquire');
 
 describe('test-agent-stopped', function() {
   var agent;
   before(function(done) {
-    // Setup: Monkeypatch gcp-metadata to not ask for retries at all.
-    var retryRequest = require('retry-request');
-    proxyquire('gcp-metadata', {
-      'retry-request': function(requestOps, callback) {
-        return retryRequest(requestOps, {
-          retries: 0
-        }, callback);
-      }
-    });
     var scope = nock('http://metadata.google.internal')
                 .get('/computeMetadata/v1/project/project-id')
                 .reply(404);

--- a/test/test-trace-writer.js
+++ b/test/test-trace-writer.js
@@ -16,6 +16,7 @@
 
 'use strict';
 
+require('./plugins/common.js');
 var assert = require('assert');
 var fakeCredentials = require('./fixtures/gcloud-credentials.json');
 var nock = require('nock');

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,9 +2,9 @@
 # yarn lockfile v1
 
 
-"@google-cloud/common@^0.12.0":
-  version "0.12.2"
-  resolved "https://registry.yarnpkg.com/@google-cloud/common/-/common-0.12.2.tgz#78c344288c4605a29f4c2899391759d7dc817c43"
+"@google-cloud/common@^0.13.2":
+  version "0.13.2"
+  resolved "https://registry.yarnpkg.com/@google-cloud/common/-/common-0.13.2.tgz#f10c1b99f2ddc678c09b79c2b705043f0bb396f7"
   dependencies:
     array-uniq "^1.0.3"
     arrify "^1.0.1"
@@ -13,13 +13,13 @@
     duplexify "^3.5.0"
     ent "^2.2.0"
     extend "^3.0.0"
-    google-auto-auth "^0.5.2"
+    google-auto-auth "^0.6.0"
     is "^3.2.0"
     log-driver "^1.2.5"
     methmeth "^1.1.0"
     modelo "^4.2.0"
     request "^2.79.0"
-    retry-request "^1.3.2"
+    retry-request "^2.0.0"
     split-array-stream "^1.0.0"
     stream-events "^1.0.1"
     string-format-obj "^1.1.0"
@@ -114,6 +114,12 @@ async@^2.1.2, async@~2.1.5:
   dependencies:
     lodash "^4.14.0"
 
+async@^2.4.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/async/-/async-2.4.0.tgz#4990200f18ea5b837c2cc4f8c031a6985c385611"
+  dependencies:
+    lodash "^4.14.0"
+
 asynckit@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
@@ -164,7 +170,7 @@ boom@2.x.x:
   dependencies:
     hoek "2.x.x"
 
-brace-expansion@^1.0.0:
+brace-expansion@^1.1.7:
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.7.tgz#3effc3c50e000531fb720eaff80f0ae8ef23cf59"
   dependencies:
@@ -450,6 +456,12 @@ end-of-stream@1.0.0:
   dependencies:
     once "~1.3.0"
 
+end-of-stream@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/end-of-stream/-/end-of-stream-1.4.0.tgz#7a90d833efda6cfa6eac0f4949dbb0fad3a63206"
+  dependencies:
+    once "^1.4.0"
+
 ent@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/ent/-/ent-2.2.0.tgz#e964219325a21d05f44466a2f686ed6ce5f5dd1d"
@@ -535,6 +547,13 @@ gcp-metadata@^0.1.0:
     extend "^3.0.0"
     retry-request "^1.3.2"
 
+gcp-metadata@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/gcp-metadata/-/gcp-metadata-0.2.0.tgz#62dafca65f3a631bc8ce2ec3b77661f5f9387a0a"
+  dependencies:
+    extend "^3.0.0"
+    retry-request "^2.0.0"
+
 generate-function@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/generate-function/-/generate-function-2.0.0.tgz#6858fe7c0969b7d4e9093337647ac79f60dfbe74"
@@ -611,11 +630,12 @@ google-auth-library@^0.10.0:
     lodash.noop "^3.0.1"
     request "^2.74.0"
 
-google-auto-auth@^0.5.2:
-  version "0.5.4"
-  resolved "https://registry.yarnpkg.com/google-auto-auth/-/google-auto-auth-0.5.4.tgz#1d86c7928d633e75a9c1ab034a527efcce4a40b1"
+google-auto-auth@^0.6.0:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/google-auto-auth/-/google-auto-auth-0.6.1.tgz#c05d820e9454739ecf28a8892eeab3d1624f2cb3"
   dependencies:
     async "^2.1.2"
+    gcp-metadata "^0.1.0"
     google-auth-library "^0.10.0"
     object-assign "^3.0.0"
     request "^2.79.0"
@@ -759,10 +779,6 @@ is-object@~1.0.1:
 is-property@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/is-property/-/is-property-1.0.2.tgz#57fe1c4e48474edd65b09911f26b1cd4095dda84"
-
-is-stream-ended@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/is-stream-ended/-/is-stream-ended-0.1.0.tgz#40f058df6b044ee598fee4df7dc1ec2bcdd8df60"
 
 is-typedarray@~1.0.0:
   version "1.0.0"
@@ -1032,10 +1048,10 @@ mime@^1.2.11:
   resolved "https://registry.yarnpkg.com/mime/-/mime-1.3.4.tgz#115f9e3b6b3daf2959983cb38f149a2d40eb5d53"
 
 "minimatch@2 || 3", minimatch@^3.0.2, minimatch@~3.0.2:
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.3.tgz#2a4e4090b96b2db06a9d7df01055a62a77c9b774"
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
   dependencies:
-    brace-expansion "^1.0.0"
+    brace-expansion "^1.1.7"
 
 minimist@0.0.8, minimist@~0.0.1:
   version "0.0.8"
@@ -1122,7 +1138,7 @@ object-assign@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-3.0.0.tgz#9bedd5ca0897949bca47e7ff408062d549f587f2"
 
-once@1.x, once@^1.3.0:
+once@1.x, once@^1.3.0, once@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1"
   dependencies:
@@ -1311,7 +1327,7 @@ request@2.79.0:
     tunnel-agent "~0.4.1"
     uuid "^3.0.0"
 
-request@^2.61.0, request@^2.72.0, request@^2.74.0, request@^2.79.0:
+request@^2.61.0, request@^2.72.0, request@^2.74.0, request@^2.79.0, request@^2.81.0:
   version "2.81.0"
   resolved "https://registry.yarnpkg.com/request/-/request-2.81.0.tgz#c6928946a0e06c5f8d6f8a9333469ffda46298a0"
   dependencies:
@@ -1347,6 +1363,13 @@ retry-request@^1.3.2:
   resolved "https://registry.yarnpkg.com/retry-request/-/retry-request-1.3.2.tgz#59ad24e71f8ae3f312d5f7b4bcf467a5e5a57bd6"
   dependencies:
     request "2.76.0"
+    through2 "^2.0.0"
+
+retry-request@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/retry-request/-/retry-request-2.0.1.tgz#fce3d5cc53e307c7dd1b4a6395bbfac1ea5ae664"
+  dependencies:
+    request "^2.81.0"
     through2 "^2.0.0"
 
 right-align@^0.1.1:
@@ -1398,11 +1421,11 @@ source-map@~0.5.1:
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.6.tgz#75ce38f52bf0733c5a7f0c118d81334a2bb5f412"
 
 split-array-stream@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/split-array-stream/-/split-array-stream-1.0.0.tgz#d5e4ffacd306161d69ed5252ff56d57e7762eaa2"
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/split-array-stream/-/split-array-stream-1.0.2.tgz#f9678169186e0eb16db8164f350742d73305a1e8"
   dependencies:
-    async "^1.4.0"
-    is-stream-ended "^0.1.0"
+    async "^2.4.0"
+    end-of-stream "^1.4.0"
 
 split2@~2.1.1:
   version "2.1.1"
@@ -1430,10 +1453,10 @@ sshpk@^1.7.0:
     tweetnacl "~0.14.0"
 
 stream-events@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/stream-events/-/stream-events-1.0.1.tgz#4fe7b2bbfcc53e6af31087e8c540483f412ce8c6"
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/stream-events/-/stream-events-1.0.2.tgz#abf39f66c0890a4eb795bc8d5e859b2615b590b2"
   dependencies:
-    stubs "^1.1.0"
+    stubs "^3.0.0"
 
 stream-shift@^1.0.0:
   version "1.0.0"
@@ -1467,9 +1490,9 @@ strip-json-comments@1.0.x:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-1.0.4.tgz#1e15fbcac97d3ee99bf2d73b4c656b082bbafb91"
 
-stubs@^1.1.0:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/stubs/-/stubs-1.1.2.tgz#945a08975016318762f8f7060731002ab2a0960c"
+stubs@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/stubs/-/stubs-3.0.0.tgz#e8d2ba1fa9c90570303c030b6900f7d5f89abe5b"
 
 supports-color@3.1.2:
   version "3.1.2"
@@ -1550,8 +1573,8 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
 
 uglify-js@^2.6:
-  version "2.8.22"
-  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-2.8.22.tgz#d54934778a8da14903fa29a326fb24c0ab51a1a0"
+  version "2.8.23"
+  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-2.8.23.tgz#8230dd9783371232d62a7821e2cf9a817270a8a0"
   dependencies:
     source-map "~0.5.1"
     yargs "~3.10.0"


### PR DESCRIPTION
This change updates @google-cloud/common to a version which is no longer
compatable with node v0.12. To upgrade this dependency, we must drop
support for 0.12 as well. Additionally, we will stop running some of the
non-interference tests which only ran on 0.12. These tests will be
upgraded to work with newer versions of node in follow on work.