### PR TITLE
http: return response object for chaining #481

### DIFF
--- a/src/plugins/plugin-http.js
+++ b/src/plugins/plugin-http.js
@@ -92,7 +92,7 @@ function patchRequest (http, api) {
                 numBytes += chunk.length;
               });
             }
-            on.apply(this, arguments);
+            return on.apply(this, arguments);
           };
         });
         res.on('end', function () {


### PR DESCRIPTION
Fix for https://github.com/GoogleCloudPlatform/cloud-trace-nodejs/issues/481