### PR TITLE
hapi/koa: End span when request is aborted

### DIFF
--- a/src/plugins/plugin-hapi.js
+++ b/src/plugins/plugin-hapi.js
@@ -82,6 +82,13 @@ function createMiddleware(api) {
         return returned;
       };
 
+      // if the event is aborted, end the span (as res.end will not be called)
+      req.once('aborted', function() {
+        root.addLabel(api.labels.ERROR_DETAILS_NAME, 'aborted');
+        root.addLabel(api.labels.ERROR_DETAILS_MESSAGE, 'client aborted the request');
+        root.endSpan();
+      });
+
       return reply.continue();
     });
   };

--- a/src/plugins/plugin-koa.js
+++ b/src/plugins/plugin-koa.js
@@ -66,6 +66,14 @@ function startSpanForRequest(api, req, res, next) {
 
       return returned;
     };
+
+    // if the event is aborted, end the span (as res.end will not be called)
+    req.once('aborted', function() {
+      root.addLabel(api.labels.ERROR_DETAILS_NAME, 'aborted');
+      root.addLabel(api.labels.ERROR_DETAILS_MESSAGE, 'client aborted the request');
+      root.endSpan();
+    });
+
     api.wrap(next);
   });
 }

--- a/test/plugins/test-trace-express.js
+++ b/test/plugins/test-trace-express.js
@@ -257,6 +257,35 @@ describe('test-trace-express', function() {
       });
     });
   });
+
+  it('should end spans even if client aborts', function(done) {
+    var app = express();
+    app.get('/', function (req, res) {
+      setTimeout(function() {
+        res.send(common.serverRes);
+        setImmediate(function() {
+          var traces = common.getTraces(agent);
+          assert.strictEqual(traces.length, 1);
+          assert.strictEqual(traces[0].spans.length, 1);
+          var span = traces[0].spans[0];
+          common.assertSpanDurationCorrect(span, common.serverWait);
+          done();
+        });
+      }, common.serverWait);
+    });
+    server = app.listen(common.serverPort, function() {
+      var req = http.get({port: common.serverPort, path: '/'},
+        function(res) {
+          assert.fail();
+        });
+      // Need error handler to catch socket hangup error
+      req.on('error', function() {});
+      // Give enough time for server to receive request
+      setTimeout(function() {
+        req.abort();
+      }, common.serverWait / 2);
+    });
+  });
 });
 
 function expressPredicate(span) {

--- a/test/plugins/test-trace-hapi.js
+++ b/test/plugins/test-trace-hapi.js
@@ -17,7 +17,7 @@
 
 var common = require('./common.js');
 
-var TraceLabels = require('../../src/trace-labels.js');
+var traceLabels = require('../../src/trace-labels.js');
 var http = require('http');
 var assert = require('assert');
 var constants = require('../../src/constants.js');
@@ -216,10 +216,10 @@ describe('hapi', function() {
         server.start(function() {
           http.get({port: common.serverPort}, function(res) {
             var labels = common.getMatchingSpan(agent, hapiPredicate).labels;
-            assert.equal(labels[TraceLabels.HTTP_RESPONSE_CODE_LABEL_KEY], '200');
-            assert.equal(labels[TraceLabels.HTTP_METHOD_LABEL_KEY], 'GET');
-            assert.equal(labels[TraceLabels.HTTP_URL_LABEL_KEY], 'http://localhost:9042/');
-            assert(labels[TraceLabels.HTTP_SOURCE_IP]);
+            assert.equal(labels[traceLabels.HTTP_RESPONSE_CODE_LABEL_KEY], '200');
+            assert.equal(labels[traceLabels.HTTP_METHOD_LABEL_KEY], 'GET');
+            assert.equal(labels[traceLabels.HTTP_URL_LABEL_KEY], 'http://localhost:9042/');
+            assert(labels[traceLabels.HTTP_SOURCE_IP]);
             done();
           });
         });
@@ -238,7 +238,7 @@ describe('hapi', function() {
         server.start(function() {
           http.get({port: common.serverPort}, function(res) {
             var labels = common.getMatchingSpan(agent, hapiPredicate).labels;
-            var stackTrace = JSON.parse(labels[TraceLabels.STACK_TRACE_DETAILS_KEY]);
+            var stackTrace = JSON.parse(labels[traceLabels.STACK_TRACE_DETAILS_KEY]);
             // Ensure that our middleware is on top of the stack
             assert.equal(stackTrace.stack_frame[0].method_name, 'middleware');
             done();
@@ -321,9 +321,9 @@ describe('hapi', function() {
               assert.strictEqual(traces.length, 1);
               assert.strictEqual(traces[0].spans.length, 1);
               var span = traces[0].spans[0];
-              assert.strictEqual(span.labels[TraceLabels.ERROR_DETAILS_NAME],
+              assert.strictEqual(span.labels[traceLabels.ERROR_DETAILS_NAME],
                 'aborted');
-              assert.strictEqual(span.labels[TraceLabels.ERROR_DETAILS_MESSAGE],
+              assert.strictEqual(span.labels[traceLabels.ERROR_DETAILS_MESSAGE],
                 'client aborted the request');
               common.assertSpanDurationCorrect(span, common.serverWait);
               done();

--- a/test/plugins/test-trace-hapi.js
+++ b/test/plugins/test-trace-hapi.js
@@ -17,7 +17,7 @@
 
 var common = require('./common.js');
 
-var traceLabels = require('../../src/trace-labels.js');
+var TraceLabels = require('../../src/trace-labels.js');
 var http = require('http');
 var assert = require('assert');
 var constants = require('../../src/constants.js');
@@ -43,8 +43,7 @@ describe('hapi', function() {
   before(function() {
     agent = require('../..').start({
       ignoreUrls: ['/ignore'],
-      samplingRate: 0,
-      logLevel: 4
+      samplingRate: 0
     });
   });
 
@@ -217,10 +216,10 @@ describe('hapi', function() {
         server.start(function() {
           http.get({port: common.serverPort}, function(res) {
             var labels = common.getMatchingSpan(agent, hapiPredicate).labels;
-            assert.equal(labels[traceLabels.HTTP_RESPONSE_CODE_LABEL_KEY], '200');
-            assert.equal(labels[traceLabels.HTTP_METHOD_LABEL_KEY], 'GET');
-            assert.equal(labels[traceLabels.HTTP_URL_LABEL_KEY], 'http://localhost:9042/');
-            assert(labels[traceLabels.HTTP_SOURCE_IP]);
+            assert.equal(labels[TraceLabels.HTTP_RESPONSE_CODE_LABEL_KEY], '200');
+            assert.equal(labels[TraceLabels.HTTP_METHOD_LABEL_KEY], 'GET');
+            assert.equal(labels[TraceLabels.HTTP_URL_LABEL_KEY], 'http://localhost:9042/');
+            assert(labels[TraceLabels.HTTP_SOURCE_IP]);
             done();
           });
         });
@@ -239,7 +238,7 @@ describe('hapi', function() {
         server.start(function() {
           http.get({port: common.serverPort}, function(res) {
             var labels = common.getMatchingSpan(agent, hapiPredicate).labels;
-            var stackTrace = JSON.parse(labels[traceLabels.STACK_TRACE_DETAILS_KEY]);
+            var stackTrace = JSON.parse(labels[TraceLabels.STACK_TRACE_DETAILS_KEY]);
             // Ensure that our middleware is on top of the stack
             assert.equal(stackTrace.stack_frame[0].method_name, 'middleware');
             done();
@@ -322,10 +321,11 @@ describe('hapi', function() {
               assert.strictEqual(traces.length, 1);
               assert.strictEqual(traces[0].spans.length, 1);
               var span = traces[0].spans[0];
-              assert.strictEqual(span.labels[traceLabels.ERROR_DETAILS_NAME],
+              assert.strictEqual(span.labels[TraceLabels.ERROR_DETAILS_NAME],
                 'aborted');
-              assert.strictEqual(span.labels[traceLabels.ERROR_DETAILS_MESSAGE],
+              assert.strictEqual(span.labels[TraceLabels.ERROR_DETAILS_MESSAGE],
                 'client aborted the request');
+              common.assertSpanDurationCorrect(span, common.serverWait);
               done();
             });
           }

--- a/test/plugins/test-trace-hapi.js
+++ b/test/plugins/test-trace-hapi.js
@@ -316,6 +316,10 @@ describe('hapi', function() {
           method: 'GET',
           path: '/',
           handler: function (req, reply) {
+            // Unlike with express and other frameworks, hapi doesn't call
+            // res.end if the request was aborted. As a call to res.end is
+            // conditional on this client-side behavior, we also listen for the
+            // 'aborted' event, and end the span there.
             req.raw.req.on('aborted', function() {
               var traces = common.getTraces(agent);
               assert.strictEqual(traces.length, 1);

--- a/test/plugins/test-trace-koa.js
+++ b/test/plugins/test-trace-koa.js
@@ -146,6 +146,10 @@ describe('koa', function() {
           }, common.serverWait / 2);
         });
         setTimeout(function() {
+          // Unlike with express and other frameworks, koa doesn't call
+          // res.end if the request was aborted. As a call to res.end is
+          // conditional on this client-side behavior, we also end a span in
+          // koa if the 'aborted' event is emitted.
           var traces = common.getTraces(agent);
           assert.strictEqual(traces.length, 1);
           assert.strictEqual(traces[0].spans.length, 1);

--- a/test/plugins/test-trace-koa.js
+++ b/test/plugins/test-trace-koa.js
@@ -19,7 +19,7 @@ var common = require('./common.js');
 var http = require('http');
 var assert = require('assert');
 var constants = require('../../src/constants.js');
-var TraceLabels = require('../../src/trace-labels.js');
+var traceLabels = require('../../src/trace-labels.js');
 var semver = require('semver');
 var appBuilders = {
   koa1: buildKoa1App
@@ -64,10 +64,10 @@ describe('koa', function() {
             res.on('end', function() {
               assert.equal(common.serverRes, result);
               var expectedKeys = [
-                TraceLabels.HTTP_METHOD_LABEL_KEY,
-                TraceLabels.HTTP_URL_LABEL_KEY,
-                TraceLabels.HTTP_SOURCE_IP,
-                TraceLabels.HTTP_RESPONSE_CODE_LABEL_KEY
+                traceLabels.HTTP_METHOD_LABEL_KEY,
+                traceLabels.HTTP_URL_LABEL_KEY,
+                traceLabels.HTTP_SOURCE_IP,
+                traceLabels.HTTP_RESPONSE_CODE_LABEL_KEY
               ];
               var span = common.getMatchingSpan(agent, koaPredicate);
               expectedKeys.forEach(function(key) {
@@ -84,7 +84,7 @@ describe('koa', function() {
         server = app.listen(common.serverPort, function() {
           http.get({port: common.serverPort}, function(res) {
             var labels = common.getMatchingSpan(agent, koaPredicate).labels;
-            var stackTrace = JSON.parse(labels[TraceLabels.STACK_TRACE_DETAILS_KEY]);
+            var stackTrace = JSON.parse(labels[traceLabels.STACK_TRACE_DETAILS_KEY]);
             // Ensure that our middleware is on top of the stack
             assert.equal(stackTrace.stack_frame[0].method_name, 'middleware');
             done();
@@ -150,9 +150,9 @@ describe('koa', function() {
           assert.strictEqual(traces.length, 1);
           assert.strictEqual(traces[0].spans.length, 1);
           var span = traces[0].spans[0];
-          assert.strictEqual(span.labels[TraceLabels.ERROR_DETAILS_NAME],
+          assert.strictEqual(span.labels[traceLabels.ERROR_DETAILS_NAME],
             'aborted');
-          assert.strictEqual(span.labels[TraceLabels.ERROR_DETAILS_MESSAGE],
+          assert.strictEqual(span.labels[traceLabels.ERROR_DETAILS_MESSAGE],
             'client aborted the request');
           common.assertSpanDurationCorrect(span, common.serverWait / 2);
           done();


### PR DESCRIPTION
This is an attempt to address #477.

Currently checking if the same problem is present in other web frameworks (it's not in express as far as I can tell).