### PR TITLE
fix: don't warn about trace loading before itself on windows

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,7 +36,7 @@ var modulesLoadedBeforeTrace = [];
 
 var traceAgent = new TraceAgent('Custom Span API');
 
-var traceModuleName = '@google-cloud' + path.sep + 'trace-agent';
+var traceModuleName = path.join('@google-cloud', 'trace-agent');
 for (var i = 0; i < filesLoadedBeforeTrace.length; i++) {
   var moduleName = traceUtil.packageNameFromPath(filesLoadedBeforeTrace[i]);
   if (moduleName && moduleName !== traceModuleName &&

--- a/index.js
+++ b/index.js
@@ -22,6 +22,7 @@ var filesLoadedBeforeTrace = Object.keys(require.cache);
 // patched before any user-land modules get loaded.
 require('continuation-local-storage');
 
+var path = require('path');
 var cls = require('./src/cls.js');
 var common = require('@google-cloud/common');
 var extend = require('extend');
@@ -35,9 +36,10 @@ var modulesLoadedBeforeTrace = [];
 
 var traceAgent = new TraceAgent('Custom Span API');
 
+var traceModuleName = '@google-cloud' + path.sep + 'trace-agent';
 for (var i = 0; i < filesLoadedBeforeTrace.length; i++) {
   var moduleName = traceUtil.packageNameFromPath(filesLoadedBeforeTrace[i]);
-  if (moduleName && moduleName !== '@google-cloud/trace-agent' &&
+  if (moduleName && moduleName !== traceModuleName &&
       modulesLoadedBeforeTrace.indexOf(moduleName) === -1) {
     modulesLoadedBeforeTrace.push(moduleName);
   }


### PR DESCRIPTION
On Windows, the Trace Agent emits a warning saying that it was loaded before itself, due to module names using system-dependent org/module separators.