### PR TITLE
feat: Add GCLOUD_TRACE_CONFIG env config

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,12 @@ See [the default configuration](config.js) for a list of possible configuration 
 require('@google-cloud/trace-agent').start({samplingRate: 500});
 ```
 
+Alternatively, you can provide configuration through a config file. This can be useful if you want to load our module using `--require` on the command line instead of editing your main script. You can start by copying the default config file and modifying it to suit your needs. The `GCLOUD_TRACE_CONFIG` environment variable should point to your configuration file.
+
+```bash
+export GCLOUD_TRACE_CONFIG=./path/to/your/trace/configuration.js
+```
+
 ## Running on Google Cloud Platform
 
 There are three different services that can host Node.js applications within Google Cloud Platform.

--- a/index.js
+++ b/index.js
@@ -53,6 +53,7 @@ for (var i = 0; i < filesLoadedBeforeTrace.length; i++) {
  * @return A normalized configuration object.
  */
 function initConfig(projectConfig) {
+
   var envConfig = {
     logLevel: process.env.GCLOUD_TRACE_LOGLEVEL,
     projectId: process.env.GCLOUD_PROJECT,
@@ -62,7 +63,16 @@ function initConfig(projectConfig) {
       minorVersion: process.env.GAE_MINOR_VERSION
     }
   };
-  var config = extend(true, {}, require('./config.js'), projectConfig, envConfig);
+
+  var envSetConfig = {};
+  if (process.env.hasOwnProperty('GCLOUD_TRACE_CONFIG')) {
+    envSetConfig = require(path.resolve(process.env.GCLOUD_TRACE_CONFIG));
+  }
+  // Configuration order of precedence:
+  // Default < Environment Variable Set Configuration File < Project
+  var config = extend(true, {}, require('./config.js'), envSetConfig,
+    projectConfig, envConfig);
+
   // Enforce the upper limit for the label value size.
   if (config.maximumLabelValueSize > constants.TRACE_SERVICE_LABEL_VALUE_LIMIT) {
     config.maximumLabelValueSize = constants.TRACE_SERVICE_LABEL_VALUE_LIMIT;

--- a/test/fixtures/test-config.js
+++ b/test/fixtures/test-config.js
@@ -18,6 +18,7 @@
 module.exports = {
   logLevel: 4,
   stackTraceLimit: 1,
-  flushDelaySeconds: 31
+  flushDelaySeconds: 31,
+  samplingRate: 15
 };
 

--- a/test/test-config-priority.js
+++ b/test/test-config-priority.js
@@ -1,0 +1,43 @@
+/**
+ * Copyright 2015 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+
+var path = require('path');
+var assert = require('assert');
+
+// Default configuration:
+// { logLevel: 1, stackTraceLimit: 0, flushDelaySeconds: 30, samplingRate: 10 };
+
+// Fixtures configuration:
+// { logLevel: 4, stackTraceLimit: 1, flushDelaySeconds: 31 };
+process.env.GCLOUD_TRACE_CONFIG =
+  path.resolve(__dirname, '..', 'test', 'fixtures', 'test-config.js');
+
+process.env.GCLOUD_TRACE_LOGLEVEL = 2;
+
+var agent = require('..').start({ logLevel: 3,
+  stackTraceLimit: 2 });
+
+describe('should respect config load order', function() {
+  it('should order Default -> env config -> start -> env specific', function() {
+    var config = agent.config_;
+
+    assert.equal(config.logLevel, 2);
+    assert.equal(config.stackTraceLimit, 2);
+    assert.equal(config.flushDelaySeconds, 31);
+    assert.equal(config.samplingRate, 15);
+  });
+});


### PR DESCRIPTION
- This implementation provides a means of setting
  the configuration file from the environment variable,
  GCLOUD_TRACE_CONFIG.

Addresses: #525 

If the decision is to change the order, I can do that as well and update the tests accordingly.