### PR TITLE
Unit tests should not depend on the environment

### DIFF
--- a/test/non-interference/express-e2e.js
+++ b/test/non-interference/express-e2e.js
@@ -25,14 +25,6 @@ var semver = require('semver');
 
 var SUPPORTED_VERSIONS = '<4.x';
 
-if (process.argv.length === 4 && process.argv[2] === '-p') {
-  process.env.GCLOUD_PROJECT = process.argv[3];
-}
-if (!process.env.GCLOUD_PROJECT) {
-  console.log('Project number must be provided with the -p flag or' +
-      ' the GCLOUD_PROJECT environment variable must be set.');
-  process.exit(1);
-}
 if (!semver.satisfies(process.version, SUPPORTED_VERSIONS)) {
   console.log('Express tests do not pass on Node.js 4.0 yet');
   process.exit(0);

--- a/test/non-interference/http-e2e.js
+++ b/test/non-interference/http-e2e.js
@@ -24,15 +24,6 @@ var path = require('path');
 var tmp = require('tmp');
 var semver = require('semver');
 
-if (process.argv.length === 4 && process.argv[2] === '-p') {
-  process.env.GCLOUD_PROJECT = process.argv[3];
-}
-if (!process.env.GCLOUD_PROJECT) {
-  console.log('Project number must be provided with the -p flag or' +
-      ' the GCLOUD_PROJECT environment variable must be set.');
-  process.exit(1);
-}
-
 // Setup
 var node_dir = tmp.dirSync().name;
 cp.execFileSync('git', ['clone', '--branch', process.version,

--- a/test/non-interference/mongo-e2e.js
+++ b/test/non-interference/mongo-e2e.js
@@ -21,15 +21,6 @@ var glob = require('glob');
 var path = require('path');
 var tmp = require('tmp');
 
-if (process.argv.length === 4 && process.argv[2] === '-p') {
-  process.env.GCLOUD_PROJECT = process.argv[3];
-}
-if (!process.env.GCLOUD_PROJECT) {
-  console.log('Project number must be provided with the -p flag or' +
-      ' the GCLOUD_PROJECT environment variable must be set.');
-  process.exit(1);
-}
-
 var tmp_dir = tmp.dirSync().name;
 process.chdir(path.join(__dirname, '..', '..'));
 console.log('Packing trace');

--- a/test/non-interference/restify-e2e.js
+++ b/test/non-interference/restify-e2e.js
@@ -25,14 +25,6 @@ var semver = require('semver');
 
 var SUPPORTED_VERSIONS = '<4.x';
 
-if (process.argv.length === 4 && process.argv[2] === '-p') {
-  process.env.GCLOUD_PROJECT = process.argv[3];
-}
-if (!process.env.GCLOUD_PROJECT) {
-  console.log('Project number must be provided with the -p flag or' +
-      ' the GCLOUD_PROJECT environment variable must be set.');
-  process.exit(1);
-}
 if (!semver.satisfies(process.version, SUPPORTED_VERSIONS)) {
   console.log('Restify tests do not pass on Node.js 4.0 yet');
   process.exit(0);

--- a/test/non-interference/start-agent.js
+++ b/test/non-interference/start-agent.js
@@ -36,6 +36,7 @@ shimmer.wrap(agent, 'get', function(original) {
   };
 });
 require('../..').start({
+  projectId: '0',
   logLevel: 1,
   samplingRate: 0
 });

--- a/test/plugins/common.js
+++ b/test/plugins/common.js
@@ -15,11 +15,6 @@
  */
 'use strict';
 
-if (!process.env.GCLOUD_PROJECT) {
-  console.log('The GCLOUD_PROJECT environment variable must be set.');
-  process.exit(1);
-}
-
 var proxyquire  = require('proxyquire');
 // Monkeypatch gcp-metadata to not ask for retries at all.
 proxyquire('gcp-metadata', {

--- a/test/plugins/test-plugins-interop-mongo-express.js
+++ b/test/plugins/test-plugins-interop-mongo-express.js
@@ -33,7 +33,7 @@ describe('mongodb + express', function() {
   var mongoose;
   var express;
   before(function() {
-    agent = require('../..').start();
+    agent = require('../..').start({ projectId: '0' });
     express = require('./fixtures/express4');
     mongoose = require('./fixtures/mongoose4');
     oldWarn = common.replaceWarnLogger(agent,

--- a/test/plugins/test-plugins-multi-version.js
+++ b/test/plugins/test-plugins-multi-version.js
@@ -30,6 +30,7 @@ describe('multiple instrumentations of the same module', function() {
 
   before(function() {
     agent = require('../..').start({
+      projectId: '0',
       enhancedDatabaseReporting: true,
       samplingRate: 0
     });

--- a/test/plugins/test-trace-connect.js
+++ b/test/plugins/test-trace-connect.js
@@ -29,6 +29,7 @@ describe('test-trace-connect', function() {
   var connect;
   before(function() {
     agent = require('../..').start({
+      projectId: '0',
       ignoreUrls: ['/ignore'],
       samplingRate: 0
     });

--- a/test/plugins/test-trace-express.js
+++ b/test/plugins/test-trace-express.js
@@ -29,6 +29,7 @@ describe('test-trace-express', function() {
   var express;
   before(function() {
     agent = require('../..').start({
+      projectId: '0',
       ignoreUrls: ['/ignore'],
       samplingRate: 0
     });

--- a/test/plugins/test-trace-generic-pool.js
+++ b/test/plugins/test-trace-generic-pool.js
@@ -15,11 +15,6 @@
  */
 'use strict';
 
-if (!process.env.GCLOUD_PROJECT) {
-  console.log('The GCLOUD_PROJECT environment variable must be set.');
-  process.exit(1);
-}
-
 var assert = require('assert');
 var common = require('./common');
 var semver = require('semver');
@@ -32,7 +27,10 @@ describe('generic-pool2', function() {
   var api;
   var genericPool;
   before(function() {
-    api = require('../..').start({ samplingRate: 0 });
+    api = require('../..').start({
+      projectId: '0',
+      samplingRate: 0
+    });
     genericPool = require('./fixtures/generic-pool2');
   });
 
@@ -87,7 +85,10 @@ describe('generic-pool3', function() {
   }
 
   before(function() {
-    agent = require('../..').start({ samplingRate: 0 });
+    agent = require('../..').start({
+      projectId: '0',
+      samplingRate: 0
+    });
     genericPool = require('./fixtures/generic-pool3');
   });
 

--- a/test/plugins/test-trace-google-gax.js
+++ b/test/plugins/test-trace-google-gax.js
@@ -25,6 +25,7 @@ describe('google-gax', function() {
 
   before(function() {
     agent = require('../..').start({
+      projectId: '0',
       enhancedDatabaseReporting: true,
       samplingRate: 0
     });

--- a/test/plugins/test-trace-google-gax.js
+++ b/test/plugins/test-trace-google-gax.js
@@ -26,16 +26,16 @@ describe('google-gax', function() {
   before(function() {
     agent = require('../..').start({
       projectId: '0',
+      keyFilename: path.join(__dirname, '..', 'fixtures', 
+          'gcloud-credentials.json'),
       enhancedDatabaseReporting: true,
       samplingRate: 0
     });
-    process.env.GOOGLE_APPLICATION_CREDENTIALS =
-        path.join(__dirname, '..', 'fixtures', 'gcloud-credentials.json');
-    speech = require('./fixtures/google-cloud-speech0.6')();
-  });
-
-  after(function() {
-    delete process.env.GOOGLE_APPLICATION_CREDENTIALS;
+    speech = require('./fixtures/google-cloud-speech0.6')({
+      projectId: '0',
+      keyFilename: path.join(__dirname, '..', 'fixtures', 
+          'gcloud-credentials.json'),    
+    });
   });
 
   it('should not interfere with google-cloud api tracing', function(done) {

--- a/test/plugins/test-trace-grpc.js
+++ b/test/plugins/test-trace-grpc.js
@@ -261,6 +261,7 @@ Object.keys(versions).forEach(function(version) {
     before(function() {
       // It is necessary for the samplingRate to be 0 for the tests to succeed
       agent = require('../..').start({
+        projectId: '0',
         samplingRate: 0,
         enhancedDatabaseReporting: true
       });

--- a/test/plugins/test-trace-hapi.js
+++ b/test/plugins/test-trace-hapi.js
@@ -42,6 +42,7 @@ describe('hapi', function() {
 
   before(function() {
     agent = require('../..').start({
+      projectId: '0',
       ignoreUrls: ['/ignore'],
       samplingRate: 0
     });

--- a/test/plugins/test-trace-http.js
+++ b/test/plugins/test-trace-http.js
@@ -20,7 +20,10 @@ var constants = require('../../src/constants.js');
 var stream = require('stream');
 var TraceLabels = require('../../src/trace-labels.js');
 
-var agent = require('../..').start({ samplingRate: 0 });
+var agent = require('../..').start({ 
+  projectId: '0',
+  samplingRate: 0
+});
 
 var assert = require('assert');
 

--- a/test/plugins/test-trace-knex.js
+++ b/test/plugins/test-trace-knex.js
@@ -39,6 +39,7 @@ describe('test-trace-knex', function() {
   var agent;
   before(function() {
     agent = require('../..').start({
+      projectId: '0',
       logLevel: 2,
       flushDelaySeconds: 1,
       enhancedDatabaseReporting: true,

--- a/test/plugins/test-trace-koa.js
+++ b/test/plugins/test-trace-koa.js
@@ -34,6 +34,7 @@ describe('koa', function() {
 
   before(function() {
     agent = require('../..').start({
+      projectId: '0',
       ignoreUrls: ['/ignore'],
       samplingRate: 0
     });

--- a/test/plugins/test-trace-mongodb.js
+++ b/test/plugins/test-trace-mongodb.js
@@ -36,6 +36,7 @@ describe('mongodb', function() {
 
   before(function() {
     agent = require('../..').start({
+      projectId: '0',
       samplingRate: 0,
       enhancedDatabaseReporting: true,
       databaseResultReportingSize: RESULT_SIZE

--- a/test/plugins/test-trace-mongoose.js
+++ b/test/plugins/test-trace-mongoose.js
@@ -30,7 +30,10 @@ describe('test-trace-mongoose', function() {
   var mongoose;
   var Simple;
   before(function() {
-    agent = require('../..').start({ samplingRate: 0 });
+    agent = require('../..').start({
+      projectId: '0',
+      samplingRate: 0
+    });
 
     mongoose = require('./fixtures/mongoose4');
     mongoose.Promise = global.Promise;

--- a/test/plugins/test-trace-mysql.js
+++ b/test/plugins/test-trace-mysql.js
@@ -34,6 +34,7 @@ describe('test-trace-mysql', function() {
   var pool;
   before(function() {
     agent = require('../..').start({
+      projectId: '0',
       enhancedDatabaseReporting: true,
       databaseResultReportingSize: RESULT_SIZE
     });

--- a/test/plugins/test-trace-pg.js
+++ b/test/plugins/test-trace-pg.js
@@ -26,6 +26,7 @@ describe('test-trace-pg', function() {
   var releaseClient;
   before(function() {
     traceApi = require('../..').start({
+      projectId: '0',
       samplingRate: 0,
       enhancedDatabaseReporting: true
     });

--- a/test/plugins/test-trace-redis.js
+++ b/test/plugins/test-trace-redis.js
@@ -41,6 +41,7 @@ describe('redis', function() {
 
   before(function() {
     agent = require('../..').start({
+      projectId: '0',
       samplingRate: 0,
       enhancedDatabaseReporting: true,
       databaseResultReportingSize: RESULT_SIZE

--- a/test/plugins/test-trace-restify.js
+++ b/test/plugins/test-trace-restify.js
@@ -33,6 +33,7 @@ describe('restify', function() {
 
   before(function() {
     agent = require('../..').start({
+      projectId: '0',
       ignoreUrls: ['/ignore'],
       samplingRate: 0
     });

--- a/test/test-default-ignore-ah-health.js
+++ b/test/test-default-ignore-ah-health.js
@@ -24,7 +24,10 @@ describe('test-default-ignore-ah-health', function() {
   var agent;
   var express;
   before(function() {
-    agent = require('..').start({samplingRate: 0});
+    agent = require('..').start({
+      projectId: '0',
+      samplingRate: 0
+    });
     express = require('./plugins/fixtures/express4');
   });
 

--- a/test/test-grpc-context.js
+++ b/test/test-grpc-context.js
@@ -55,7 +55,10 @@ Object.keys(versions).forEach(function(version) {
   var httpLogCount;
   describe('express + ' + version, function() {
     before(function(done) {
-      agent = require('..').start({ samplingRate: 0 });
+      agent = require('..').start({
+        projectId: '0',
+        samplingRate: 0
+      });
       express = require('./plugins/fixtures/express4');
       grpc = require(versions[version]);
 

--- a/test/test-index.js
+++ b/test/test-index.js
@@ -16,16 +16,11 @@
 
 'use strict';
 
-if (!process.env.GCLOUD_PROJECT) {
-  console.log('The GCLOUD_PROJECT environment variable must be set.');
-  process.exit(1);
-}
-
 var assert = require('assert');
 var trace = require('..');
 
 describe('index.js', function() {
-  var agent = trace.start();
+  var agent = trace.start({ projectId: '0' });
 
   it('should get the agent with `Trace.get`', function() {
     assert.strictEqual(agent, trace.get());

--- a/test/test-mysql-pool.js
+++ b/test/test-mysql-pool.js
@@ -26,8 +26,11 @@ if (semver.satisfies(process.version, '>=4')) {
     var agent;
     var Hapi;
     before(function() {
-      agent = require('..').start({ samplingRate: 0,
-                                       enhancedDatabaseReporting: true });
+      agent = require('..').start({
+        projectId: '0',
+        samplingRate: 0,
+        enhancedDatabaseReporting: true
+      });
       Hapi = require('./plugins/fixtures/hapi13');
     });
 

--- a/test/test-plugins-sample-warning.js
+++ b/test/test-plugins-sample-warning.js
@@ -31,7 +31,10 @@ describe('express + dbs', function() {
   var agent;
 
   before(function() {
-    agent = require('..').start({ samplingRate: 0 });
+    agent = require('..').start({
+      projectId: '0',
+      samplingRate: 0
+    });
   });
 
   beforeEach(function() {

--- a/test/test-span-data.js
+++ b/test/test-span-data.js
@@ -16,11 +16,6 @@
 
 'use strict';
 
-if (!process.env.GCLOUD_PROJECT) {
-  console.log('The GCLOUD_PROJECT environment variable must be set.');
-  process.exit(1);
-}
-
 var TraceLabels = require('../src/trace-labels.js');
 var assert = require('assert');
 var cls = require('../src/cls.js');
@@ -31,7 +26,10 @@ describe('SpanData', function() {
 
   var agent;
   before(function() {
-    agent = require('..').start({samplingRate: 0});
+    agent = require('..').start({
+      projectId: '0',
+      samplingRate: 0
+    });
   });
 
   it('has correct default values', function() {

--- a/test/test-trace-agent.js
+++ b/test/test-trace-agent.js
@@ -18,11 +18,6 @@
 
  var constants = require('../src/constants.js');
 
-if (!process.env.GCLOUD_PROJECT) {
-  console.log('The GCLOUD_PROJECT environment variable must be set.');
-  process.exit(1);
-}
-
 var emptyLogger = {
   warn: console.warn,
   info: console.info,
@@ -31,12 +26,15 @@ var emptyLogger = {
 };
 
 var assert = require('assert');
-var config = require('../config.js');
+var defaultConfig = require('../config.js');
+var extend = require('extend');
 var file = require('../src/trace-agent.js');
 var SpanData = require('../src/span-data.js');
-var agent = file.get(config, emptyLogger);
 var constants = require('../src/constants.js');
 var cls = require('../src/cls.js');
+
+var config = extend({ projectId: '0'}, defaultConfig);
+var agent = file.get(config, emptyLogger);
 
 describe('Trace Agent', function() {
 

--- a/test/test-trace-cluster.js
+++ b/test/test-trace-cluster.js
@@ -23,7 +23,10 @@ describe('test-trace-cluster', function() {
   var agent;
   var express;
   before(function() {
-    agent = require('..').start({samplingRate: 0});
+    agent = require('..').start({
+      projectId: '0',
+      samplingRate: 0
+    });
     express = require('./plugins/fixtures/express4');
   });
 

--- a/test/test-trace-gcloud.js
+++ b/test/test-trace-gcloud.js
@@ -25,8 +25,11 @@ nock.disableNetConnect();
 describe('test-trace-gcloud', function() {
   var agent;
   before(function() {
-    agent = require('..').start({ samplingRate: 0,
-      enhancedDatabaseReporting: true });
+    agent = require('..').start({
+      projectId: '0',
+      samplingRate: 0,
+      enhancedDatabaseReporting: true
+    });
   });
 
   // This does a gcloud.datastore.get() request that makes a gRPC 'lookup' call.

--- a/test/test-trace-header-context.js
+++ b/test/test-trace-header-context.js
@@ -26,7 +26,10 @@ describe('test-trace-header-context', function() {
   var agent;
   var express;
   before(function() {
-    agent = require('..').start({ samplingRate: 0 });
+    agent = require('..').start({
+      projectId: '0',
+      samplingRate: 0
+    });
     express = require('./plugins/fixtures/express4');
   });
 

--- a/test/test-trace-options-sampling.js
+++ b/test/test-trace-options-sampling.js
@@ -28,7 +28,10 @@ describe('express + mongo with trace options header + sampling', function() {
   var agent;
   var express;
   before(function() {
-    agent = require('..').start({ samplingRate: 1 });
+    agent = require('..').start({
+      projectId: '0',
+      samplingRate: 1
+    });
     express = require('./plugins/fixtures/express4');
   });
 

--- a/test/test-trace-options.js
+++ b/test/test-trace-options.js
@@ -29,7 +29,10 @@ describe('express + mongo with trace options header', function() {
   var agent;
   var express;
   before(function() {
-    agent = require('..').start({ samplingRate: 0 });
+    agent = require('..').start({
+      projectId: '0',
+      samplingRate: 0
+    });
     express = require('./plugins/fixtures/express4');
   });
 

--- a/test/test-unpatch.js
+++ b/test/test-unpatch.js
@@ -25,7 +25,7 @@ describe('index.js', function() {
   var agent;
   var checkUnpatches = [];
   beforeEach(function() {
-    agent = trace.start({ forceNewAgent_: true });
+    agent = trace.start({ projectId: '0', forceNewAgent_: true });
   });
 
   afterEach(function() {


### PR DESCRIPTION
I broke the unit tests on travis when I added the system tests and remove the global setting of GCLOUD_PROJECT in travis.yml.

This eliminates the unit tests' dependence on GCLOUD_PROJECT.