### PR TITLE
fix: actually prevent warning when loading https plugin

### DIFF
--- a/src/plugins/plugin-http.ts
+++ b/src/plugins/plugin-http.ts
@@ -145,14 +145,12 @@ function patchHttp(http, api) {
 }
 
 function patchHttps(https, api) { // https.get depends on https.request in <8.9 and >=8.9.1
-  if (semver.satisfies(process.version, '=8.9.0 || >=9.0.0')) {
-    shimmer.wrap(https, 'request', function requestWrap(request) {
-      return makeRequestTrace(request, api);
-    });
-    shimmer.wrap(https, 'get', function getWrap(get) {
-      return makeRequestTrace(get, api);
-    });
-  }
+  shimmer.wrap(https, 'request', function requestWrap(request) {
+    return makeRequestTrace(request, api);
+  });
+  shimmer.wrap(https, 'get', function getWrap(get) {
+    return makeRequestTrace(get, api);
+  });
 }
 
 function unpatchHttp(http) {
@@ -163,10 +161,8 @@ function unpatchHttp(http) {
 }
 
 function unpatchHttps(https) {
-  if (semver.satisfies(process.version, '=8.9.0 || >=9.0.0')) {
-    shimmer.unwrap(https, 'request');
-    shimmer.unwrap(https, 'get');
-  }
+  shimmer.unwrap(https, 'request');
+  shimmer.unwrap(https, 'get');
 }
 
 module.exports = [
@@ -177,6 +173,7 @@ module.exports = [
   },
   {
     file: 'https',
+    versions: '=8.9.0 || >=9.0.0',
     patch: patchHttps,
     unpatch: unpatchHttps
   }


### PR DESCRIPTION
In #596 I confused the condition for triggering the unwanted warning message -- this happens when no patches in a plugin fall in a given range, not when a single patch is ignored. This PR corrects for that. It's a combination of reverting #596 and changing the warn condition to be "there are patches, but none were loaded because _all_ of their supported version ranges are not satisfied". (For the https plugin, there are no patches, so the condition is false.)