### PR TITLE
Fix document source link

### DIFF
--- a/doc/trace-api.md
+++ b/doc/trace-api.md
@@ -80,7 +80,7 @@ It is highly recommended for plugins to set this header field in responses, _if_
   * Returns `string`
   * Returns a string that should be set in the response headers in a traced request. If incomingTraceContext is falsey (indicating that the incoming request didn't have a trace context), this function returns an empty string.
 
-This function is usually called from within the function passed to `runInRootSpan`. See any of the built-in plugins ([express](src/plugins/plugin-express.js#L35)) for an example. Note that the value for `isTraced` is based on the value of the root span - if a root span was created, that means that this request is being traced.
+This function is usually called from within the function passed to `runInRootSpan`. See any of the built-in plugins ([express](../src/plugins/plugin-express.js#L42)) for an example. Note that the value for `isTraced` is based on the value of the root span - if a root span was created, that means that this request is being traced.
 
 ### For Outgoing Requests
 


### PR DESCRIPTION
- The link in the TraceApi documentation was referencing
  a local directory path but instead needed to be out
  one directory.
- The line number referencing runInRootSpan is now on L42
  ipo L35.  That said, in the future it may make sense to
  remove the line number because keeping all of this in sync
  is borderline maintenance pain.