### PR TITLE
trace policy: only call match if candidate isn't string

### DIFF
--- a/config.js
+++ b/config.js
@@ -65,14 +65,12 @@ module.exports = {
     // See `bufferSize`.
     flushDelaySeconds: 30,
 
-    // If paths are present in this array, then these paths will be ignored before
-    // `samplingRate` based decisions are made. Paths must include a leading
-    // forward slash and be of the form:
-    //   /componentOne/componentTwo/...
-    // Paths can additionally be classified by regex in which case any path matching
-    // any provided regex will be ignored.
+    // If an incoming request path matches any of the regular expressions (via
+    // String.prototype.match) in this array, then this request will be ignored
+    // before `samplingRate` based decisions are made.
+    // Objects in this array should be RegExp objects or strings.
     // We ignore the health checker probes (/_ah/health) by default.
-    ignoreUrls: [ '/_ah/health' ],
+    ignoreUrls: [ '^/_ah/health' ],
 
     // An upper bound on the number of traces to gather each second. If set to 0,
     // sampling is disabled and all traces are recorded. Sampling rates greater

--- a/src/tracing-policy.js
+++ b/src/tracing-policy.js
@@ -40,7 +40,7 @@ function FilterPolicy(basePolicy, filterUrls) {
 FilterPolicy.prototype.matches = function(url) {
   return this.filterUrls.some(function(candidate) {
     return (typeof candidate === 'string' && candidate === url) ||
-      url.match(candidate);
+      (typeof candidate !== 'string' && url.match(candidate));
   });
 };
 

--- a/src/tracing-policy.js
+++ b/src/tracing-policy.js
@@ -39,8 +39,7 @@ function FilterPolicy(basePolicy, filterUrls) {
 
 FilterPolicy.prototype.matches = function(url) {
   return this.filterUrls.some(function(candidate) {
-    return (typeof candidate === 'string' && candidate === url) ||
-      (typeof candidate !== 'string' && url.match(candidate));
+    return url.match(candidate);
   });
 };
 

--- a/test/test-trace-policy.js
+++ b/test/test-trace-policy.js
@@ -32,7 +32,7 @@ describe('FilterPolicy', function() {
   it('should allow non-filtered urls', function() {
     var policy = tracingPolicy.createTracePolicy({
       samplingRate: 0,
-      ignoreUrls: ['/_ah/health']
+      ignoreUrls: ['/_ah/health', '/']
     });
     assert(policy.shouldTrace(null, '/_ah/background'));
   });

--- a/test/test-trace-policy.js
+++ b/test/test-trace-policy.js
@@ -23,16 +23,19 @@ describe('FilterPolicy', function() {
   it('should not allow filtered urls', function() {
     var policy = tracingPolicy.createTracePolicy({
       samplingRate: 0,
-      ignoreUrls: ['/_ah/health', /\/book*/]
+      ignoreUrls: ['^/_ah/health', /^\/book*/, '/foo']
     });
     assert(!policy.shouldTrace(null, '/_ah/health'));
     assert(!policy.shouldTrace(null, '/book/test'));
+    assert(!policy.shouldTrace(null, '/foo'));
+    assert(!policy.shouldTrace(null, '/foo/bar'));
+    assert(!policy.shouldTrace(null, '/bar/foo'));
   });
 
   it('should allow non-filtered urls', function() {
     var policy = tracingPolicy.createTracePolicy({
       samplingRate: 0,
-      ignoreUrls: ['/_ah/health', '/']
+      ignoreUrls: ['^/_ah/health', '^/$']
     });
     assert(policy.shouldTrace(null, '/_ah/background'));
   });


### PR DESCRIPTION
This change makes it so that `String.prototype.match` is only called in `FilterPolicy` for `RegExp` objects. It shouldn't be called for strings -- consider if we wanted to ignore `'/'` but not anything else.