### PR TITLE
fix: options.port is supposed to be a number

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5594,6 +5594,7 @@
         "make-error": "1.3.0",
         "minimist": "1.2.0",
         "mkdirp": "0.5.1",
+        "source-map-support": "0.4.18",
         "tsconfig": "6.0.0",
         "v8flags": "3.0.1",
         "yn": "2.0.0"
@@ -5617,6 +5618,21 @@
             "ansi-styles": "3.2.0",
             "escape-string-regexp": "1.0.5",
             "supports-color": "4.5.0"
+          }
+        },
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+          "dev": true
+        },
+        "source-map-support": {
+          "version": "0.4.18",
+          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
+          "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
+          "dev": true,
+          "requires": {
+            "source-map": "0.5.7"
           }
         },
         "supports-color": {

--- a/src/plugins/plugin-http.ts
+++ b/src/plugins/plugin-http.ts
@@ -40,7 +40,7 @@ function extractUrl(options) {
   return isString(uri) ? uri :
     (options.protocol || agent.protocol) + '//' +
     (options.hostname || options.host || 'localhost') +
-    ((isString(options.port) ? (':' + options.port) : '')) +
+    (options.port ? (':' + options.port) : '') +
     (options.path || options.pathName || '/');
 }
 

--- a/test/plugins/test-trace-http.ts
+++ b/test/plugins/test-trace-http.ts
@@ -172,6 +172,22 @@ describe('test-trace-http', function() {
     );
   });
 
+  it('custom port number must be included in the url label', function(done) {
+    server.listen(common.serverPort, common.runInTransaction.bind(null,
+      function(endTransaction) {
+        http.get({port: common.serverPort});
+        setTimeout(function() {
+          endTransaction();
+          var traces = common.getTraces();
+          assert.equal(traces.length, 1);
+          assert.equal(traces[0].spans[1].labels['/http/url'],
+              `http://localhost:${common.serverPort}/`);
+          done();
+        }, common.serverWait * 1.5);
+      })
+    );
+  });
+
   it('should accurately measure get time, error', function(done) {
     var server = http.Server(function(req, res) {
       setTimeout(function() {


### PR DESCRIPTION
Per node's doc, `options.port` is supposed to be a number, but
trace-agent is checking if it's a string. Update the code so we just
check if it's truthy. I think it's better because zero is not a valid
port number and it'll also work for (non-empty) strings too.