### PR TITLE
get rid of commitlint

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,1 +1,0 @@
-module.exports = {extends: ['@commitlint/config-angular']};

--- a/package.json
+++ b/package.json
@@ -10,8 +10,7 @@
     "changelog": "./bin/run-changelog.sh",
     "coverage": "./bin/run-test.sh -c",
     "bump": "./bin/run-bump.sh",
-    "closure": "./node_modules/.bin/closure-npc",
-    "commitmsg": "commitlint -e"
+    "closure": "./node_modules/.bin/closure-npc"
   },
   "keywords": [
     "google",
@@ -24,8 +23,6 @@
     "node": ">=0.12"
   },
   "devDependencies": {
-    "@commitlint/cli": "^3.0.3",
-    "@commitlint/config-angular": "^3.0.3",
     "@google-cloud/datastore": "^1.0.2",
     "changelog-maker": "^2.2.2",
     "closure-npc": "*",
@@ -34,7 +31,6 @@
     "glob": "^7.0.3",
     "google-auto-auth": "^0.7.0",
     "got": "^5.7.1",
-    "husky": "^0.14.3",
     "istanbul": "^0.4.2",
     "jshint": "^2.9.1",
     "mocha": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -9,8 +9,7 @@
     "system-test": "mocha --no-timeouts system-test/*.js",
     "changelog": "./bin/run-changelog.sh",
     "coverage": "./bin/run-test.sh -c",
-    "bump": "./bin/run-bump.sh",
-    "closure": "./node_modules/.bin/closure-npc"
+    "bump": "./bin/run-bump.sh"
   },
   "keywords": [
     "google",
@@ -25,7 +24,6 @@
   "devDependencies": {
     "@google-cloud/datastore": "^1.0.2",
     "changelog-maker": "^2.2.2",
-    "closure-npc": "*",
     "coveralls": "^2.11.8",
     "express": "^4.15.2",
     "glob": "^7.0.3",


### PR DESCRIPTION
We tried this experiment, I am not sure it is successful:
Too onerous. Unfriendly to non-collaborators. Doesn't work well with github squash and rebase workflow.


Opinions @GoogleCloudPlatform/node-team ?