### PR TITLE
Typo fixes throughout a few comments

### DIFF
--- a/doc/trace-api.md
+++ b/doc/trace-api.md
@@ -17,7 +17,7 @@ These functions provide the capability to create trace spans, add labels to them
   * `options`: [`TraceOptions`](#trace-span-options)
   * `fn`: `function(?Span): any`
   * Returns `any` (return value of `fn`)
-  * Attempts to create a root span and runs the given callback, passing it a `Span` object if the root span was successfuly created. Otherwise, the given function is run with `null` as an argument. This may be for one of two reasons:
+  * Attempts to create a root span and runs the given callback, passing it a `Span` object if the root span was successfully created. Otherwise, the given function is run with `null` as an argument. This may be for one of two reasons:
     * The trace policy, as specified by the user-given configuration, disallows a root span from being created under the current circumstances.
     * The trace agent is disabled, either because it wasn't started at all, started in disabled mode, or encountered an initialization error.
   * **Note:** You must call `endSpan` on the span object provided as an argument for the span to be recorded.
@@ -78,7 +78,7 @@ It is highly recommended for plugins to set this header field in responses, _if_
   * `incomingTraceContext`: `string`
   * `isTraced`: `boolean`
   * Returns `string`
-  * Returns a string that should be set in the response headers in a traced request. If incomingTraceContext is falsey (indicating that the incoming request didn't have a trace context), this function returns an empty string.
+  * Returns a string that should be set in the response headers in a traced request. If incomingTraceContext is falsy (indicating that the incoming request didn't have a trace context), this function returns an empty string.
 
 This function is usually called from within the function passed to `runInRootSpan`. See any of the built-in plugins ([express](src/plugins/plugin-express.js#L35)) for an example. Note that the value for `isTraced` is based on the value of the root span - if a root span was created, that means that this request is being traced.
 

--- a/src/trace-api.js
+++ b/src/trace-api.js
@@ -165,7 +165,7 @@ TraceApiImplementation.prototype.runInRootSpan = function(options, fn) {
  * Creates and returns a new ChildSpan object nested within the root span. If
  * there is no current RootSpan object, this function returns null.
  * @param {object} options An object that specifies options for how the child
- * span is created and propogated.
+ * span is created and propagated.
  * @param {string} options.name The name to apply to the child span.
  * @param {?number} options.skipFrames The number of stack frames to skip when
  * collecting call stack information for the root span, starting from the top;


### PR DESCRIPTION
- Fix various comment typos such as
  successfully and falsy to stay consistent
  throughout the codebase.