### PR TITLE
style: change constants/trace labels to consts from namespaces; remove JSDoc types

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -16,23 +16,23 @@
 
 'use strict';
 
-export namespace Constants {
-  /** @const {string} header that carries trace context across Google infrastructure. */
-  export const TRACE_CONTEXT_HEADER_NAME = 'x-cloud-trace-context';
+export const Constants = {
+  /** Header that carries trace context across Google infrastructure. */
+  TRACE_CONTEXT_HEADER_NAME: 'x-cloud-trace-context',
 
-  /** @const {string} header that is used to identify outgoing http made by the agent. */
-  export const TRACE_AGENT_REQUEST_HEADER = 'x-cloud-trace-agent-request';
+  /** Header that is used to identify outgoing http made by the agent. */
+  TRACE_AGENT_REQUEST_HEADER: 'x-cloud-trace-agent-request',
 
-  /** @const {number} bitmask to determine whether trace is enabled in trace options. */
-  export const TRACE_OPTIONS_TRACE_ENABLED = 1 << 0;
+  /** Bitmask to determine whether trace is enabled in trace options. */
+  TRACE_OPTIONS_TRACE_ENABLED: 1 << 0,
 
   /** See: cloud.google.com/trace/api/reference/rest/v1/projects.traces for limits. */
   /** Maximum size of a span name in bytes. */
-  export const TRACE_SERVICE_SPAN_NAME_LIMIT = 127;
+  TRACE_SERVICE_SPAN_NAME_LIMIT: 127,
 
   /** Maximum size of a label key in bytes. */
-  export const TRACE_SERVICE_LABEL_KEY_LIMIT = 127;
+  TRACE_SERVICE_LABEL_KEY_LIMIT: 127,
 
   /** Maximum size of a label value in bytes. */
-  export const TRACE_SERVICE_LABEL_VALUE_LIMIT = 16 * 1024 - 1;
+  TRACE_SERVICE_LABEL_VALUE_LIMIT: 16 * 1024 - 1
 };

--- a/src/span-data.ts
+++ b/src/span-data.ts
@@ -43,18 +43,18 @@ interface StackFrame {
 }
 
 // Auto-incrementing integer
-let uid: number = 1;
+let uid = 1;
 
 export class SpanData {
   public readonly span: TraceSpan;
 
   /**
    * Creates a trace context object.
-   * @param {Trace} trace The object holding the spans comprising this trace.
-   * @param {string} name The name of the span.
-   * @param {number} parentSpanId The id of the parent span, 0 for root spans.
-   * @param {boolean} isRoot Whether this is a root span.
-   * @param {number} skipFrames the number of frames to remove from the top of the stack.
+   * @param trace The object holding the spans comprising this trace.
+   * @param name The name of the span.
+   * @param parentSpanId The id of the parent span, 0 for root spans.
+   * @param isRoot Whether this is a root span.
+   * @param skipFrames the number of frames to remove from the top of the stack.
    * @constructor
    */
   constructor(

--- a/src/trace-labels.ts
+++ b/src/trace-labels.ts
@@ -19,78 +19,74 @@
 /**
  * Well-known trace span label values.
  */
-export namespace TraceLabels {
+export const TraceLabels = {
   /**
-   * @type {string} The well-known label for http status code.
+   * The well-known label for http status code.
    */
-  export const HTTP_RESPONSE_CODE_LABEL_KEY = '/http/status_code';
+  HTTP_RESPONSE_CODE_LABEL_KEY: '/http/status_code',
 
   /**
-   * @type {string} The well-known label for http request url.
+   * The well-known label for http request url.
    */
-  export const HTTP_URL_LABEL_KEY = '/http/url';
+  HTTP_URL_LABEL_KEY: '/http/url',
 
   /**
-   * @type {string} The well-known label for http method.
+   * The well-known label for http method.
    */
-  export const HTTP_METHOD_LABEL_KEY = '/http/method';
+  HTTP_METHOD_LABEL_KEY: '/http/method',
 
   /**
-   * @type {string} The well-known label for http response size.
+   * The well-known label for http response size.
    */
-  export const HTTP_RESPONSE_SIZE_LABEL_KEY = '/http/response/size';
+  HTTP_RESPONSE_SIZE_LABEL_KEY: '/http/response/size',
 
   /**
-   * @type {string} The well-known label for stack-traces
+   * The well-known label for stack-traces
    */
-  export const STACK_TRACE_DETAILS_KEY = '/stacktrace';
+  STACK_TRACE_DETAILS_KEY: '/stacktrace',
 
   /**
-   * @type {string} The well-known label for network error name.
+   * The well-known label for network error name.
    */
-  export const ERROR_DETAILS_NAME = '/error/name';
+  ERROR_DETAILS_NAME: '/error/name',
 
   /**
-   * @type {string} The well-known label for network error message.
+   * The well-known label for network error message.
    */
-  export const ERROR_DETAILS_MESSAGE = '/error/message';
+  ERROR_DETAILS_MESSAGE: '/error/message',
 
   /**
-   * @type {string} The well-known label for the app version on AppEngine.
+   * The well-known label for the app version on AppEngine.
    */
-  export const GAE_VERSION = 'g.co/gae/app/version';
+  GAE_VERSION: 'g.co/gae/app/version',
 
   /**
    * @type {string} The well-known label for the module name on AppEngine.
    */
-  export const GAE_MODULE_NAME = 'g.co/gae/app/module';
+  GAE_MODULE_NAME: 'g.co/gae/app/module',
 
   /**
-   * @type {string} The well-known label for the module version on AppEngine.
+   * The well-known label for the module version on AppEngine.
    */
-  export const GAE_MODULE_VERSION = 'g.co/gae/app/module_version';
+  GAE_MODULE_VERSION: 'g.co/gae/app/module_version',
 
   /**
-   * @type {string} The label for GCE instance id. This is not a label
-   *   recognized by the trace API.
+   * The label for GCE instance id. This is not a label recognized by the trace API.
    */
-  export const GCE_INSTANCE_ID = 'g.co/gce/instanceid';
+  GCE_INSTANCE_ID: 'g.co/gce/instanceid',
 
   /**
-   * @type {string} The label for GCE hostname. This is not a label
-   *   recognized by the trace API.
+   * The label for GCE hostname. This is not a label recognized by the trace API.
    */
-  export const GCE_HOSTNAME = 'g.co/gce/hostname';
+  GCE_HOSTNAME: 'g.co/gce/hostname',
 
   /**
-   * @type {string} The label for http request source ip. This is not a
-   *   label recognized by the trace API.
+   * The label for http request source ip. This is not a label recognized by the trace API.
    */
-  export const HTTP_SOURCE_IP = '/http/source/ip';
+  HTTP_SOURCE_IP: '/http/source/ip',
 
   /**
-   * @type {string} The well-known label for agent metadata.
-   *   Values should have the form "<name> <version>".
+   * The well-known label for agent metadata. Values should have the form "<name> <version>".
    */
-  export const AGENT_DATA = '/agent';
+  AGENT_DATA: '/agent'
 };

--- a/src/trace-span.ts
+++ b/src/trace-span.ts
@@ -43,8 +43,8 @@ export class TraceSpan {
 
   /**
    * Sets or updates a label value.
-   * @param {string} key The label key to set.
-   * @param {string} value The new value of the label.
+   * @param key The label key to set.
+   * @param value The new value of the label.
    */
   setLabel(key: string, value: string): void {
     this.labels[key] = value;
@@ -59,7 +59,7 @@ export class TraceSpan {
 
   /**
    * Checks whether or not this span has been closed.
-   * @returns {boolean} True if the span is closed, false otherwise.
+   * @returns True if the span is closed, false otherwise.
    */
   isClosed(): boolean {
     return this.endTime !== '';

--- a/src/trace-writer.ts
+++ b/src/trace-writer.ts
@@ -55,7 +55,7 @@ export interface LabelObject {
  * A class representing a service that publishes traces in the background.
  */
 export class TraceWriter extends common.Service {
-  // TODO(kjin): Make this private (it's public for testing)
+  // TODO(kjin): Make public members private (they're public for testing)
   private logger_: common.Logger;
   private config_: TraceWriterOptions;
   /** Stringified traces to be published */
@@ -69,8 +69,8 @@ export class TraceWriter extends common.Service {
 
   /**
    * Constructs a new TraceWriter instance.
-   * @param {!Logger} logger The Trace Agent's logger object.
-   * @param {Object} config A config object containing information about
+   * @param logger The Trace Agent's logger object.
+   * @param config A config object containing information about
    *   authorization credentials.
    * @constructor
    */
@@ -239,7 +239,7 @@ export class TraceWriter extends common.Service {
    * Ensures that all sub spans of the provided spanData are
    * closed and then queues the span data to be published.
    *
-   * @param {SpanData} spanData The trace to be queued.
+   * @param spanData The trace to be queued.
    */
   writeSpan(spanData: SpanData) {
     for (const span of spanData.trace.spans) {
@@ -261,7 +261,7 @@ export class TraceWriter extends common.Service {
    * Buffers the provided trace to be published.
    *
    * @private
-   * @param {Trace} trace The trace to be queued.
+   * @param trace The trace to be queued.
    */
   queueTrace_(trace: Trace) {
     this.getProjectId((err, projectId?) => {
@@ -316,7 +316,7 @@ export class TraceWriter extends common.Service {
   /**
    * Publishes flushed traces to the network.
    * 
-   * @param {string} json The stringified json representation of the queued traces.
+   * @param json The stringified json representation of the queued traces.
    */
   publish_(json: string) {
     const uri = `https://cloudtrace.googleapis.com/v1/projects/${this.config_.projectId}/traces`;

--- a/src/util.ts
+++ b/src/util.ts
@@ -73,9 +73,8 @@ export interface TraceContext {
  * note that we ignore trailing garbage if there is more than one '='
  * Returns null if traceId or spanId could not be found.
  *
- * @param {string} str string representation of the trace headers
- * @return {?{traceId: string, spanId: string, options: number}}
- *         object with keys. null if there is a problem.
+ * @param str string representation of the trace headers
+ * @return object with keys. null if there is a problem.
  */
 export function parseContextFromHeader(str: string): TraceContext | null {
   if (!str) {
@@ -97,9 +96,8 @@ export function parseContextFromHeader(str: string): TraceContext | null {
  * Generates a trace context header value that can be used
  * to follow the associated request through other Google services.
  *
- * @param {?{traceId: string, spanId: string, options: number}} traceContext
- *        An object with information sufficient for creating a serialized trace
- *        context.
+ * @param traceContext An object with information sufficient for creating a
+ *        serialized trace context.
  */
 export function generateTraceContext(traceContext: TraceContext): string {
   if (!traceContext) {
@@ -117,7 +115,7 @@ export function generateTraceContext(traceContext: TraceContext): string {
  * For example:
  *   './node_modules/bar/index/foo.js' => 'bar'
  *
- * @param {string} path The full import path.
+ * @param path The full import path.
  */
 export function packageNameFromPath(path: string) {
   const matches = moduleRegex.exec(path);
@@ -128,8 +126,8 @@ export function packageNameFromPath(path: string) {
  * Determines the path at which the requested module will be loaded given
  * the provided parent module.
  *
- * @param {string} request The name of the module to be loaded.
- * @param {object} parent The module into which the requested module will be loaded.
+ * @param request The name of the module to be loaded.
+ * @param parent The module into which the requested module will be loaded.
  */
 export function findModulePath(request: string, parent: NodeModule): string | null {
   const mainScriptDir = path.dirname(Module._resolveFilename(request, parent));
@@ -146,7 +144,7 @@ export function findModulePath(request: string, parent: NodeModule): string | nu
 /**
  * Determines the version of the module located at `modulePath`.
  *
- * @param {?string} modulePath The absolute path to the root directory of the
+ * @param modulePath The absolute path to the root directory of the
  *    module being loaded. This may be null if we are loading an internal module
  *    such as http.
  */


### PR DESCRIPTION
The style guide forbids namespaces. This commit changes `Constants` and `TraceLabels` to plain objects. Also, it removes JSDoc types.

In response to https://github.com/GoogleCloudPlatform/cloud-trace-nodejs/pull/559#pullrequestreview-63831472