### PR TITLE
test: restore Function#length property in wrapped mocha test functions when using continuation-local-storage with node 8

### DIFF
--- a/test/plugins/common.js
+++ b/test/plugins/common.js
@@ -26,18 +26,11 @@ var semver = require('semver');
 var logger = require('@google-cloud/common').logger;
 var trace = require('../..');
 var cls = require('../../src/cls.js');
-if (semver.satisfies(process.version, '>=8')) {
+if (semver.satisfies(process.version, '>=8') && process.env.GCLOUD_TRACE_NEW_CONTEXT) {
   // Monkeypatch the monkeypatcher
   var oldIt = global.it;
   global.it = function it(title, fn) {
-    var wrapped = cls.createNamespace().bind(fn);
-    if (fn.length === 1) {
-      var oldWrapped = wrapped;
-      wrapped = function(done) {
-        return oldWrapped.apply(this, arguments);
-      };
-    }
-    return oldIt.call(this, title, wrapped);
+    return oldIt.call(this, title, cls.createNamespace().bind(fn));
   };
 }
 var tracePolicy = require('../../src/tracing-policy.js');

--- a/test/plugins/common.js
+++ b/test/plugins/common.js
@@ -30,7 +30,14 @@ if (semver.satisfies(process.version, '>=8')) {
   // Monkeypatch the monkeypatcher
   var oldIt = global.it;
   global.it = function it(title, fn) {
-    return oldIt.call(this, title, cls.createNamespace().bind(fn));
+    var wrapped = cls.createNamespace().bind(fn);
+    if (fn.length === 1) {
+      var oldWrapped = wrapped;
+      wrapped = function(done) {
+        return oldWrapped.apply(this, arguments);
+      };
+    }
+    return oldIt.call(this, title, wrapped);
   };
 }
 var tracePolicy = require('../../src/tracing-policy.js');

--- a/test/test-cls-ah.js
+++ b/test/test-cls-ah.js
@@ -19,11 +19,9 @@ var assert = require('assert');
 var http = require('http');
 var semver = require('semver');
 
-if (semver.satisfies(process.version, '<8')) {
+if (semver.satisfies(process.version, '<8') || !process.env.GCLOUD_TRACE_NEW_CONTEXT) {
   console.log('Skipping cls-ah tests on node version without async hooks');
   return;
-} else {
-  assert.ok(process.env.GCLOUD_TRACE_NEW_CONTEXT);
 }
 
 var cls = require('../src/cls-ah.js');


### PR DESCRIPTION
This change allows tests using c-l-s (instead of async-hooks) to run correctly in Node 8.