### PR TITLE
warn when creating a child of a closed span

### DIFF
--- a/src/span-data.js
+++ b/src/span-data.js
@@ -94,6 +94,10 @@ function SpanData(agent, trace, name, parentSpanId, isRoot, skipFrames) {
  * @returns {SpanData} The new child trace span data.
  */
 SpanData.prototype.createChildSpanData = function(name, skipFrames) {
+  if (this.span.isClosed()) {
+    this.agent.logger.warn('creating child for an already closed span',
+        name, this.span.name);
+  }
   return new SpanData(this.agent, this.trace, name, this.span.spanId, false,
       skipFrames + 1);
 };


### PR DESCRIPTION
In cases where context is misattributed, bugs manifest with spans being attributed to an already closed span. It would be good to have a warning for these as a mechanism to debug.

