### PR TITLE
fix: propagate context in koa tracing

### DIFF
--- a/src/plugins/plugin-koa.ts
+++ b/src/plugins/plugin-koa.ts
@@ -16,12 +16,11 @@
 'use strict';
 
 const shimmer = require('shimmer');
-const co = require('co');
-var urlParse = require('url').parse;
+const urlParse = require('url').parse;
 
 function startSpanForRequest(api, req, res, next) {
-  var originalEnd = res.end;
-  var options = {
+  const originalEnd = res.end;
+  const options = {
     name: urlParse(req.url).pathname,
     url: req.url,
     traceContext: req.headers[api.constants.TRACE_CONTEXT_HEADER_NAME],
@@ -29,14 +28,14 @@ function startSpanForRequest(api, req, res, next) {
   };
   return api.runInRootSpan(options, function(root) {
     // Set response trace context.
-    var responseTraceContext =
+    const responseTraceContext =
       api.getResponseTraceContext(options.traceContext, !!root);
     if (responseTraceContext) {
       res.setHeader(api.constants.TRACE_CONTEXT_HEADER_NAME, responseTraceContext);
     }
     
     if (!root) {
-      return;
+      return next;
     }
 
     api.wrapEmitter(req);

--- a/test/plugins/test-trace-koa.ts
+++ b/test/plugins/test-trace-koa.ts
@@ -25,8 +25,9 @@ var semver = require('semver');
 var appBuilders: any = {
   koa1: buildKoa1App,
 };
-if (semver.satisfies(process.version, '>4')) {
-  appBuilders.koa2 = buildKoa2App;
+var skipKoa2 = semver.satisfies(process.version, '<=4');
+if (!skipKoa2) {
+  appBuilders.koa2 = buildKoa2App
 }
 
 describe('koa', function() {
@@ -42,7 +43,7 @@ describe('koa', function() {
   });
 
   Object.keys(appBuilders).forEach(function(version) {
-    describe.skip(version, function() {
+    describe(version, function() {
       var buildKoaApp = appBuilders[version];
 
       afterEach(function() {
@@ -196,7 +197,7 @@ describe('koa', function() {
       });
     });
 
-    it('should work in koa 2', function(done) {
+    (skipKoa2 ? it.skip : it)('should work in koa 2', function(done) {
       var children: any[] = [];
       var Koa = require('./fixtures/koa2');
       var app = new Koa();


### PR DESCRIPTION
Fixes #593

The Koa tracing plugin ignored the return value of `api.wrap`, resulting in trace context not being propagated correctly. This affects both Koa 1 and 2, but Koa 1 needs different patching logic altogether (as it relies on generator functions).