### PR TITLE
fix: use new node error constructor type definitions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
     "@google-cloud/common": {
       "version": "0.15.1",
       "resolved": "https://registry.npmjs.org/@google-cloud/common/-/common-0.15.1.tgz",
-      "integrity": "sha512-cnVtHLvyiSQvb1RzXWDp7PA1sA8Jmc47+wp/xwHwdGOlQZfKog5iluZ0C/LB8iklFXpcTwlNMorqLuZ/qH0DDA==",
+      "integrity": "sha1-pveVNd5ibMDgWwzNqdsMNgmeR6M=",
       "requires": {
         "array-uniq": "1.0.3",
         "arrify": "1.0.1",
@@ -248,7 +248,7 @@
       "integrity": "sha1-oz4N+dzptCTRyY/E/evYV43O7H4=",
       "dev": true,
       "requires": {
-        "@types/node": "8.0.53"
+        "@types/node": "8.0.58"
       }
     },
     "@types/extend": {
@@ -263,7 +263,7 @@
       "integrity": "sha512-JAMFhOaHIciYVh8fb5/83nmuO/AHwmto+Hq7a9y8FzLDcC1KCU344XDOMEmahnrTFlHjgh4L0WJFczNIX2GxnQ==",
       "dev": true,
       "requires": {
-        "@types/node": "8.0.53"
+        "@types/node": "8.0.58"
       }
     },
     "@types/glob": {
@@ -273,7 +273,7 @@
       "dev": true,
       "requires": {
         "@types/minimatch": "3.0.1",
-        "@types/node": "8.0.53"
+        "@types/node": "8.0.58"
       }
     },
     "@types/is": {
@@ -297,7 +297,7 @@
     "@types/mocha": {
       "version": "2.2.44",
       "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-2.2.44.tgz",
-      "integrity": "sha512-k2tWTQU8G4+iSMvqKi0Q9IIsWAp/n8xzdZS4Q4YVIltApoMA00wFBFdlJnmoaK1/z7B0Cy0yPe6GgXteSmdUNw==",
+      "integrity": "sha1-HUp5jlPzUhL9WtTQQFBiAXHNW14=",
       "dev": true
     },
     "@types/ncp": {
@@ -306,13 +306,13 @@
       "integrity": "sha1-dJQyUR9q10fQTpiDexjMqQRVZ/s=",
       "dev": true,
       "requires": {
-        "@types/node": "8.0.53"
+        "@types/node": "8.0.58"
       }
     },
     "@types/node": {
-      "version": "8.0.53",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-8.0.53.tgz",
-      "integrity": "sha512-54Dm6NwYeiSQmRB1BLXKr5GELi0wFapR1npi8bnZhEcu84d/yQKqnwwXQ56hZ0RUbTG6L5nqDZaN3dgByQXQRQ==",
+      "version": "8.0.58",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-8.0.58.tgz",
+      "integrity": "sha512-V746iUU7eHNdzQipoACuguDlVhC7IHK8CES1jSkuFt352wwA84BCWPXaGekBd7R5XdNK5ReHONDVKxlL9IreAw==",
       "dev": true
     },
     "@types/once": {
@@ -324,7 +324,7 @@
     "@types/pify": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@types/pify/-/pify-3.0.0.tgz",
-      "integrity": "sha512-BIRcpFqRm64rVuuYCFzOF37I2IEP3sXhiCjy8NbzJkxqFY2CLiDLFPhh6Sph/eXPXctg05MayCEDmeKCOIUBFg==",
+      "integrity": "sha1-4X2Vwn500jBevAaw+NKMsC+WEv4=",
       "dev": true
     },
     "@types/proxyquire": {
@@ -340,7 +340,7 @@
       "dev": true,
       "requires": {
         "@types/form-data": "2.2.1",
-        "@types/node": "8.0.53"
+        "@types/node": "8.0.58"
       }
     },
     "@types/semver": {
@@ -358,10 +358,10 @@
     "@types/uuid": {
       "version": "3.4.3",
       "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-3.4.3.tgz",
-      "integrity": "sha512-5fRLCYhLtDb3hMWqQyH10qtF+Ud2JnNCXTCZ+9ktNdCcgslcuXkDTkFcJNk++MT29yDntDnlF1+jD+uVGumsbw==",
+      "integrity": "sha1-EhrOJl9Vac5A9PbQ/3ijOMcyp1Q=",
       "dev": true,
       "requires": {
-        "@types/node": "8.0.53"
+        "@types/node": "8.0.58"
       }
     },
     "JSONStream": {
@@ -1096,7 +1096,7 @@
     "continuation-local-storage": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/continuation-local-storage/-/continuation-local-storage-3.2.1.tgz",
-      "integrity": "sha512-jx44cconVqkCEEyLSKWwkvUXwO561jXMa3LPjTPsm5QR22PA0/mhe33FT4Xb5y74JDvt/Cq+5lm8S8rskLv9ZA==",
+      "integrity": "sha1-EfYT906RT+mzTJKtLSj+auHbf/s=",
       "requires": {
         "async-listener": "0.6.8",
         "emitter-listener": "1.1.1"
@@ -1302,7 +1302,7 @@
     "coveralls": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/coveralls/-/coveralls-3.0.0.tgz",
-      "integrity": "sha512-ZppXR9y5PraUOrf/DzHJY6gzNUhXYE3b9D43xEXs4QYZ7/Oe0Gy0CS+IPKWFfvQFXB3RG9QduaQUFehzSpGAFw==",
+      "integrity": "sha1-Iu9zAzBTgIDSm4wVHckUav3oipk=",
       "dev": true,
       "requires": {
         "js-yaml": "3.6.1",
@@ -1889,7 +1889,7 @@
     "gcp-metadata": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-0.4.1.tgz",
-      "integrity": "sha512-yFE7v+NyoMiTOi2L6r8q87eVbiZCKooJNPKXTHhBStga8pwwgWofK9iHl00qd0XevZxcpk7ORaEL/ALuTvlaGQ==",
+      "integrity": "sha1-ZGI7hBdTV8wRmtemrsdZOSqQpYs=",
       "requires": {
         "extend": "3.0.1",
         "retry-request": "3.1.0"
@@ -2158,7 +2158,7 @@
         "gcp-metadata": {
           "version": "0.3.1",
           "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-0.3.1.tgz",
-          "integrity": "sha512-5kJPX/RXuqoLmHiOOgkSDk/LI0QaXpEvZ3pvQP4ifjGGDKZKVSOjL/GcDjXA5kLxppFCOjmmsu0Uoop9d1upaQ==",
+          "integrity": "sha1-MTgURW58PQ7rj4sISzNXnohvgpo=",
           "requires": {
             "extend": "3.0.1",
             "retry-request": "3.1.0"
@@ -2167,7 +2167,7 @@
         "google-auth-library": {
           "version": "0.12.0",
           "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-0.12.0.tgz",
-          "integrity": "sha512-79qCXtJ1VweBmmLr4yLq9S4clZB2p5Y+iACvuKk9gu4JitEnPc+bQFmYvtCYehVR44MQzD1J8DVmYW2w677IEw==",
+          "integrity": "sha1-o/xsKW0Au1Tk2HfvWBoFlHMw0H8=",
           "requires": {
             "gtoken": "1.2.3",
             "jws": "3.1.4",
@@ -3146,7 +3146,7 @@
     "gts": {
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/gts/-/gts-0.5.1.tgz",
-      "integrity": "sha512-+2dBzbax1Km3buM8Xg/iYAZoR3CoppZkzYsQHNpH4N9bVkJ+o243aXRRmzz8yvqmcuDUss2gyN+sbB2yt9SxAw==",
+      "integrity": "sha1-QvVZSd/U9SuURh3iYpVireOgDuw=",
       "dev": true,
       "requires": {
         "chalk": "2.3.0",
@@ -3172,7 +3172,7 @@
         "chalk": {
           "version": "2.3.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
-          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+          "integrity": "sha1-tepI78nBeT3MybR2fJORTT8tUro=",
           "dev": true,
           "requires": {
             "ansi-styles": "3.2.0",
@@ -4341,7 +4341,7 @@
     "mocha": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/mocha/-/mocha-4.0.1.tgz",
-      "integrity": "sha512-evDmhkoA+cBNiQQQdSKZa2b9+W2mpLoj50367lhy+Klnx9OV8XlCIhigUnn1gaTFLQCa0kdNhEGDr0hCXOQFDw==",
+      "integrity": "sha1-Cu5alc9ppGGIIPXlH6MXFxF9rxs=",
       "dev": true,
       "requires": {
         "browser-stdout": "1.3.0",
@@ -4359,7 +4359,7 @@
         "debug": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "integrity": "sha1-W7WgZyYotkFJVmuhaBnmFRjGcmE=",
           "dev": true,
           "requires": {
             "ms": "2.0.0"
@@ -4368,19 +4368,19 @@
         "diff": {
           "version": "3.3.1",
           "resolved": "https://registry.npmjs.org/diff/-/diff-3.3.1.tgz",
-          "integrity": "sha512-MKPHZDMB0o6yHyDryUOScqZibp914ksXwAMYMTHj6KO8UeKsRYNJD3oNCKjTqZon+V488P7N/HzXF8t7ZR95ww==",
+          "integrity": "sha1-qoVnpu7QPFMfyJ0/cRzQ5SWd7HU=",
           "dev": true
         },
         "growl": {
           "version": "1.10.3",
           "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.3.tgz",
-          "integrity": "sha512-hKlsbA5Vu3xsh1Cg3J7jSmX/WaW6A5oBeqzM88oNbCRQFz+zUaXm6yxS4RVytp1scBoJzSYl4YAEOQIt6O8V1Q==",
+          "integrity": "sha1-GSa6kM8+3+KttJJ/WIC8IsZseQ8=",
           "dev": true
         },
         "supports-color": {
           "version": "4.4.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
-          "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
+          "integrity": "sha1-iD992rwWUUKyphQn8zUt7RldGj4=",
           "dev": true,
           "requires": {
             "has-flag": "2.0.0"
@@ -5000,7 +5000,7 @@
     "request": {
       "version": "2.83.0",
       "resolved": "https://registry.npmjs.org/request/-/request-2.83.0.tgz",
-      "integrity": "sha512-lR3gD69osqm6EYLk9wB/G1W/laGWjzH90t1vEa2xuxHD5KUrSzp9pUSfTm+YC5Nxt2T8nMPEvKlhbQayU7bgFw==",
+      "integrity": "sha1-ygtl2gLtYpNYh4COb1EDgQNOM1Y=",
       "requires": {
         "aws-sign2": "0.7.0",
         "aws4": "1.6.0",
@@ -5117,7 +5117,7 @@
     "semver": {
       "version": "5.4.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
-      "integrity": "sha1-4FnAnYVx8FQII3M0M1BdOi8AsY4="
+      "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg=="
     },
     "semver-diff": {
       "version": "2.1.0",
@@ -5197,7 +5197,7 @@
     "shimmer": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/shimmer/-/shimmer-1.2.0.tgz",
-      "integrity": "sha512-xTCx2vohXC2EWWDqY/zb4+5Mu28D+HYNSOuFzsyRDRvI/e1ICb69afwaUwfjr+25ZXldbOLyp+iDUZHq8UnTag=="
+      "integrity": "sha1-+Wb3VVeJdj502IQRk2haXnhzZmU="
     },
     "signal-exit": {
       "version": "3.0.2",
@@ -5226,7 +5226,7 @@
     "source-map-support": {
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.0.tgz",
-      "integrity": "sha512-vUoN3I7fHQe0R/SJLKRdKYuEdRGogsviXFkHHo17AWaTGv17VLnxw+CFXvqy+y4ORZ3doWLQcxRYfwKrsd/H7Q==",
+      "integrity": "sha1-IBinrSvfj68mkeX92rJr7VorrKs=",
       "dev": true,
       "requires": {
         "source-map": "0.6.1"
@@ -5235,7 +5235,7 @@
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
           "dev": true
         }
       }
@@ -5684,7 +5684,7 @@
         "source-map-support": {
           "version": "0.4.18",
           "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
-          "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
+          "integrity": "sha1-Aoam3ovkJkEzhZTpfM6nXwosWF8=",
           "dev": true,
           "requires": {
             "source-map": "0.5.7"

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "@types/is": "0.0.17",
     "@types/mocha": "^2.2.44",
     "@types/ncp": "^2.0.1",
-    "@types/node": "^8.0.53",
+    "@types/node": "^8.0.58",
     "@types/once": "^1.4.0",
     "@types/pify": "^3.0.0",
     "@types/proxyquire": "^1.3.28",

--- a/src/span-data.ts
+++ b/src/span-data.ts
@@ -79,10 +79,10 @@ export class SpanData implements SpanDataInterface {
 
       const origPrepare = Error.prepareStackTrace;
       Error.prepareStackTrace =
-          (error: Error, structured: CallSite[]): CallSite[] => {
+          (error: Error, structured: NodeJS.CallSite[]): NodeJS.CallSite[] => {
             return structured;
           };
-      const e: {stack?: CallSite[]} = {};
+      const e: {stack?: NodeJS.CallSite[]} = {};
       Error.captureStackTrace(e, SpanData);
 
       const stackFrames: StackFrame[] = [];

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -18,31 +18,6 @@ declare namespace NodeJS {
   }
 }
 
-interface CallSite {
-  getThis: () => any | undefined;
-  getTypeName: () => string;
-  getFunction: () => Function | undefined;
-  getFunctionName: () => string;
-  getMethodName: () => string;
-  getFileName: () => string | undefined;
-  getLineNumber: () => number | undefined;
-  getColumnNumber: () => number | undefined;
-  getEvalOrigin: () => CallSite | undefined;
-  isToplevel: () => boolean;
-  isEval: () => boolean;
-  isNative: () => boolean;
-  isConstructor: () => boolean;
-}
-
-interface ErrorConstructor {
-  prepareStackTrace?: (
-    error: Error,
-    structuredStackTrace: CallSite[]
-  ) => CallSite[] | string;
-  captureStackTrace(targetObject: Object, constructorOpt?: Function): void;
-  stackTraceLimit: number;
-}
-
 declare module '@google-cloud/common' {
   import * as request from 'request';
 


### PR DESCRIPTION
`@types/node` recently introduces built-in `CallSite` and `ErrorConstructor` type definitions, so this change removes them. (The compilation will fail otherwise because the definitions are slightly incompatible.)