### PR TITLE
feat: expand restify supported version range to include v5, v6

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ The trace agent can do automatic tracing of the following web frameworks:
 * [gRPC](https://www.npmjs.com/package/grpc)* server (version 1)
 * [hapi](https://www.npmjs.com/package/hapi) (versions 8 - 16)
 * [koa](https://www.npmjs.com/package/koa) (version 1)
-* [restify](https://www.npmjs.com/package/restify) (versions 3 - 4)
+* [restify](https://www.npmjs.com/package/restify) (versions 3 - 6)
 
 The agent will also automatic trace of the following kinds of RPCs:
 * Outbound HTTP requests through the `http` and `https` core modules

--- a/src/plugins/plugin-restify.ts
+++ b/src/plugins/plugin-restify.ts
@@ -18,7 +18,7 @@
 
 var shimmer = require('shimmer');
 
-var SUPPORTED_VERSIONS = '<=4.x';
+var SUPPORTED_VERSIONS = '<=6.x';
 
 function unpatchRestify(restify) {
   shimmer.unwrap(restify, 'createServer');

--- a/test/plugins/fixtures/restify5/index.js
+++ b/test/plugins/fixtures/restify5/index.js
@@ -1,0 +1,1 @@
+module.exports = require('restify');

--- a/test/plugins/fixtures/restify5/package.json
+++ b/test/plugins/fixtures/restify5/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "restify5",
+  "version": "1.0.0",
+  "main": "index.js",
+  "dependencies": {
+    "restify": "^5.2.0"
+  }
+}

--- a/test/plugins/fixtures/restify6/index.js
+++ b/test/plugins/fixtures/restify6/index.js
@@ -1,0 +1,1 @@
+module.exports = require('restify');

--- a/test/plugins/fixtures/restify6/package.json
+++ b/test/plugins/fixtures/restify6/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "restify6",
+  "version": "1.0.0",
+  "main": "index.js",
+  "dependencies": {
+    "restify": "^6.0.1"
+  }
+}

--- a/test/plugins/test-trace-restify.ts
+++ b/test/plugins/test-trace-restify.ts
@@ -23,7 +23,9 @@ var assert = require('assert');
 var common = require('./common'/*.js*/);
 var semver = require('semver');
 var versions: any = {
-  restify4: './fixtures/restify4'
+  restify4: './fixtures/restify4',
+  restify5: './fixtures/restify5',
+  restify6: './fixtures/restify6'
 };
 if (semver.satisfies(process.version, '<7')) {
   versions.restify3 = './fixtures/restify3';


### PR DESCRIPTION
This change adds tracing for restify 5 and 6. Addresses #571