### PR TITLE
patching: fix module-internal requires not being intercepted

### DIFF
--- a/src/trace-plugin-loader.js
+++ b/src/trace-plugin-loader.js
@@ -164,7 +164,7 @@ function activate(agent) {
           return patchedRoot;
         }
       } else {
-        var modulePath = Module._resolveFilename(request, parent);
+        var modulePath = Module._resolveFilename(request, parent).replace('/', path.sep);
         if (intercepts[modulePath]) {
           return intercepts[modulePath].interceptedValue;
         }

--- a/src/trace-plugin-loader.js
+++ b/src/trace-plugin-loader.js
@@ -151,8 +151,8 @@ function activate(agent) {
     // Future requires get patched as they get loaded.
     return function Module_load(request, parent, isMain) {
       var instrumentation = plugins[request];
-      var moduleRoot = util.findModulePath(request, parent);
       if (instrumentation) {
+        var moduleRoot = util.findModulePath(request, parent);
         var moduleVersion = util.findModuleVersion(moduleRoot, originalModuleLoad);
         if (moduleAlreadyPatched(instrumentation, moduleRoot, moduleVersion)) {
           return originalModuleLoad.apply(this, arguments);
@@ -163,8 +163,11 @@ function activate(agent) {
         if (patchedRoot !== null) {
           return patchedRoot;
         }
-      } else if (intercepts[moduleRoot]) {
-        return intercepts[moduleRoot].interceptedValue;
+      } else {
+        var modulePath = Module._resolveFilename(request, parent);
+        if (intercepts[modulePath]) {
+          return intercepts[modulePath].interceptedValue;
+        }
       }
       return originalModuleLoad.apply(this, arguments);
     };

--- a/test/test-plugin-loader.js
+++ b/test/test-plugin-loader.js
@@ -75,6 +75,16 @@ describe('Trace Plugin Loader', function() {
       };
     });
 
+    // Prevent filename resolution from happening to fake modules
+    shimmer.wrap(Module, '_resolveFilename', function(originalResolve) {
+      return function wrappedResolveFilename(request) {
+        if (fakeModules[request.replace('/', path.sep)]) {
+          return request;
+        }
+        return originalResolve.apply(this, arguments);
+      };
+    });
+
     // proxyquire the plugin loader with stubbed module utility methods
     pluginLoader = proxyquire('../src/trace-plugin-loader.js', {
       './util.js': {


### PR DESCRIPTION
Intercepts are only being done for top-level modules -- in other words, files being required internally within modules won't be intercepted.

In this fix, we cache modules that were intercepted in a separate object so that when loaded, we'll return the replaced value instead.