### PR TITLE
refactor: remove active_ flag

### DIFF
--- a/src/trace-api.js
+++ b/src/trace-api.js
@@ -50,7 +50,6 @@ var nullSpan = {};
  */
 function TraceAgent(name) {
   this.pluginName_ = name;
-  this.active_ = true;
   this.disable(); // disable immediately
 }
 
@@ -63,9 +62,6 @@ function TraceAgent(name) {
  * @private
  */
 TraceAgent.prototype.enable = function(logger, config) {
-  if (this.isActive()) {
-    return;
-  }
   this.logger_ = logger;
   this.config_ = config;
   this.policy_ = TracingPolicy.createTracePolicy(config);
@@ -73,7 +69,6 @@ TraceAgent.prototype.enable = function(logger, config) {
   for (var memberName in TraceAgent.prototype) {
     this[memberName] = TraceAgent.prototype[memberName];
   }
-  this.active_ = true;
 };
 
 /**
@@ -82,9 +77,6 @@ TraceAgent.prototype.enable = function(logger, config) {
  * @private
  */
 TraceAgent.prototype.disable = function() {
-  if (!this.isActive()) {
-    return;
-  }
   // Even though plugins should be unpatched, setting a new policy that
   // never generates traces allows persisting wrapped methods (either because
   // they are already instantiated or the plugin doesn't unpatch them) to
@@ -94,7 +86,6 @@ TraceAgent.prototype.disable = function() {
   for (var memberName in phantomApiImpl) {
     this[memberName] = phantomApiImpl[memberName];
   }
-  this.active_ = false;
 };
 
 /**
@@ -104,7 +95,7 @@ TraceAgent.prototype.disable = function() {
  * @private
  */
 TraceAgent.prototype.isActive = function() {
-  return this.active_;
+  return !!this.namespace_;
 };
 
 /**

--- a/test/non-interference/http-e2e.js
+++ b/test/non-interference/http-e2e.js
@@ -32,11 +32,18 @@ fs.mkdirSync(path.join(node_dir, 'test', 'tmp'));
 console.log('Turning off global checks');
 // The use of the -i flag as '-i.bak' to specify a backup extension of '.bak'
 // is needed to ensure that the command works on both Linux and OS X
+var testCommonPath = [
+    path.join(node_dir, 'test', 'common', 'index.js'),
+    path.join(node_dir, 'test', 'common.js')
+].find(function(candidatePath) {
+    return fs.existsSync(candidatePath);
+});
+if (!testCommonPath) {
+    console.error('No common.js or common/index.js found in test directory');
+    process.exit(1);
+}
 cp.execFileSync('sed', ['-i.bak', 's/exports.globalCheck = true/' +
-    'exports.globalCheck = false/g',
-    semver.satisfies(process.version, '>=8.0.0') ?
-        path.join(node_dir, 'test', 'common', 'index.js') :
-        path.join(node_dir, 'test', 'common.js')]);
+    'exports.globalCheck = false/g', testCommonPath]);
 var test_glob = semver.satisfies(process.version, '0.12.x') ?
     path.join(node_dir, 'test', 'simple', 'test-http*.js') :
     path.join(node_dir, 'test', 'parallel', 'test-http*.js');


### PR DESCRIPTION
`this.active_` guards are unnecessary in `TraceApi`. This change removes them.