### PR TITLE
start testing against Node 8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 npm-debug.log
 coverage
 .DS_Store
+package-lock.json

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ language: node_js
 node_js:
   - "4"
   - "6"
-  - "7"
+  - "8"
 
 services:
   - mongodb

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,9 +2,9 @@
 environment:
   matrix:
   # node.js
-  # Testing against LTS/Current, 0.12 intentionally omitted to reduce maintenance burden
   - nodejs_version: "4"
   - nodejs_version: "6"
+  - nodejs_version: "8"
 
 services:
   - mongodb

--- a/test/non-interference/http-e2e.js
+++ b/test/non-interference/http-e2e.js
@@ -33,7 +33,10 @@ console.log('Turning off global checks');
 // The use of the -i flag as '-i.bak' to specify a backup extension of '.bak'
 // is needed to ensure that the command works on both Linux and OS X
 cp.execFileSync('sed', ['-i.bak', 's/exports.globalCheck = true/' +
-    'exports.globalCheck = false/g', path.join(node_dir, 'test', 'common.js')]);
+    'exports.globalCheck = false/g',
+    semver.satisfies(process.version, '>=8.0.0') ?
+        path.join(node_dir, 'test', 'common', 'index.js') :
+        path.join(node_dir, 'test', 'common.js')]);
 var test_glob = semver.satisfies(process.version, '0.12.x') ?
     path.join(node_dir, 'test', 'simple', 'test-http*.js') :
     path.join(node_dir, 'test', 'parallel', 'test-http*.js');

--- a/test/plugins/test-trace-http.js
+++ b/test/plugins/test-trace-http.js
@@ -17,6 +17,7 @@
 
 var common = require('./common.js');
 var constants = require('../../src/constants.js');
+var semver = require('semver');
 var stream = require('stream');
 var TraceLabels = require('../../src/trace-labels.js');
 
@@ -44,6 +45,15 @@ describe('test-trace-http', function() {
   afterEach(function() {
     common.cleanTraces(agent);
     server.close();
+  });
+
+  it('should patch the necessary functions', function() {
+    assert.strictEqual(http.request.__wrapped, true);
+    if (semver.satisfies(process.version, '>=8.0.0')) {
+      assert.strictEqual(http.get.__wrapped, true, 'should patch get');
+    } else {
+      assert.strictEqual(http.get.__wrapped, undefined, 'should not patch get');
+    }
   });
 
   it('should accurately measure get time with callback', function(done) {


### PR DESCRIPTION
Node 8 is being tested now. Because of changes in Node core, we were no longer able to trace http.get calls. This PR includes a fix for that too.