### PR TITLE
src: patch https in Node 8.9 and 9.0

### DIFF
--- a/config.ts
+++ b/config.ts
@@ -164,6 +164,7 @@ export const defaultConfig = {
     'grpc': path.join(__dirname, 'src/plugins/plugin-grpc.js'),
     'hapi': path.join(__dirname, 'src/plugins/plugin-hapi.js'),
     'http': path.join(__dirname, 'src/plugins/plugin-http.js'),
+    'https': path.join(__dirname, 'src/plugins/plugin-https.js'),
     'knex': path.join(__dirname, 'src/plugins/plugin-knex.js'),
     'koa': path.join(__dirname, 'src/plugins/plugin-koa.js'),
     'mongodb-core': path.join(__dirname, 'src/plugins/plugin-mongodb-core.js'),

--- a/src/plugins/plugin-http.ts
+++ b/src/plugins/plugin-http.ts
@@ -174,7 +174,7 @@ module.exports = [
   },
   {
     file: 'https',
-    versions: '>=8.9.0',
+    versions: '=8.9.0 || >=9.0.0',
     patch: patchHttps,
     unpatch: unpatchHttps
   }

--- a/src/plugins/plugin-http.ts
+++ b/src/plugins/plugin-http.ts
@@ -144,8 +144,7 @@ function patchHttp(http, api) {
   }
 }
 
-function patchHttps(https, api) {
-  console.log('patch https');
+function patchHttps(https, api) { // https.get depends on https.request in <8.9 and >=8.9.1
   shimmer.wrap(https, 'request', function requestWrap(request) {
     return makeRequestTrace(request, api);
   });

--- a/src/plugins/plugin-https.ts
+++ b/src/plugins/plugin-https.ts
@@ -1,0 +1,25 @@
+/**
+ * Copyright 2015 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+// Force load http to patch https with the http plugin.
+// https depends on http anyway, so this shouldn't cause an unnecessary load.
+require('http');
+
+module.exports = [];
+
+export default {};

--- a/src/plugins/plugin-https.ts
+++ b/src/plugins/plugin-https.ts
@@ -14,12 +14,8 @@
  * limitations under the License.
  */
 
-'use strict';
-
 // Force load http to patch https with the http plugin.
 // https depends on http anyway, so this shouldn't cause an unnecessary load.
-require('http');
+import 'http';
 
-module.exports = [];
-
-export default {};
+export = [];

--- a/test/plugins/test-trace-http.ts
+++ b/test/plugins/test-trace-http.ts
@@ -22,7 +22,7 @@ var common = require('./common'/*.js*/);
 var semver = require('semver');
 var stream = require('stream');
 
-require('../..').start({ 
+require('../..').start({
   projectId: '0',
   samplingRate: 0
 });
@@ -308,9 +308,7 @@ describe('test-trace-http', function() {
   });
 });
 
-// TODO(kjin): https patching doens't work in Node 8.9+; see #589 on GitHub.
-var noHttps = semver.satisfies(process.version, '>=8.9.0');
-(noHttps ? describe.skip : describe)('https', function() {
+describe('https', function() {
   var https;
   before(function() {
     https = require('https');

--- a/test/test-config-plugins.ts
+++ b/test/test-config-plugins.ts
@@ -23,7 +23,7 @@ var shimmer = require('shimmer');
 var trace = require('..');
 
 var instrumentedModules = ['connect', 'express', 'generic-pool', 'grpc', 'hapi',
-  'http', 'knex', 'koa', 'mongodb-core', 'mysql', 'pg', 'redis', 'restify'];
+  'http', 'https', 'knex', 'koa', 'mongodb-core', 'mysql', 'pg', 'redis', 'restify'];
 
 describe('plugin configuration', function() {
   var plugins;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,7 @@
   },
   "include": [
     "*.ts",
-    "src/*.ts"
+    "src/*.ts",
+    "src/plugins/plugin-https.ts"
   ]
 }


### PR DESCRIPTION
Fixes #589 

Loading either `http` or `https` will cause both to be patched for tracing. This is in line with behavior in <8.9, as `https.request` used to depend on `http.request`.

The only new user-facing change is in the addition of the `https` config field: disabling causes the specific behavior of not patching `https` only if it's loaded before `http` in user-space code. It's a niche use-case so I think this is justifiable, but please let me know your thoughts.

By nature of our loader system this is uncharted territory, so feel free to give suggestions if you think there's a better approach.