### PR TITLE
test: omit agent argument from all test-common helper functions

### DIFF
--- a/test/plugins/common.js
+++ b/test/plugins/common.js
@@ -39,13 +39,14 @@ var SERVER_RES = '1729';
 var SERVER_KEY = fs.readFileSync(path.join(__dirname, 'fixtures', 'key.pem'));
 var SERVER_CERT = fs.readFileSync(path.join(__dirname, 'fixtures', 'cert.pem'));
 
+var shouldTraceArgs = [];
+
 function trackShouldTraceArgs() {
   var agent = trace.get();
   var privateAgent = agent.private_();
-  privateAgent._shouldTraceArgs = [];
   var shouldTrace = privateAgent.shouldTrace;
   privateAgent.shouldTrace = function() {
-    privateAgent._shouldTraceArgs.push([].slice.call(arguments, 0));
+    shouldTraceArgs.push([].slice.call(arguments, 0));
     return shouldTrace.apply(this, arguments);
   };
 }
@@ -65,11 +66,7 @@ function replaceWarnLogger(fn) {
  * Cleans the tracer state between test runs.
  */
 function cleanTraces() {
-  var agent = trace.get();
-  var privateAgent = agent.private_();
-  if (privateAgent) {
-    privateAgent._shouldTraceArgs = [];
-  }
+  shouldTraceArgs = [];
   TraceWriter.get().buffer_ = [];
 }
 
@@ -78,8 +75,7 @@ function getTraces() {
 }
 
 function getShouldTraceArgs() {
-  var agent = trace.get();
-  return agent.private_()._shouldTraceArgs;
+  return shouldTraceArgs;
 }
 
 function getMatchingSpan(predicate) {

--- a/test/plugins/test-plugins-interop-mongo-express.js
+++ b/test/plugins/test-plugins-interop-mongo-express.js
@@ -36,7 +36,7 @@ describe('mongodb + express', function() {
     agent = require('../..').start({ projectId: '0' });
     express = require('./fixtures/express4');
     mongoose = require('./fixtures/mongoose4');
-    oldWarn = common.replaceWarnLogger(agent,
+    oldWarn = common.replaceWarnLogger(
       function(error) {
         assert(error.indexOf('mongo') === -1, error);
     });
@@ -56,8 +56,8 @@ describe('mongodb + express', function() {
     server = app.listen(common.serverPort, function() {
       http.get({port: common.serverPort}, function(res) {
         server.close();
-        common.cleanTraces(agent);
-        common.replaceWarnLogger(agent, oldWarn);
+        common.cleanTraces();
+        common.replaceWarnLogger(oldWarn);
         done();
       });
     });

--- a/test/plugins/test-plugins-multi-version.js
+++ b/test/plugins/test-plugins-multi-version.js
@@ -53,11 +53,11 @@ describe('multiple instrumentations of the same module', function() {
   });
 
   it('should record spans', function(done) {
-    common.runInTransaction(agent, function(endTransaction) {
+    common.runInTransaction(function(endTransaction) {
       clientv0.get('v0', function(err, n) {
         clientv2.get('v2', function(err, n) {
           endTransaction();
-          var spans = common.getMatchingSpans(agent, redisPredicate.bind(null, 'redis-get'));
+          var spans = common.getMatchingSpans(redisPredicate.bind(null, 'redis-get'));
           assert.equal(spans.length, 2);
           assert.equal(spans[0].labels.arguments, '["v0"]');
           assert.equal(spans[0].labels.command, 'get');

--- a/test/plugins/test-trace-connect.js
+++ b/test/plugins/test-trace-connect.js
@@ -49,7 +49,7 @@ describe('test-trace-connect', function() {
   });
 
   afterEach(function() {
-    common.cleanTraces(agent);
+    common.cleanTraces();
     server.close();
   });
 
@@ -61,7 +61,7 @@ describe('test-trace-connect', function() {
       }, common.serverWait);
     });
     server = app.listen(common.serverPort, function() {
-      common.doRequest(agent, 'GET', done, connectPredicate);
+      common.doRequest('GET', done, connectPredicate);
     });
   });
 
@@ -78,7 +78,7 @@ describe('test-trace-connect', function() {
       }, common.serverWait / 2);
     });
     server = app.listen(common.serverPort, function() {
-      common.doRequest(agent, 'GET', done, connectPredicate);
+      common.doRequest('GET', done, connectPredicate);
     });
   });
 
@@ -91,7 +91,7 @@ describe('test-trace-connect', function() {
       }, common.serverWait);
     });
     server = app.listen(common.serverPort, function() {
-      common.doRequest(agent, 'GET', done, connectPredicate);
+      common.doRequest('GET', done, connectPredicate);
     });
   });
 
@@ -102,7 +102,7 @@ describe('test-trace-connect', function() {
     });
     server = app.listen(common.serverPort, function() {
       http.get({port: common.serverPort}, function(res) {
-        var labels = common.getMatchingSpan(agent, connectPredicate).labels;
+        var labels = common.getMatchingSpan(connectPredicate).labels;
         assert.equal(labels[traceLabels.HTTP_RESPONSE_CODE_LABEL_KEY], '200');
         assert.equal(labels[traceLabels.HTTP_METHOD_LABEL_KEY], 'GET');
         assert.equal(labels[traceLabels.HTTP_URL_LABEL_KEY], 'http://localhost:9042/');
@@ -119,7 +119,7 @@ describe('test-trace-connect', function() {
     });
     server = app.listen(common.serverPort, function() {
       http.get({port: common.serverPort}, function(res) {
-        var labels = common.getMatchingSpan(agent, connectPredicate).labels;
+        var labels = common.getMatchingSpan(connectPredicate).labels;
         var stackTrace = JSON.parse(labels[traceLabels.STACK_TRACE_DETAILS_KEY]);
         // Ensure that our middleware is on top of the stack
         assert.equal(stackTrace.stack_frame[0].method_name, 'middleware');
@@ -135,7 +135,7 @@ describe('test-trace-connect', function() {
     });
     server = app.listen(common.serverPort, function() {
       http.get({path: '/?a=b', port: common.serverPort}, function(res) {
-        var span = common.getMatchingSpan(agent, connectPredicate);
+        var span = common.getMatchingSpan(connectPredicate);
         assert.equal(span.name, '/');
         done();
       });
@@ -149,7 +149,7 @@ describe('test-trace-connect', function() {
     });
     server = app.listen(common.serverPort, function() {
       http.get({port: common.serverPort}, function(res) {
-        var labels = common.getMatchingSpan(agent, connectPredicate).labels;
+        var labels = common.getMatchingSpan(connectPredicate).labels;
         assert.equal(labels[traceLabels.HTTP_RESPONSE_CODE_LABEL_KEY], '500');
         done();
       });
@@ -186,7 +186,7 @@ describe('test-trace-connect', function() {
     });
     server = app.listen(common.serverPort, function() {
       http.get({port: common.serverPort, path: '/ignore/me'}, function(res) {
-        assert.equal(common.getTraces(agent).length, 0);
+        assert.equal(common.getTraces().length, 0);
         done();
       });
     });
@@ -198,7 +198,7 @@ describe('test-trace-connect', function() {
       setTimeout(function() {
         res.end(common.serverRes);
         setImmediate(function() {
-          var traces = common.getTraces(agent);
+          var traces = common.getTraces();
           assert.strictEqual(traces.length, 1);
           assert.strictEqual(traces[0].spans.length, 1);
           var span = traces[0].spans[0];

--- a/test/plugins/test-trace-datastore.js
+++ b/test/plugins/test-trace-datastore.js
@@ -43,7 +43,7 @@ describe('test-trace-datastore', function() {
     // timeout is set to accommodate for this remote request and reduce
     // flakiness.
     this.timeout(20000);
-    common.runInTransaction(agent, function(endTransaction) {
+    common.runInTransaction(function(endTransaction) {
       var ds = require('./fixtures/google-cloud-datastore1')({
         projectId: '-1',
         keyFilename: path.join(__dirname, '..', 'fixtures', 'gcloud-credentials.json')
@@ -55,13 +55,13 @@ describe('test-trace-datastore', function() {
         assert.strictEqual(err.code, 401);
         assert.notStrictEqual(
             err.message.indexOf('accounts.google.com:443/o/oauth2/token'), -1);
-        var trace = common.getMatchingSpan(agent, grpcPredicate);
+        var trace = common.getMatchingSpan(grpcPredicate);
         assert(trace);
         assert.notStrictEqual(trace.labels.argument.indexOf(
             '"keys":[{"path":[{"kind":"bad","name":"key"}]}]'), -1);
         assert(trace.labels.error);
         delete process.env.GOOGLE_APPLICATION_CREDENTIALS;
-        common.cleanTraces(agent);
+        common.cleanTraces();
         done();
       });
     });

--- a/test/plugins/test-trace-express.js
+++ b/test/plugins/test-trace-express.js
@@ -48,7 +48,7 @@ describe('test-trace-express', function() {
     process.stderr.write = write;
   });
   afterEach(function() {
-    common.cleanTraces(agent);
+    common.cleanTraces();
     server.close();
   });
 
@@ -60,7 +60,7 @@ describe('test-trace-express', function() {
       }, common.serverWait);
     });
     server = app.listen(common.serverPort, function() {
-      common.doRequest(agent, 'GET', done, expressPredicate);
+      common.doRequest('GET', done, expressPredicate);
     });
   });
 
@@ -75,7 +75,7 @@ describe('test-trace-express', function() {
       next();
     });
     server = app.listen(common.serverPort, function() {
-      common.doRequest(agent, 'GET', done, expressPredicate);
+      common.doRequest('GET', done, expressPredicate);
     });
   });
 
@@ -87,7 +87,7 @@ describe('test-trace-express', function() {
       }, common.serverWait);
     });
     server = app.listen(common.serverPort, function() {
-      common.doRequest(agent, 'POST', done, expressPredicate);
+      common.doRequest('POST', done, expressPredicate);
     });
   });
 
@@ -99,7 +99,7 @@ describe('test-trace-express', function() {
       }, common.serverWait);
     });
     server = app.listen(common.serverPort, function() {
-      common.doRequest(agent, 'PUT', done, expressPredicate);
+      common.doRequest('PUT', done, expressPredicate);
     });
   });
 
@@ -116,7 +116,7 @@ describe('test-trace-express', function() {
       }, common.serverWait / 2);
     });
     server = app.listen(common.serverPort, function() {
-      common.doRequest(agent, 'GET', done, expressParamPredicate, '/:id');
+      common.doRequest('GET', done, expressParamPredicate, '/:id');
     });
   });
 
@@ -133,7 +133,7 @@ describe('test-trace-express', function() {
       }, common.serverWait / 2);
     });
     server = app.listen(common.serverPort, function() {
-      common.doRequest(agent, 'GET', done, expressPredicate);
+      common.doRequest('GET', done, expressPredicate);
     });
   });
 
@@ -146,7 +146,7 @@ describe('test-trace-express', function() {
       }, common.serverWait);
     });
     server = app.listen(common.serverPort, function() {
-      common.doRequest(agent, 'GET', done, expressPredicate);
+      common.doRequest('GET', done, expressPredicate);
     });
   });
 
@@ -157,7 +157,7 @@ describe('test-trace-express', function() {
     });
     server = app.listen(common.serverPort, function() {
       http.get({port: common.serverPort}, function(res) {
-        var labels = common.getMatchingSpan(agent, expressPredicate).labels;
+        var labels = common.getMatchingSpan(expressPredicate).labels;
         assert.equal(labels[traceLabels.HTTP_RESPONSE_CODE_LABEL_KEY], '200');
         assert.equal(labels[traceLabels.HTTP_METHOD_LABEL_KEY], 'GET');
         assert.equal(labels[traceLabels.HTTP_URL_LABEL_KEY], 'http://localhost/');
@@ -174,7 +174,7 @@ describe('test-trace-express', function() {
     });
     server = app.listen(common.serverPort, function() {
       http.get({port: common.serverPort}, function(res) {
-        var labels = common.getMatchingSpan(agent, expressPredicate).labels;
+        var labels = common.getMatchingSpan(expressPredicate).labels;
         var stackTrace = JSON.parse(labels[traceLabels.STACK_TRACE_DETAILS_KEY]);
         // Ensure that our middleware is on top of the stack
         assert.equal(stackTrace.stack_frame[0].method_name, 'middleware');
@@ -190,7 +190,7 @@ describe('test-trace-express', function() {
     });
     server = app.listen(common.serverPort, function() {
       http.get({path: '/?a=b', port: common.serverPort}, function(res) {
-        var name = common.getMatchingSpan(agent, expressPredicate).name;
+        var name = common.getMatchingSpan(expressPredicate).name;
         assert.equal(name, '/');
         done();
       });
@@ -204,7 +204,7 @@ describe('test-trace-express', function() {
     });
     server = app.listen(common.serverPort, function() {
       http.get({port: common.serverPort}, function(res) {
-        var labels = common.getMatchingSpan(agent, expressPredicate).labels;
+        var labels = common.getMatchingSpan(expressPredicate).labels;
         assert.equal(labels[traceLabels.HTTP_RESPONSE_CODE_LABEL_KEY], '500');
         done();
       });
@@ -218,7 +218,7 @@ describe('test-trace-express', function() {
     });
     server = app.listen(common.serverPort, function() {
       http.get({port: common.serverPort}, function(res) {
-        var labels = common.getMatchingSpan(agent, expressPredicate).labels;
+        var labels = common.getMatchingSpan(expressPredicate).labels;
         assert.equal(labels[traceLabels.HTTP_RESPONSE_CODE_LABEL_KEY], '500');
         done();
       });
@@ -253,7 +253,7 @@ describe('test-trace-express', function() {
     });
     server = app.listen(common.serverPort, function() {
       http.get({port: common.serverPort, path: '/ignore/me'}, function(res) {
-        assert.equal(common.getTraces(agent).length, 0);
+        assert.equal(common.getTraces().length, 0);
         done();
       });
     });
@@ -265,7 +265,7 @@ describe('test-trace-express', function() {
       setTimeout(function() {
         res.send(common.serverRes);
         setImmediate(function() {
-          var traces = common.getTraces(agent);
+          var traces = common.getTraces();
           assert.strictEqual(traces.length, 1);
           assert.strictEqual(traces[0].spans.length, 1);
           var span = traces[0].spans[0];

--- a/test/plugins/test-trace-generic-pool.js
+++ b/test/plugins/test-trace-generic-pool.js
@@ -36,10 +36,10 @@ describe('generic-pool2', function() {
 
   after(function() {
     common.stopAgent(api);
-    common.cleanTraces(api);
+    common.cleanTraces();
   });
 
-  it('perserves context', function(done) {
+  it('preserves context', function(done) {
     var config = {
       name: 'generic-pool2 test',
       create: function(callback) {
@@ -94,8 +94,8 @@ describe('generic-pool3', function() {
   });
 
   after(function() {
-    common.stopAgent(agent);
-    common.cleanTraces(agent);
+    common.stopAgent();
+    common.cleanTraces();
   });
 
   it ('preserves context', function() {
@@ -143,7 +143,7 @@ describe('generic-pool3', function() {
         childSpan.endSpan();
         rootSpan.endSpan();
 
-        var spans = common.getTraces(agent)[0].spans;
+        var spans = common.getTraces()[0].spans;
         assert.ok(spans);
         assert.strictEqual(spans.length, 4);
         assert.strictEqual(spans[0].name, ROOT_SPAN);

--- a/test/plugins/test-trace-google-gax.js
+++ b/test/plugins/test-trace-google-gax.js
@@ -39,7 +39,7 @@ describe('google-gax', function() {
   });
 
   it('should not interfere with google-cloud api tracing', function(done) {
-    common.runInTransaction(agent, function(endRootSpan) {
+    common.runInTransaction(function(endRootSpan) {
       speech.recognize('./index.js', {
         encoding: 'LINEAR16',
         sampleRate: 16000
@@ -49,7 +49,7 @@ describe('google-gax', function() {
         // generated.
         assert.equal(err.message, 'invalid_client');
         assert.equal(err.code, 16);
-        var span = common.getMatchingSpan(agent, function(span) {
+        var span = common.getMatchingSpan(function(span) {
           return span.kind === 'RPC_CLIENT' && span.name.indexOf('grpc:') === 0;
         });
         assert.ok(span);

--- a/test/plugins/test-trace-hapi.js
+++ b/test/plugins/test-trace-hapi.js
@@ -61,7 +61,7 @@ describe('hapi', function() {
       });
 
       afterEach(function(done) {
-        common.cleanTraces(agent);
+        common.cleanTraces();
         server.stop(done);
       });
 
@@ -78,7 +78,7 @@ describe('hapi', function() {
           }
         });
         server.start(function() {
-          common.doRequest(agent, 'GET', done, hapiPredicate);
+          common.doRequest('GET', done, hapiPredicate);
         });
       });
 
@@ -95,7 +95,7 @@ describe('hapi', function() {
           }
         });
         server.start(function() {
-          common.doRequest(agent, 'POST', done, hapiPredicate);
+          common.doRequest('POST', done, hapiPredicate);
         });
       });
 
@@ -115,7 +115,7 @@ describe('hapi', function() {
           handler: { custom: { val: common.serverRes } }
         });
         server.start(function() {
-          common.doRequest(agent, 'GET', done, hapiPredicate);
+          common.doRequest('GET', done, hapiPredicate);
         });
       });
 
@@ -144,7 +144,7 @@ describe('hapi', function() {
         }, function(err) {
           assert(!err);
           server.start(function() {
-            common.doRequest(agent, 'GET', done, hapiPredicate);
+            common.doRequest('GET', done, hapiPredicate);
           });
         });
       });
@@ -172,7 +172,7 @@ describe('hapi', function() {
         });
         server.start(function() {
           assert(afterSuccess);
-          common.doRequest(agent, 'GET', done, hapiPredicate);
+          common.doRequest('GET', done, hapiPredicate);
         });
       });
 
@@ -200,7 +200,7 @@ describe('hapi', function() {
             assert(extensionSuccess);
             done();
           };
-          common.doRequest(agent, 'GET', cb, hapiPredicate);
+          common.doRequest('GET', cb, hapiPredicate);
         });
       });
 
@@ -216,7 +216,7 @@ describe('hapi', function() {
         });
         server.start(function() {
           http.get({port: common.serverPort}, function(res) {
-            var labels = common.getMatchingSpan(agent, hapiPredicate).labels;
+            var labels = common.getMatchingSpan(hapiPredicate).labels;
             assert.equal(labels[traceLabels.HTTP_RESPONSE_CODE_LABEL_KEY], '200');
             assert.equal(labels[traceLabels.HTTP_METHOD_LABEL_KEY], 'GET');
             assert.equal(labels[traceLabels.HTTP_URL_LABEL_KEY], 'http://localhost:9042/');
@@ -238,7 +238,7 @@ describe('hapi', function() {
         });
         server.start(function() {
           http.get({port: common.serverPort}, function(res) {
-            var labels = common.getMatchingSpan(agent, hapiPredicate).labels;
+            var labels = common.getMatchingSpan(hapiPredicate).labels;
             var stackTrace = JSON.parse(labels[traceLabels.STACK_TRACE_DETAILS_KEY]);
             // Ensure that our middleware is on top of the stack
             assert.equal(stackTrace.stack_frame[0].method_name, 'middleware');
@@ -259,7 +259,7 @@ describe('hapi', function() {
         });
         server.start(function() {
           http.get({path: '/?a=b', port: common.serverPort}, function(res) {
-            var span = common.getMatchingSpan(agent, hapiPredicate);
+            var span = common.getMatchingSpan(hapiPredicate);
             assert.equal(span.name, '/');
             done();
           });
@@ -304,7 +304,7 @@ describe('hapi', function() {
         });
         server.start(function() {
           http.get({port: common.serverPort, path: '/ignore/me'}, function(res) {
-            assert.equal(common.getTraces(agent).length, 0);
+            assert.equal(common.getTraces().length, 0);
             done();
           });
         });
@@ -322,7 +322,7 @@ describe('hapi', function() {
             // conditional on this client-side behavior, we also listen for the
             // 'aborted' event, and end the span there.
             req.raw.req.on('aborted', function() {
-              var traces = common.getTraces(agent);
+              var traces = common.getTraces();
               assert.strictEqual(traces.length, 1);
               assert.strictEqual(traces[0].spans.length, 1);
               var span = traces[0].spans[0];

--- a/test/plugins/test-trace-knex.js
+++ b/test/plugins/test-trace-knex.js
@@ -65,7 +65,7 @@ describe('test-trace-knex', function() {
           assert.ok(result);
           knex.insert(obj).into(TABLE_NAME).then(function(result) {
             assert.ok(result);
-            common.cleanTraces(agent);
+            common.cleanTraces();
             done();
           });
         });
@@ -74,20 +74,20 @@ describe('test-trace-knex', function() {
       afterEach(function(done) {
         knex.schema.dropTable(TABLE_NAME).then(function(result) {
           assert.ok(result);
-          common.cleanTraces(agent);
+          common.cleanTraces();
           done();
         });
       });
 
       it('should perform basic operations using ' + version, function(done) {
-        common.runInTransaction(agent, function(endRootSpan) {
+        common.runInTransaction(function(endRootSpan) {
           knex(TABLE_NAME).select().then(function(res) {
             endRootSpan();
             assert(res);
             assert.equal(res.length, 1);
             assert.equal(res[0].k, 1);
             assert.equal(res[0].v, 'obj');
-            var spans = common.getMatchingSpans(agent, function (span) {
+            var spans = common.getMatchingSpans(function (span) {
               return span.name === 'mysql-query';
             });
             if (version === 'knex11') {
@@ -105,7 +105,7 @@ describe('test-trace-knex', function() {
       });
 
       it('should propagate context using ' + version, function(done) {
-        common.runInTransaction(agent, function(endRootSpan) {
+        common.runInTransaction(function(endRootSpan) {
           knex.select().from(TABLE_NAME).then(function(res) {
             assert.ok(common.hasContext());
             endRootSpan();
@@ -117,10 +117,10 @@ describe('test-trace-knex', function() {
       });
 
       it('should remove trace frames from stack using ' + version, function(done) {
-        common.runInTransaction(agent, function(endRootSpan) {
+        common.runInTransaction(function(endRootSpan) {
           knex.select().from(TABLE_NAME).then(function(res) {
             endRootSpan();
-            var spans = common.getMatchingSpans(agent, function (span) {
+            var spans = common.getMatchingSpans(function (span) {
               return span.name === 'mysql-query';
             });
             var labels = spans[0].labels;
@@ -136,7 +136,7 @@ describe('test-trace-knex', function() {
       });
 
       it('should work with events using ' + version, function(done) {
-        common.runInTransaction(agent, function(endRootSpan) {
+        common.runInTransaction(function(endRootSpan) {
           knex.select().from(TABLE_NAME).on('query-response', function(response, obj, builder) {
             var row = response[0];
             assert.ok(row);
@@ -146,7 +146,7 @@ describe('test-trace-knex', function() {
             assert.ifError(err);
           }).then(function(res) {
             endRootSpan();
-            var spans = common.getMatchingSpans(agent, function (span) {
+            var spans = common.getMatchingSpans(function (span) {
               return span.name === 'mysql-query';
             });
             if (version === 'knex11') {
@@ -166,11 +166,11 @@ describe('test-trace-knex', function() {
       });
 
       it('should work without events or callback using ' + version, function(done) {
-        common.runInTransaction(agent, function(endRootSpan) {
+        common.runInTransaction(function(endRootSpan) {
           knex.select().from(TABLE_NAME).then(function(result) {
             setTimeout(function() {
               endRootSpan();
-              var spans = common.getMatchingSpans(agent, function (span) {
+              var spans = common.getMatchingSpans(function (span) {
                 return span.name === 'mysql-query';
               });
               if (version === 'knex11') {
@@ -193,7 +193,7 @@ describe('test-trace-knex', function() {
           k: 2,
           v: 'obj2'
         };
-        common.runInTransaction(agent, function(endRootSpan) {
+        common.runInTransaction(function(endRootSpan) {
           knex.transaction(function(trx) {
             knex.insert(obj2)
                 .into(TABLE_NAME)
@@ -226,7 +226,7 @@ describe('test-trace-knex', function() {
                 assert.equal(res.length, 1);
                 assert.equal(res[0].k, 1);
                 assert.equal(res[0].v, 'obj');
-                var spans = common.getMatchingSpans(agent, function (span) {
+                var spans = common.getMatchingSpans(function (span) {
                   return span.name === 'mysql-query';
                 });
                 var expectedCmds;

--- a/test/plugins/test-trace-koa.js
+++ b/test/plugins/test-trace-koa.js
@@ -45,14 +45,14 @@ describe('koa', function() {
       var buildKoaApp = appBuilders[version];
 
       afterEach(function() {
-        common.cleanTraces(agent);
+        common.cleanTraces();
         server.close();
       });
 
       it('should accurately measure get time, get', function(done) {
         var app = buildKoaApp();
         server = app.listen(common.serverPort, function() {
-          common.doRequest(agent, 'GET', done, koaPredicate);
+          common.doRequest('GET', done, koaPredicate);
         });
       });
 
@@ -70,7 +70,7 @@ describe('koa', function() {
                 traceLabels.HTTP_SOURCE_IP,
                 traceLabels.HTTP_RESPONSE_CODE_LABEL_KEY
               ];
-              var span = common.getMatchingSpan(agent, koaPredicate);
+              var span = common.getMatchingSpan(koaPredicate);
               expectedKeys.forEach(function(key) {
                 assert(span.labels[key]);
               });
@@ -84,7 +84,7 @@ describe('koa', function() {
         var app = buildKoaApp();
         server = app.listen(common.serverPort, function() {
           http.get({port: common.serverPort}, function(res) {
-            var labels = common.getMatchingSpan(agent, koaPredicate).labels;
+            var labels = common.getMatchingSpan(koaPredicate).labels;
             var stackTrace = JSON.parse(labels[traceLabels.STACK_TRACE_DETAILS_KEY]);
             // Ensure that our middleware is on top of the stack
             assert.equal(stackTrace.stack_frame[0].method_name, 'middleware');
@@ -97,7 +97,7 @@ describe('koa', function() {
         var app = buildKoaApp();
         server = app.listen(common.serverPort, function() {
           http.get({path: '/?a=b', port: common.serverPort}, function(res) {
-            var name = common.getMatchingSpan(agent, koaPredicate).name;
+            var name = common.getMatchingSpan(koaPredicate).name;
             assert.equal(name, '/');
             done();
           });
@@ -126,7 +126,7 @@ describe('koa', function() {
         var app = buildKoaApp();
         server = app.listen(common.serverPort, function() {
           http.get({port: common.serverPort, path: '/ignore/me'}, function(res) {
-            assert.equal(common.getTraces(agent).length, 0);
+            assert.equal(common.getTraces().length, 0);
             done();
           });
         });
@@ -151,7 +151,7 @@ describe('koa', function() {
           // res.end if the request was aborted. As a call to res.end is
           // conditional on this client-side behavior, we also end a span in
           // koa if the 'aborted' event is emitted.
-          var traces = common.getTraces(agent);
+          var traces = common.getTraces();
           assert.strictEqual(traces.length, 1);
           assert.strictEqual(traces[0].spans.length, 1);
           var span = traces[0].spans[0];

--- a/test/plugins/test-trace-mongoose.js
+++ b/test/plugins/test-trace-mongoose.js
@@ -58,7 +58,7 @@ describe('test-trace-mongoose', function() {
       assert(!err, 'Skipping: error connecting to mongo at localhost:27017.');
       sim.save(function(err) {
         assert(!err);
-        common.cleanTraces(agent);
+        common.cleanTraces();
         done();
       });
     });
@@ -69,7 +69,7 @@ describe('test-trace-mongoose', function() {
       assert(!err);
       mongoose.connection.close(function(err) {
         assert(!err);
-        common.cleanTraces(agent);
+        common.cleanTraces();
         done();
       });
     });
@@ -81,11 +81,11 @@ describe('test-trace-mongoose', function() {
       f2: false,
       f3: 1729
     });
-    common.runInTransaction(agent, function(endTransaction) {
+    common.runInTransaction(function(endTransaction) {
       data.save(function(err) {
         endTransaction();
         assert(!err);
-        var trace = common.getMatchingSpan(agent, mongoPredicate.bind(null, 'mongo-insert'));
+        var trace = common.getMatchingSpan(mongoPredicate.bind(null, 'mongo-insert'));
         assert(trace);
         done();
       });
@@ -93,14 +93,14 @@ describe('test-trace-mongoose', function() {
   });
 
   it('should accurately measure update time', function(done) {
-    common.runInTransaction(agent, function(endTransaction) {
+    common.runInTransaction(function(endTransaction) {
       Simple.findOne({f1: 'sim'}, function(err, res) {
         assert(!err);
         res.f2 = false;
         res.save(function(err) {
           endTransaction();
           assert(!err);
-          var trace = common.getMatchingSpan(agent, mongoPredicate.bind(null, 'mongo-update'));
+          var trace = common.getMatchingSpan(mongoPredicate.bind(null, 'mongo-update'));
           assert(trace);
           done();
         });
@@ -109,11 +109,11 @@ describe('test-trace-mongoose', function() {
   });
 
   it('should accurately measure retrieval time', function(done) {
-    common.runInTransaction(agent, function(endTransaction) {
+    common.runInTransaction(function(endTransaction) {
       Simple.findOne({f1: 'sim'}, function(err, res) {
         endTransaction();
         assert(!err);
-        var trace = common.getMatchingSpan(agent, mongoPredicate.bind(null, 'mongo-cursor'));
+        var trace = common.getMatchingSpan(mongoPredicate.bind(null, 'mongo-cursor'));
         assert(trace);
         done();
       });
@@ -121,11 +121,11 @@ describe('test-trace-mongoose', function() {
   });
 
   it('should accurately measure delete time', function(done) {
-    common.runInTransaction(agent, function(endTransaction) {
+    common.runInTransaction(function(endTransaction) {
       Simple.remove({f1: 'sim'}, function(err, res) {
         endTransaction();
         assert(!err);
-        var trace = common.getMatchingSpan(agent, mongoPredicate.bind(null, 'mongo-remove'));
+        var trace = common.getMatchingSpan(mongoPredicate.bind(null, 'mongo-remove'));
         assert(trace);
         done();
       });
@@ -141,11 +141,11 @@ describe('test-trace-mongoose', function() {
   });
 
   it('should remove trace frames from stack', function(done) {
-    common.runInTransaction(agent, function(endTransaction) {
+    common.runInTransaction(function(endTransaction) {
       Simple.findOne({f1: 'sim'}, function(err, res) {
         endTransaction();
         assert(!err);
-        var trace = common.getMatchingSpan(agent, mongoPredicate.bind(null, 'mongo-cursor'));
+        var trace = common.getMatchingSpan(mongoPredicate.bind(null, 'mongo-cursor'));
         var labels = trace.labels;
         var stackTrace = JSON.parse(labels[traceLabels.STACK_TRACE_DETAILS_KEY]);
         // Ensure that our patch is on top of the stack

--- a/test/plugins/test-trace-redis.js
+++ b/test/plugins/test-trace-redis.js
@@ -62,24 +62,24 @@ describe('redis', function() {
           assert(false, 'redis error ' + err);
         });
         client.set('beforeEach', 42, function() {
-          common.cleanTraces(agent);
+          common.cleanTraces();
           done();
         });
       });
 
       afterEach(function(done) {
         client.quit(function() {
-          common.cleanTraces(agent);
+          common.cleanTraces();
           done();
         });
       });
 
       it('should accurately measure get time', function(done) {
-        common.runInTransaction(agent, function(endTransaction) {
+        common.runInTransaction(function(endTransaction) {
           client.get('beforeEach', function(err, n) {
             endTransaction();
             assert.equal(n, 42);
-            var trace = common.getMatchingSpan(agent, redisPredicate.bind(null, 'redis-get'));
+            var trace = common.getMatchingSpan(redisPredicate.bind(null, 'redis-get'));
             assert(trace);
             done();
           });
@@ -87,7 +87,7 @@ describe('redis', function() {
       });
 
       it('should propagate context', function(done) {
-        common.runInTransaction(agent, function(endTransaction) {
+        common.runInTransaction(function(endTransaction) {
           client.get('beforeEach', function(err, n) {
             assert.ok(common.hasContext());
             endTransaction();
@@ -97,10 +97,10 @@ describe('redis', function() {
       });
 
       it('should accurately measure set time', function(done) {
-        common.runInTransaction(agent, function(endTransaction) {
+        common.runInTransaction(function(endTransaction) {
           client.set('key', 'redis_value', function(err) {
             endTransaction();
-            var trace = common.getMatchingSpan(agent, redisPredicate.bind(null, 'redis-set'));
+            var trace = common.getMatchingSpan(redisPredicate.bind(null, 'redis-set'));
             assert(trace);
             done();
           });
@@ -108,11 +108,11 @@ describe('redis', function() {
       });
 
       it('should accurately measure hset time', function(done) {
-        common.runInTransaction(agent, function(endTransaction) {
+        common.runInTransaction(function(endTransaction) {
           // Test error case as hset requires 3 parameters
           client.hset('key', 'redis_value', function(err) {
             endTransaction();
-            var trace = common.getMatchingSpan(agent, redisPredicate.bind(null, 'redis-hset'));
+            var trace = common.getMatchingSpan(redisPredicate.bind(null, 'redis-hset'));
             assert(trace);
             done();
           });
@@ -120,11 +120,11 @@ describe('redis', function() {
       });
 
       it('should remove trace frames from stack', function(done) {
-        common.runInTransaction(agent, function(endTransaction) {
+        common.runInTransaction(function(endTransaction) {
           // Test error case as hset requires 3 parameters
           client.hset('key', 'redis_value', function(err) {
             endTransaction();
-            var trace = common.getMatchingSpan(agent, redisPredicate.bind(null, 'redis-hset'));
+            var trace = common.getMatchingSpan(redisPredicate.bind(null, 'redis-hset'));
             var labels = trace.labels;
             var stackTrace = JSON.parse(labels[traceLabels.STACK_TRACE_DETAILS_KEY]);
             // Ensure that our patch is on top of the stack

--- a/test/plugins/test-trace-restify.js
+++ b/test/plugins/test-trace-restify.js
@@ -61,7 +61,7 @@ describe('restify', function() {
         process.stderr.write = write;
       });
       afterEach(function() {
-        common.cleanTraces(agent);
+        common.cleanTraces();
         server.close();
       });
 
@@ -78,7 +78,7 @@ describe('restify', function() {
           }, common.serverWait);
         });
         server.listen(common.serverPort, function(){
-          common.doRequest(agent, 'GET', done, restifyPredicate);
+          common.doRequest('GET', done, restifyPredicate);
         });
       });
 
@@ -95,7 +95,7 @@ describe('restify', function() {
           }, common.serverWait);
         });
         server.listen(common.serverPort, function(){
-          common.doRequest(agent, 'POST', done, restifyPredicate);
+          common.doRequest('POST', done, restifyPredicate);
         });
       });
 
@@ -116,7 +116,7 @@ describe('restify', function() {
           }, common.serverWait / 2);
         });
         server.listen(common.serverPort, function(){
-          common.doRequest(agent, 'GET', done, restifyPredicate);
+          common.doRequest('GET', done, restifyPredicate);
         });
       });
 
@@ -133,7 +133,7 @@ describe('restify', function() {
           }, common.serverWait);
         });
         server.listen(common.serverPort, function(){
-          common.doRequest(agent, 'GET', done, restifyPredicate);
+          common.doRequest('GET', done, restifyPredicate);
         });
       });
 
@@ -155,7 +155,7 @@ describe('restify', function() {
           }, common.serverWait / 2);
         });
         server.listen(common.serverPort, function(){
-          common.doRequest(agent, 'GET', done, restifyPredicate);
+          common.doRequest('GET', done, restifyPredicate);
         });
       });
 
@@ -171,7 +171,7 @@ describe('restify', function() {
         });
         server.listen(common.serverPort, function(){
           http.get({port: common.serverPort}, function(res) {
-            var labels = common.getMatchingSpan(agent, restifyPredicate).labels;
+            var labels = common.getMatchingSpan(restifyPredicate).labels;
             assert.equal(labels[traceLabels.HTTP_RESPONSE_CODE_LABEL_KEY], '200');
             assert.equal(labels[traceLabels.HTTP_METHOD_LABEL_KEY], 'GET');
             assert.equal(labels[traceLabels.HTTP_URL_LABEL_KEY], 'http://localhost:9042/');
@@ -193,7 +193,7 @@ describe('restify', function() {
         });
         server.listen(common.serverPort, function() {
           http.get({port: common.serverPort}, function(res) {
-            var labels = common.getMatchingSpan(agent, restifyPredicate).labels;
+            var labels = common.getMatchingSpan(restifyPredicate).labels;
             var stackTrace = JSON.parse(labels[traceLabels.STACK_TRACE_DETAILS_KEY]);
             // Ensure that our middleware is on top of the stack
             assert.equal(stackTrace.stack_frame[0].method_name, 'middleware');
@@ -214,7 +214,7 @@ describe('restify', function() {
         });
         server.listen(common.serverPort, function() {
           http.get({path: '/?a=b', port: common.serverPort}, function(res) {
-            var span = common.getMatchingSpan(agent, restifyPredicate);
+            var span = common.getMatchingSpan(restifyPredicate);
             assert.equal(span.name, '/');
             done();
           });
@@ -259,7 +259,7 @@ describe('restify', function() {
         });
         server.listen(common.serverPort, function() {
           http.get({port: common.serverPort, path: '/ignore/me'}, function(res) {
-            assert.equal(common.getTraces(agent).length, 0);
+            assert.equal(common.getTraces().length, 0);
             done();
           });
         });
@@ -272,7 +272,7 @@ describe('restify', function() {
             res.write(common.serverRes);
             res.end();
             setImmediate(function() {
-              var traces = common.getTraces(agent);
+              var traces = common.getTraces();
               assert.strictEqual(traces.length, 1);
               assert.strictEqual(traces[0].spans.length, 1);
               var span = traces[0].spans[0];

--- a/test/test-agent-metadata.js
+++ b/test/test-agent-metadata.js
@@ -59,7 +59,7 @@ describe('agent interaction with metadata service', function() {
     agent = trace.start({logLevel: 0, forceNewAgent_: true});
     setTimeout(function() {
       assert.ok(agent.isActive());
-      assert.equal(common.getConfig(agent).projectId, '1234');
+      assert.equal(common.getConfig().projectId, '1234');
       scope.done();
       done();
     }, 500);
@@ -87,9 +87,9 @@ describe('agent interaction with metadata service', function() {
 
     agent = trace.start({projectId: '0', logLevel: 0, forceNewAgent_: true});
     setTimeout(function() {
-      common.runInTransaction(agent, function(end) {
+      common.runInTransaction(function(end) {
         end();
-        var span = common.getMatchingSpan(agent, spanPredicate);
+        var span = common.getMatchingSpan(spanPredicate);
         assert.equal(span.labels[traceLabels.GCE_HOSTNAME], 'host');
         scope.done();
         done();
@@ -106,9 +106,9 @@ describe('agent interaction with metadata service', function() {
 
     agent = trace.start({projectId: '0', logLevel: 0, forceNewAgent_: true});
     setTimeout(function() {
-      common.runInTransaction(agent, function(end) {
+      common.runInTransaction(function(end) {
         end();
-        var span = common.getMatchingSpan(agent, spanPredicate);
+        var span = common.getMatchingSpan(spanPredicate);
         assert.equal(span.labels[traceLabels.GCE_INSTANCE_ID], 1729);
         scope.done();
         done();
@@ -120,9 +120,9 @@ describe('agent interaction with metadata service', function() {
     nock.disableNetConnect();
     agent = trace.start({projectId: '0', logLevel: 0, forceNewAgent_: true});
     setTimeout(function() {
-      common.runInTransaction(agent, function(end) {
+      common.runInTransaction(function(end) {
         end();
-        var span = common.getMatchingSpan(agent, spanPredicate);
+        var span = common.getMatchingSpan(spanPredicate);
         assert(span.labels[traceLabels.GCE_HOSTNAME],
             require('os').hostname());
         assert(!span.labels[traceLabels.GCE_INSTANCE_ID]);
@@ -144,9 +144,9 @@ describe('agent interaction with metadata service', function() {
       }
     });
     setTimeout(function() {
-      common.runInTransaction(agent, function(end) {
+      common.runInTransaction(function(end) {
         end();
-        var span = common.getMatchingSpan(agent, spanPredicate);
+        var span = common.getMatchingSpan(spanPredicate);
         assert(span.labels[traceLabels.GAE_MODULE_NAME], 'config');
         assert(span.labels[traceLabels.GAE_MODULE_VERSION], 'configVer');
         assert.equal(span.labels[traceLabels.GAE_VERSION],
@@ -171,9 +171,9 @@ describe('agent interaction with metadata service', function() {
       }
     });
     setTimeout(function() {
-      common.runInTransaction(agent, function(end) {
+      common.runInTransaction(function(end) {
         end();
-        var span = common.getMatchingSpan(agent, spanPredicate);
+        var span = common.getMatchingSpan(spanPredicate);
         assert.equal(span.labels[traceLabels.GAE_MODULE_NAME], 'foo');
         assert.equal(span.labels[traceLabels.GAE_MODULE_VERSION],
           '20151119t120000');
@@ -190,9 +190,9 @@ describe('agent interaction with metadata service', function() {
     process.env.GAE_MINOR_VERSION = '81818';
     agent = trace.start({projectId: '0', logLevel: 0, forceNewAgent_: true});
     setTimeout(function() {
-      common.runInTransaction(agent, function(end) {
+      common.runInTransaction(function(end) {
         end();
-        var span = common.getMatchingSpan(agent, spanPredicate);
+        var span = common.getMatchingSpan(spanPredicate);
         assert.equal(span.labels[traceLabels.GAE_MODULE_NAME],
           'default');
         assert.equal(span.labels[traceLabels.GAE_MODULE_VERSION],
@@ -217,9 +217,9 @@ describe('agent interaction with metadata service', function() {
       delete process.env.GAE_SERVICE;
       agent = trace.start({projectId: '0', logLevel: 0, forceNewAgent_: true});
       setTimeout(function() {
-        common.runInTransaction(agent, function(end) {
+        common.runInTransaction(function(end) {
           end();
-          var span = common.getMatchingSpan(agent, spanPredicate);
+          var span = common.getMatchingSpan(spanPredicate);
           assert.equal(span.labels[traceLabels.GAE_MODULE_NAME],
             'host');
           scope.done();
@@ -240,9 +240,9 @@ describe('agent interaction with metadata service', function() {
       delete process.env.GAE_SERVICE;
       agent = trace.start({projectId: '0', logLevel: 0, forceNewAgent_: true});
       setTimeout(function() {
-        common.runInTransaction(agent, function(end) {
+        common.runInTransaction(function(end) {
           end();
-          var span = common.getMatchingSpan(agent, spanPredicate);
+          var span = common.getMatchingSpan(spanPredicate);
           scope.done();
           assert.equal(span.labels[traceLabels.GAE_MODULE_NAME],
             require('os').hostname());

--- a/test/test-config-credentials.js
+++ b/test/test-config-credentials.js
@@ -23,7 +23,7 @@ var common = require('./plugins/common.js');
 
 var queueSpans = function(n, agent) {
   for (var i = 0; i < n; i++) {
-    common.runInTransaction(agent, function(end) {
+    common.runInTransaction(function(end) {
       end();
     });
   }

--- a/test/test-config-max-label-size.js
+++ b/test/test-config-max-label-size.js
@@ -24,14 +24,14 @@ var common = require('./plugins/common.js');
 
 describe('maximumLabelValueSize configuration', function() {
   it('should not allow values above server maximum', function() {
-    var agent = trace.start({forceNewAgent_: true, maximumLabelValueSize: 1000000});
-    var valueMax = common.getConfig(agent).maximumLabelValueSize;
+    trace.start({forceNewAgent_: true, maximumLabelValueSize: 1000000});
+    var valueMax = common.getConfig().maximumLabelValueSize;
     assert.strictEqual(valueMax, constants.TRACE_SERVICE_LABEL_VALUE_LIMIT);
   });
 
   it('should not modify values below server maximum', function() {
-    var agent = trace.start({forceNewAgent_: true, maximumLabelValueSize: 10});
-    var valueMax = common.getConfig(agent).maximumLabelValueSize;
+    trace.start({forceNewAgent_: true, maximumLabelValueSize: 10});
+    var valueMax = common.getConfig().maximumLabelValueSize;
     assert.strictEqual(valueMax, 10);
   });
 });

--- a/test/test-config-plugins.js
+++ b/test/test-config-plugins.js
@@ -26,8 +26,8 @@ var instrumentedModules = ['connect', 'express', 'generic-pool', 'grpc', 'hapi',
 
 describe('plugin configuration', function() {
   it('should have correct defaults', function() {
-    var agent = trace.start({forceNewAgent_: true});
-    var plugins = common.getConfig(agent).plugins;
+    trace.start({forceNewAgent_: true});
+    var plugins = common.getConfig().plugins;
     assert.strictEqual(JSON.stringify(Object.keys(plugins)),
       JSON.stringify(instrumentedModules));
     for (var i = 0; i < instrumentedModules.length; i++) {
@@ -37,8 +37,8 @@ describe('plugin configuration', function() {
   });
 
   it('should handle empty object', function() {
-    var agent = trace.start({forceNewAgent_: true, plugins: {}});
-    var plugins = common.getConfig(agent).plugins;
+    trace.start({forceNewAgent_: true, plugins: {}});
+    var plugins = common.getConfig().plugins;
     assert.strictEqual(JSON.stringify(Object.keys(plugins)),
       JSON.stringify(instrumentedModules));
     assert.ok(instrumentedModules.every(function(e) {
@@ -47,10 +47,10 @@ describe('plugin configuration', function() {
   });
 
   it('should overwrite builtin plugins correctly', function() {
-    var agent = trace.start({forceNewAgent_: true, plugins: {
+    trace.start({forceNewAgent_: true, plugins: {
       express: 'foo'
     }});
-    var plugins = common.getConfig(agent).plugins;
+    var plugins = common.getConfig().plugins;
     assert.strictEqual(JSON.stringify(Object.keys(plugins)),
       JSON.stringify(instrumentedModules));
     assert.ok(instrumentedModules.filter(function(e) {

--- a/test/test-default-ignore-ah-health.js
+++ b/test/test-default-ignore-ah-health.js
@@ -42,7 +42,7 @@ describe('test-default-ignore-ah-health', function() {
         res.on('data', function(data) { result += data; });
         res.on('end', function() {
           assert.equal(result, '🏥');
-          assert.equal(common.getTraces(agent).length, 0);
+          assert.equal(common.getTraces().length, 0);
           server.close();
           done();
         });

--- a/test/test-env-log-level.js
+++ b/test/test-env-log-level.js
@@ -25,21 +25,21 @@ var common = require('./plugins/common.js');
 
 describe('should respect environment variables', function() {
   it('should respect GCLOUD_TRACE_LOGLEVEL', function() {
-    var agent = trace.start({forceNewAgent_: true});
-    assert.equal(common.getConfig(agent).logLevel, 4);
+    trace.start({forceNewAgent_: true});
+    assert.equal(common.getConfig().logLevel, 4);
   });
 
   it('should prefer env to config', function() {
-    var agent = trace.start({logLevel: 2, forceNewAgent_: true});
-    assert.equal(common.getConfig(agent).logLevel, 4);
+    trace.start({logLevel: 2, forceNewAgent_: true});
+    assert.equal(common.getConfig().logLevel, 4);
   });
 
   it('should fix out of bounds log level', function() {
     process.env.GCLOUD_TRACE_LOGLEVEL = -5;
-    var agent = trace.start({forceNewAgent_: true});
-    assert.equal(common.getConfig(agent).logLevel, 0);
+    trace.start({forceNewAgent_: true});
+    assert.equal(common.getConfig().logLevel, 0);
     process.env.GCLOUD_TRACE_LOGLEVEL = 300;
-    agent = trace.start({forceNewAgent_: true});
-    assert.equal(common.getConfig(agent).logLevel, 5);
+    trace.start({forceNewAgent_: true});
+    assert.equal(common.getConfig().logLevel, 5);
   });
 });

--- a/test/test-env-project-id.js
+++ b/test/test-env-project-id.js
@@ -25,12 +25,12 @@ var common = require('./plugins/common.js');
 
 describe('should respect environment variables', function() {
   it('should respect GCLOUD_PROJECT', function() {
-    var agent = trace.start({forceNewAgent_: true});
-    assert.equal(common.getConfig(agent).projectId, 1729);
+    trace.start({forceNewAgent_: true});
+    assert.equal(common.getConfig().projectId, 1729);
   });
 
   it('should prefer env to config', function() {
-    var agent = trace.start({projectId: 1927, forceNewAgent_: true});
-    assert.equal(common.getConfig(agent).projectId, 1729);
+    trace.start({projectId: 1927, forceNewAgent_: true});
+    assert.equal(common.getConfig().projectId, 1729);
   });
 });

--- a/test/test-grpc-context.js
+++ b/test/test-grpc-context.js
@@ -62,7 +62,7 @@ Object.keys(versions).forEach(function(version) {
       express = require('./plugins/fixtures/express4');
       grpc = require(versions[version]);
 
-      common.replaceWarnLogger(agent, function(msg) {
+      common.replaceWarnLogger(function(msg) {
         if (msg.indexOf('http') !== -1) {
           httpLogCount++;
         }
@@ -162,57 +162,57 @@ Object.keys(versions).forEach(function(version) {
       // We expect a single untraced http request for each test cooresponding to the
       // top level request used to start the desired test.
       assert.equal(httpLogCount, 1);
-      common.cleanTraces(agent);
+      common.cleanTraces();
     });
 
     it('grpc should preserve context for unary requests', function(done) {
       http.get({port: common.serverPort, path: '/unary'}, function(res) {
-        assert.strictEqual(common.getTraces(agent).length, 2);
+        assert.strictEqual(common.getTraces().length, 2);
         // gRPC Server: 1 root span, 1 http span.
-        assert.strictEqual(common.getTraces(agent)[0].spans.length, 2);
-        assert.strictEqual(common.getTraces(agent)[0].spans[0].kind, 'RPC_SERVER');
+        assert.strictEqual(common.getTraces()[0].spans.length, 2);
+        assert.strictEqual(common.getTraces()[0].spans[0].kind, 'RPC_SERVER');
         // gRPC Client: 1 root span from express, 1 gRPC span, 1 http span.
-        assert.strictEqual(common.getTraces(agent)[1].spans.length, 3);
+        assert.strictEqual(common.getTraces()[1].spans.length, 3);
         done();
       });
     });
 
     it('grpc should preserve context for client requests', function(done) {
       http.get({port: common.serverPort, path: '/client'}, function(res) {
-        assert.strictEqual(common.getTraces(agent).length, 2);
+        assert.strictEqual(common.getTraces().length, 2);
         // gRPC Server: 1 root span, 11 http spans (10 from 'data' listeners,
         // 1 from 'end' listener).
-        assert.strictEqual(common.getTraces(agent)[0].spans.length, 12);
-        assert.strictEqual(common.getTraces(agent)[0].spans[0].kind, 'RPC_SERVER');
+        assert.strictEqual(common.getTraces()[0].spans.length, 12);
+        assert.strictEqual(common.getTraces()[0].spans[0].kind, 'RPC_SERVER');
         // gRPC Client: 1 root span from express, 1 gRPC span, 1 http span.
-        assert.strictEqual(common.getTraces(agent)[1].spans.length, 3);
+        assert.strictEqual(common.getTraces()[1].spans.length, 3);
         done();
       });
     });
 
     it('grpc should preserve context for server requests', function(done) {
       http.get({port: common.serverPort, path: '/server'}, function(res) {
-        assert.strictEqual(common.getTraces(agent).length, 2);
+        assert.strictEqual(common.getTraces().length, 2);
         // gRPC Server: 1 root span, 1 http span.
-        assert.strictEqual(common.getTraces(agent)[0].spans.length, 2);
-        assert.strictEqual(common.getTraces(agent)[0].spans[0].kind, 'RPC_SERVER');
+        assert.strictEqual(common.getTraces()[0].spans.length, 2);
+        assert.strictEqual(common.getTraces()[0].spans[0].kind, 'RPC_SERVER');
         // gRPC Client: 1 root span from express, 1 gRPC span, and 11 http spans
         // (10 from 'data' listeners and 1 from the 'status' listener).
-        assert.strictEqual(common.getTraces(agent)[1].spans.length, 13);
+        assert.strictEqual(common.getTraces()[1].spans.length, 13);
         done();
       });
     });
 
     it('grpc should preserve context for bidi requests', function(done) {
       http.get({port: common.serverPort, path: '/bidi'}, function(res) {
-        assert.strictEqual(common.getTraces(agent).length, 2);
+        assert.strictEqual(common.getTraces().length, 2);
         // gRPC Server: 1 root span, 11 http spans (10 from 'data' listeners,
         // 1 from 'end' listener).
-        assert.strictEqual(common.getTraces(agent)[0].spans.length, 12);
-        assert.strictEqual(common.getTraces(agent)[0].spans[0].kind, 'RPC_SERVER');
+        assert.strictEqual(common.getTraces()[0].spans.length, 12);
+        assert.strictEqual(common.getTraces()[0].spans[0].kind, 'RPC_SERVER');
         // gRPC Client: 1 root span from express, 1 gRPC span, and 11 http spans
         // (10 from 'data' listeners and 1 from the 'status' listener).
-        assert.strictEqual(common.getTraces(agent)[1].spans.length, 13);
+        assert.strictEqual(common.getTraces()[1].spans.length, 13);
         done();
       });
     });

--- a/test/test-mysql-pool.js
+++ b/test/test-mysql-pool.js
@@ -57,7 +57,7 @@ if (semver.satisfies(process.version, '>=4')) {
             var result = '';
             res.on('data', function(data) { result += data; });
             res.on('end', function() {
-              var spans = common.getMatchingSpans(agent, function (span) {
+              var spans = common.getMatchingSpans(function (span) {
                 return span.name === 'mysql-query';
               });
               assert.equal(spans.length, 1);

--- a/test/test-no-self-tracing.js
+++ b/test/test-no-self-tracing.js
@@ -35,11 +35,11 @@ describe('test-no-self-tracing', function() {
                 .get('/computeMetadata/v1/instance/hostname').reply(200)
                 .get('/computeMetadata/v1/instance/id').reply(200)
                 .get('/computeMetadata/v1/project/project-id').reply(200);
-    var agent = require('..').start({forceNewAgent_: true});
+    require('..').start({forceNewAgent_: true});
     require('http'); // Must require http to force patching of the module
-    var oldWarn = common.replaceWarnLogger(agent, newWarn);
+    var oldWarn = common.replaceWarnLogger(newWarn);
     setTimeout(function() {
-      common.replaceWarnLogger(agent, oldWarn);
+      common.replaceWarnLogger(oldWarn);
       scope.done();
       done();
     }, 200); // Need to wait for metadata access attempt
@@ -51,19 +51,19 @@ describe('test-no-self-tracing', function() {
                 .get('/computeMetadata/v1/instance/id').reply(200);
     var apiScope = nock('https://cloudtrace.googleapis.com')
                 .patch('/v1/projects/0/traces').reply(200);
-    var agent = require('..').start({
+    require('..').start({
       projectId: '0',
       bufferSize: 1,
       forceNewAgent_: true
     });
-    common.avoidTraceWriterAuth(agent);
+    common.avoidTraceWriterAuth();
     require('http'); // Must require http to force patching of the module
-    var oldWarn = common.replaceWarnLogger(agent, newWarn);
-    common.runInTransaction(agent, function(end) {
+    var oldWarn = common.replaceWarnLogger(newWarn);
+    common.runInTransaction(function(end) {
       end();
       setTimeout(function() {
-        assert.equal(common.getTraces(agent).length, 0);
-        common.replaceWarnLogger(agent, oldWarn);
+        assert.equal(common.getTraces().length, 0);
+        common.replaceWarnLogger(oldWarn);
         metadataScope.done();
         apiScope.done();
         done();

--- a/test/test-plugins-sample-warning.js
+++ b/test/test-plugins-sample-warning.js
@@ -38,7 +38,7 @@ describe('express + dbs', function() {
   });
 
   beforeEach(function() {
-    oldWarn = common.replaceWarnLogger(agent, function(msg) {
+    oldWarn = common.replaceWarnLogger(function(msg) {
       if (msg.indexOf('http') !== -1) {
         untracedHttpSpanCount++;
       }
@@ -46,7 +46,7 @@ describe('express + dbs', function() {
   });
 
   afterEach(function() {
-    common.replaceWarnLogger(agent, oldWarn);
+    common.replaceWarnLogger(oldWarn);
     untracedHttpSpanCount = 0;
   });
 
@@ -68,7 +68,7 @@ describe('express + dbs', function() {
       http.get({port: common.serverPort}, function(res) {
         http.get({port: common.serverPort}, function(res) {
           server.close();
-          common.cleanTraces(agent);
+          common.cleanTraces();
           assert.equal(untracedHttpSpanCount, 2);
           done();
         });
@@ -91,7 +91,7 @@ describe('express + dbs', function() {
       http.get({port: common.serverPort + 1}, function(res) {
         http.get({port: common.serverPort + 1}, function(res) {
           server.close();
-          common.cleanTraces(agent);
+          common.cleanTraces();
           assert.equal(untracedHttpSpanCount, 2);
           done();
         });
@@ -112,7 +112,7 @@ describe('express + dbs', function() {
       http.get({port: common.serverPort + 2}, function(res) {
         http.get({port: common.serverPort + 2}, function(res) {
           server.close();
-          common.cleanTraces(agent);
+          common.cleanTraces();
           assert.equal(untracedHttpSpanCount, 2);
           done();
         });
@@ -139,7 +139,7 @@ describe('express + dbs', function() {
       http.get({port: common.serverPort + 3}, function(res) {
         http.get({port: common.serverPort + 3}, function(res) {
           server.close();
-          common.cleanTraces(agent);
+          common.cleanTraces();
           assert.equal(untracedHttpSpanCount, 2);
           done();
         });

--- a/test/test-span-data.js
+++ b/test/test-span-data.js
@@ -34,7 +34,7 @@ describe('SpanData', function() {
 
   it('has correct default values', function() {
     cls.getNamespace().run(function() {
-      var spanData = common.createRootSpanData(agent, 'name', 1, 2);
+      var spanData = common.createRootSpanData('name', 1, 2);
       assert.ok(spanData.trace);
       assert.strictEqual(spanData.trace.traceId, 1);
       assert.ok(spanData.span.spanId);
@@ -44,7 +44,7 @@ describe('SpanData', function() {
 
   it('converts label values to strings', function() {
     cls.getNamespace().run(function() {
-      var spanData = common.createRootSpanData(agent, 'name', 1, 2);
+      var spanData = common.createRootSpanData('name', 1, 2);
       spanData.addLabel('a', 'b');
       assert.strictEqual(spanData.span.labels.a, 'b');
       spanData.addLabel('c', 5);
@@ -54,7 +54,7 @@ describe('SpanData', function() {
 
   it('serializes object labels correctly', function() {
     cls.getNamespace().run(function() {
-      var spanData = common.createRootSpanData(agent, 'name', 1, 2);
+      var spanData = common.createRootSpanData('name', 1, 2);
       spanData.addLabel('a', [{i: 5}, {j: 6}]);
       assert.strictEqual(spanData.span.labels.a, '[ { i: 5 }, { j: 6 } ]');
     });
@@ -62,7 +62,7 @@ describe('SpanData', function() {
 
   it('serializes symbol labels correctly', function() {
     cls.getNamespace().run(function() {
-      var spanData = common.createRootSpanData(agent, 'name', 1, 2);
+      var spanData = common.createRootSpanData('name', 1, 2);
       spanData.addLabel('a', Symbol('b'));
       assert.strictEqual(spanData.span.labels.a, 'Symbol(b)');
     });
@@ -70,7 +70,7 @@ describe('SpanData', function() {
 
   it('truncate large span names to limit', function() {
     cls.getNamespace().run(function() {
-      var spanData = common.createRootSpanData(agent, Array(200).join('a'), 1, 2);
+      var spanData = common.createRootSpanData(Array(200).join('a'), 1, 2);
       assert.strictEqual(
         spanData.span.name,
         Array(constants.TRACE_SERVICE_SPAN_NAME_LIMIT - 2).join('a') + '...');
@@ -79,7 +79,7 @@ describe('SpanData', function() {
 
   it('truncate large label keys to limit', function() {
     cls.getNamespace().run(function() {
-      var spanData = common.createRootSpanData(agent, 'name', 1, 2);
+      var spanData = common.createRootSpanData('name', 1, 2);
       var longLabelKey = Array(200).join('a');
       spanData.addLabel(longLabelKey, 5);
       assert.strictEqual(
@@ -90,17 +90,17 @@ describe('SpanData', function() {
 
   it('truncate large label values to limit', function() {
     cls.getNamespace().run(function() {
-      var spanData = common.createRootSpanData(agent, 'name', 1, 2);
+      var spanData = common.createRootSpanData('name', 1, 2);
       var longLabelVal = Array(16550).join('a');
       spanData.addLabel('a', longLabelVal);
       assert.strictEqual(spanData.span.labels.a,
-        Array(common.getConfig(agent).maximumLabelValueSize - 2).join('a') + '...');
+        Array(common.getConfig().maximumLabelValueSize - 2).join('a') + '...');
     });
   });
 
   it('creates children', function() {
     cls.getNamespace().run(function() {
-      var spanData = common.createRootSpanData(agent, 'name', 1, 2);
+      var spanData = common.createRootSpanData('name', 1, 2);
       var child = spanData.createChildSpanData('name2');
       assert.strictEqual(child.span.name, 'name2');
       assert.strictEqual(child.span.parentSpanId, spanData.span.spanId);
@@ -111,7 +111,7 @@ describe('SpanData', function() {
 
   it('closes', function() {
     cls.getNamespace().run(function() {
-      var spanData = common.createRootSpanData(agent, 'name', 1, 2);
+      var spanData = common.createRootSpanData('name', 1, 2);
       assert.ok(!spanData.span.isClosed());
       spanData.close();
       assert.ok(spanData.span.isClosed());
@@ -119,9 +119,9 @@ describe('SpanData', function() {
   });
 
   it('captures stack traces', function() {
-    common.getConfig(agent).stackTraceLimit = 25;
+    common.getConfig().stackTraceLimit = 25;
     cls.getNamespace().run(function() {
-      var spanData = common.createRootSpanData(agent, 'name', 1, 2, 1);
+      var spanData = common.createRootSpanData('name', 1, 2, 1);
       assert.ok(!spanData.span.isClosed());
       spanData.close();
       var stack = spanData.span.labels[TraceLabels.STACK_TRACE_DETAILS_KEY];
@@ -135,9 +135,9 @@ describe('SpanData', function() {
   });
 
   it('does not limit stack trace', function() {
-    common.getConfig(agent).maximumLabelValueSize = 10;
+    common.getConfig().maximumLabelValueSize = 10;
     cls.getNamespace().run(function() {
-      var spanData = common.createRootSpanData(agent, 'name', 1, 2, 1);
+      var spanData = common.createRootSpanData('name', 1, 2, 1);
       spanData.close();
       var stack = spanData.span.labels[TraceLabels.STACK_TRACE_DETAILS_KEY];
       assert.ok(stack.length > 10);
@@ -148,10 +148,10 @@ describe('SpanData', function() {
 
   it('should close all spans', function() {
     cls.getNamespace().run(function() {
-      var spanData = common.createRootSpanData(agent, 'hi');
+      var spanData = common.createRootSpanData('hi');
       spanData.createChildSpanData('sub');
       spanData.close();
-      var traces = common.getTraces(agent);
+      var traces = common.getTraces();
       for (var i = 0; i < traces.length; i++) {
         for (var j = 0; j < traces[i].spans.length; j++) {
           assert.notEqual(traces[i].spans[j].endTime, '');

--- a/test/test-trace-api.js
+++ b/test/test-trace-api.js
@@ -101,12 +101,12 @@ describe('Trace Interface', function() {
     
     before(function() {
       traceAPI.enable_(agent);
-      traceAPI.private_().traceWriter.request = request;
+      TraceWriter.get().request = request;
       common.avoidTraceWriterAuth();
     });
 
     afterEach(function() {
-      TraceWriter.get().buffer_ = []; // clear traces
+      common.cleanTraces();
       cls.destroyNamespace();
       traceAPI.private_().namespace = cls.createNamespace();
     });

--- a/test/test-trace-cluster.js
+++ b/test/test-trace-cluster.js
@@ -50,7 +50,7 @@ describe('test-trace-cluster', function() {
           server.close();
           done();
         };
-        common.doRequest(agent, 'GET', finalize, expressPredicate);
+        common.doRequest('GET', finalize, expressPredicate);
       });
     }
   });

--- a/test/test-trace-header-context.js
+++ b/test/test-trace-header-context.js
@@ -36,7 +36,7 @@ describe('test-trace-header-context', function() {
   afterEach(function() {
     // On node 0.12, mocha may run multiple tests in the same
     // cls context, we need to manually clean out the context.
-    common.clearNamespace(agent);
+    common.clearNamespace();
   });
 
   it('should give correct context', function() {
@@ -61,14 +61,14 @@ describe('test-trace-header-context', function() {
     app.get('/self', function(req, res) {
       assert(req.headers[constants.TRACE_CONTEXT_HEADER_NAME]);
       res.send(common.serverRes);
-      var traces = common.getTraces(agent);
+      var traces = common.getTraces();
       assert.equal(traces.length, 2);
       assert.equal(traces[0].spans.length, 2);
       assert.equal(traces[1].spans.length, 1);
       assert.equal(traces[0].spans[0].name, '/');
       assert.equal(traces[0].spans[1].name, 'localhost');
       assert.equal(traces[1].spans[0].name, '/self');
-      common.cleanTraces(agent);
+      common.cleanTraces();
       server.close();
       done();
     });
@@ -87,14 +87,14 @@ describe('test-trace-header-context', function() {
     app.get('/self', function(req, res) {
       assert(req.headers[constants.TRACE_CONTEXT_HEADER_NAME]);
       res.send(common.serverRes);
-      var traces = common.getTraces(agent);
+      var traces = common.getTraces();
       assert.equal(traces.length, 2);
       assert.equal(traces[0].spans.length, 2);
       assert.equal(traces[1].spans.length, 1);
       assert.equal(traces[0].spans[0].name, '/');
       assert.equal(traces[0].spans[1].name, 'localhost');
       assert.equal(traces[1].spans[0].name, '/self');
-      common.cleanTraces(agent);
+      common.cleanTraces();
       server.close();
       done();
     });
@@ -119,14 +119,14 @@ describe('test-trace-header-context', function() {
         req.headers[constants.TRACE_CONTEXT_HEADER_NAME].slice(8),
         ';o=1');
       res.send(common.serverRes);
-      var traces = common.getTraces(agent);
+      var traces = common.getTraces();
       assert.equal(traces.length, 2);
       assert.equal(traces[0].spans.length, 2);
       assert.equal(traces[1].spans.length, 1);
       assert.equal(traces[0].spans[0].name, '/');
       assert.equal(traces[0].spans[1].name, 'localhost');
       assert.equal(traces[1].spans[0].name, '/self');
-      common.cleanTraces(agent);
+      common.cleanTraces();
       server.close();
       done();
     });

--- a/test/test-trace-options-sampling.js
+++ b/test/test-trace-options-sampling.js
@@ -51,8 +51,8 @@ describe('express + mongo with trace options header + sampling', function() {
         res.on('end', function() {
           if (++doneCount === 5) {
             // Only one trace should be sampled even though all have enabled header.
-            assert.equal(common.getTraces(agent).length, 1);
-            common.cleanTraces(agent);
+            assert.equal(common.getTraces().length, 1);
+            common.cleanTraces();
             server.close();
             done();
           }

--- a/test/test-trace-options.js
+++ b/test/test-trace-options.js
@@ -65,8 +65,8 @@ function sendRequests(agent, options, expectedTraceCount, done) {
       res.on('data', function() {});
       res.on('end', function() {
         if (++doneCount === options.length) {
-          assert.equal(common.getTraces(agent).length, expectedTraceCount);
-          common.cleanTraces(agent);
+          assert.equal(common.getTraces().length, expectedTraceCount);
+          common.cleanTraces();
           done();
         }
       });

--- a/test/test-trace-uncaught-exception.js
+++ b/test/test-trace-uncaught-exception.js
@@ -29,7 +29,7 @@ var path = '/v1/projects/0/traces';
 
 var queueSpans = function(n, agent) {
   for (var i = 0; i < n; i++) {
-    common.runInTransaction(agent, function(end) {
+    common.runInTransaction(function(end) {
       end();
     });
   }
@@ -71,10 +71,10 @@ describe('tracewriter publishing', function() {
         samplingRate: 0,
         onUncaughtException: 'flush'
       });
-      common.avoidTraceWriterAuth(agent);
+      common.avoidTraceWriterAuth();
       cls.getNamespace().run(function() {
         queueSpans(2, agent);
-        buf = common.getTraces(agent);
+        buf = common.getTraces();
         throw new Error(':(');
       });
     });

--- a/test/test-unpatch.js
+++ b/test/test-unpatch.js
@@ -29,7 +29,7 @@ describe('index.js', function() {
   });
 
   afterEach(function() {
-    common.stopAgent(agent);
+    common.stopAgent();
     checkUnpatches.forEach(function(f) { f(); });
     checkUnpatches = [];
   });


### PR DESCRIPTION
Dependent on #517

Most changes are mechanical, the large change in particular is in [`test-trace-api.js`](https://github.com/GoogleCloudPlatform/cloud-trace-nodejs/pull/518/files#diff-6672fc4a2f77ed575dedbaced33e52cf). Because the `agent` argument is removed, and `test-trace-api.js` is the only file that effectively used this argument, some functionality that was previously in `common.js` had to be duplicated here.