### PR TITLE
Port mysql plugin to support mysql2

### DIFF
--- a/config.ts
+++ b/config.ts
@@ -168,6 +168,7 @@ export const defaultConfig = {
     'koa': path.join(__dirname, 'src/plugins/plugin-koa.js'),
     'mongodb-core': path.join(__dirname, 'src/plugins/plugin-mongodb-core.js'),
     'mysql': path.join(__dirname, 'src/plugins/plugin-mysql.js'),
+    'mysql2': path.join(__dirname, 'src/plugins/plugin-mysql2.js'),
     'pg': path.join(__dirname, 'src/plugins/plugin-pg.js'),
     'redis': path.join(__dirname, 'src/plugins/plugin-redis.js'),
     'restify': path.join(__dirname, 'src/plugins/plugin-restify.js')

--- a/src/plugins/plugin-mysql2.ts
+++ b/src/plugins/plugin-mysql2.ts
@@ -1,0 +1,101 @@
+/**
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+
+var shimmer = require('shimmer');
+
+var SUPPORTED_VERSIONS = '^1.3.5';
+
+function createCreateQueryWrap(api) {
+  return function createQueryWrap(createQuery) {
+    return function createQuery_trace(sql, values, cb, config) {
+      var span = api.createChildSpan({
+        name: 'mysql-query'
+      });
+      var query = createQuery.apply(this, arguments);
+      if (!span) {
+        return query;
+      }
+      if (api.enhancedDatabaseReportingEnabled()) {
+        span.addLabel('sql', query.sql);
+        if (query.values) {
+          span.addLabel('values', query.values);
+        }
+      }
+      api.wrapEmitter(query);
+      if (query.onResult) {
+        query.onResult = wrapCallback(api, span, query.onResult);
+      } else {
+        query.on('end', function() {
+          span.endSpan();
+        });
+      }
+      return query;
+    };
+  };
+}
+
+function wrapCallback(api, span, done) {
+  var fn = function(err, res) {
+    if (api.enhancedDatabaseReportingEnabled()) {
+      if (err) {
+        span.addLabel('error', err);
+      }
+      if (res) {
+        span.addLabel('result', res);
+      }
+    }
+    span.endSpan();
+    if (done) {
+      done(err, res);
+    }
+  };
+  return api.wrap(fn);
+}
+
+function createWrapGetConnection(api) {
+  return function wrapGetConnection(getConnection) {
+    return function getConnection_trace(cb) {
+      return getConnection.call(this, api.wrap(cb));
+    };
+  };
+}
+
+module.exports = [
+  {
+    file: 'lib/connection.js',
+    versions: SUPPORTED_VERSIONS,
+    patch: function(Connection, api) {
+      shimmer.wrap(Connection, 'createQuery', createCreateQueryWrap(api));
+    },
+    unpatch: function(Connection) {
+      shimmer.unwrap(Connection, 'createQuery');
+    }
+  },
+  {
+    file: 'lib/pool.js',
+    versions: SUPPORTED_VERSIONS,
+    patch: function(Pool, api) {
+      shimmer.wrap(Pool.prototype, 'getConnection',
+                   createWrapGetConnection(api));
+    },
+    unpatch: function(Pool) {
+      shimmer.unwrap(Pool.prototype, 'getConnection');
+    }
+  }
+];
+
+export default {};


### PR DESCRIPTION
This PR adds support for the `mysql2` npm module (as per #582).

I am unsure on how to get the test suite up and running correctly, if someone could point me in the right direction I'd be happy to also write tests for the added plugin 👍 

I will put comments on the relevant lines that changed from `plugin-mysql.js`