### PR TITLE
fix: add projectId to config type definitions

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -126,6 +126,12 @@ export interface Config {
   ignoreContextHeader?: boolean;
 
   /**
+   * The ID of the Google Cloud Platform project with which traces should
+   * be associated.
+   */
+  projectId?: string;
+
+  /**
    * The contents of a key file. If this field is set, its contents will be
    * used for authentication instead of your application default credentials.
    */

--- a/src/config.ts
+++ b/src/config.ts
@@ -21,7 +21,10 @@ const pluginDirectory =
 
 /** Available configuration options. */
 export interface Config {
-  /** Log levels: 0=disabled, 1=error, 2=warn, 3=info, 4=debug */
+  /**
+   * Log levels: 0=disabled, 1=error, 2=warn, 3=info, 4=debug
+   * The value of GCLOUD_TRACE_LOGLEVEL takes precedence over this value.
+   */
   logLevel?: number;
 
   /**
@@ -127,7 +130,9 @@ export interface Config {
 
   /**
    * The ID of the Google Cloud Platform project with which traces should
-   * be associated.
+   * be associated. The value of GCLOUD_PROJECT takes precedence over this
+   * value; if neither are provided, the trace agent will attempt to retrieve
+   * this information from the GCE metadata service.
    */
   projectId?: string;
 


### PR DESCRIPTION
Somehow I left out `projectId` from the `Config` object type definitions (probably because it doesn't have a default value)... this change adds it.