### PR TITLE
fix: add explicit active flag in trace agent

### DIFF
--- a/src/trace-api.js
+++ b/src/trace-api.js
@@ -50,7 +50,8 @@ var nullSpan = {};
  */
 function TraceAgent(name) {
   this.pluginName_ = name;
-  this.disable(); // start disabled
+  this.active_ = true;
+  this.disable(); // disable immediately
 }
 
 /**
@@ -72,6 +73,7 @@ TraceAgent.prototype.enable = function(logger, config) {
   for (var memberName in TraceAgent.prototype) {
     this[memberName] = TraceAgent.prototype[memberName];
   }
+  this.active_ = true;
 };
 
 /**
@@ -92,6 +94,7 @@ TraceAgent.prototype.disable = function() {
   for (var memberName in phantomApiImpl) {
     this[memberName] = phantomApiImpl[memberName];
   }
+  this.active_ = false;
 };
 
 /**
@@ -101,7 +104,7 @@ TraceAgent.prototype.disable = function() {
  * @private
  */
 TraceAgent.prototype.isActive = function() {
-  return !!this.namespace_;
+  return this.active_;
 };
 
 /**

--- a/test/test-index.js
+++ b/test/test-index.js
@@ -20,6 +20,7 @@ require('./plugins/common.js');
 var assert = require('assert');
 var nock = require('nock');
 var trace = require('..');
+var TraceAgent = require('../src/trace-api.js');
 
 var disabledAgent = trace.get();
 
@@ -35,6 +36,7 @@ describe('index.js', function() {
       'wrapEmitter'
     ].forEach(function(fn) {
       assert.strictEqual(typeof disabledAgent[fn], 'function');
+      assert.notStrictEqual(disabledAgent[fn], TraceAgent.prototype[fn]);
     });
     assert.ok(disabledAgent.constants);
     assert.ok(disabledAgent.labels);


### PR DESCRIPTION
Using the custom span API while the Trace Agent is disabled causes an error, since the agent is in an inconsistent state where it uses its enabled implementation without being explicitly enabled. (Note that this doesn't affect plugin usage because plugins are not loaded if the trace agent is disabled).

This change adds an `active_` field in TraceAgent instead of relying on whether the namespace exists. This ensures that the agent is actually disabled completely.