### PR TITLE
fix semver prerelease not-a-function error

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -349,6 +349,18 @@
       "integrity": "sha1-82WFNa9/H1AqzW2n2vQF/+sffuQ=",
       "dev": true
     },
+    "@types/strip-bom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/strip-bom/-/strip-bom-3.0.0.tgz",
+      "integrity": "sha1-FKjsOVbC6B7bdSB5CuzyHCkK69I=",
+      "dev": true
+    },
+    "@types/strip-json-comments": {
+      "version": "0.0.30",
+      "resolved": "https://registry.npmjs.org/@types/strip-json-comments/-/strip-json-comments-0.0.30.tgz",
+      "integrity": "sha512-7NQmHra/JILCd1QqpSzl8+mJRc8ZHz3uDm8YV1Ks9IhK0epEiTw8aIErbvH9PI+6XbqhyIQy3462nEsn7UVzjQ==",
+      "dev": true
+    },
     "@types/tmp": {
       "version": "0.0.33",
       "resolved": "https://registry.npmjs.org/@types/tmp/-/tmp-0.0.33.tgz",
@@ -5638,9 +5650,9 @@
       "dev": true
     },
     "ts-node": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-3.3.0.tgz",
-      "integrity": "sha1-wTxqMCTjC+EYDdUwOPwgkonUv2k=",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-4.1.0.tgz",
+      "integrity": "sha512-xcZH12oVg9PShKhy3UHyDmuDLV3y7iKwX25aMVPt1SIXSuAfWkFiGPEkg+th8R4YKW/QCxDoW7lJdb15lx6QWg==",
       "dev": true,
       "requires": {
         "arrify": "1.0.1",
@@ -5649,8 +5661,8 @@
         "make-error": "1.3.0",
         "minimist": "1.2.0",
         "mkdirp": "0.5.1",
-        "source-map-support": "0.4.18",
-        "tsconfig": "6.0.0",
+        "source-map-support": "0.5.0",
+        "tsconfig": "7.0.0",
         "v8flags": "3.0.1",
         "yn": "2.0.0"
       },
@@ -5667,7 +5679,7 @@
         "chalk": {
           "version": "2.3.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
-          "integrity": "sha1-tepI78nBeT3MybR2fJORTT8tUro=",
+          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
           "dev": true,
           "requires": {
             "ansi-styles": "3.2.0",
@@ -5675,20 +5687,11 @@
             "supports-color": "4.5.0"
           }
         },
-        "source-map": {
-          "version": "0.5.7",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+        "strip-bom": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
           "dev": true
-        },
-        "source-map-support": {
-          "version": "0.4.18",
-          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
-          "integrity": "sha1-Aoam3ovkJkEzhZTpfM6nXwosWF8=",
-          "dev": true,
-          "requires": {
-            "source-map": "0.5.7"
-          }
         },
         "supports-color": {
           "version": "4.5.0",
@@ -5698,24 +5701,18 @@
           "requires": {
             "has-flag": "2.0.0"
           }
-        }
-      }
-    },
-    "tsconfig": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/tsconfig/-/tsconfig-6.0.0.tgz",
-      "integrity": "sha1-aw6DdgA9evGGT434+J3QBZ/80DI=",
-      "dev": true,
-      "requires": {
-        "strip-bom": "3.0.0",
-        "strip-json-comments": "2.0.1"
-      },
-      "dependencies": {
-        "strip-bom": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
-          "dev": true
+        },
+        "tsconfig": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/tsconfig/-/tsconfig-7.0.0.tgz",
+          "integrity": "sha512-vZXmzPrL+EmC4T/4rVlT2jNVMWCi/O4DIiSj3UHg1OE5kCKbk4mfrXc6dZksLgRM/TZlKnousKH9bbTazUWRRw==",
+          "dev": true,
+          "requires": {
+            "@types/strip-bom": "3.0.0",
+            "@types/strip-json-comments": "0.0.30",
+            "strip-bom": "3.0.0",
+            "strip-json-comments": "2.0.1"
+          }
         }
       }
     },

--- a/src/trace-plugin-loader.ts
+++ b/src/trace-plugin-loader.ts
@@ -168,7 +168,7 @@ export function activate(logger: Logger, config: PluginLoaderConfig): void {
             if (semver.valid(version)) {
               // strip version of pre-release tags.
               // warn if they exist.
-              if (!!semver.prerelease(version)) {
+              if (typeof semver.prerelease === 'function' && !!semver.prerelease(version)) {
                 const originalVersion = version;
                 version = version.split('-')[0];
                 logger.warn(`${moduleRoot}: Using patch for version ${


### PR DESCRIPTION
Using node:8.9.1-stretch from https://hub.docker.com/_/node/ and with semver 5.4.1 in package-lock.json caused `TypeError: semver.prerelease is not a function`. This just ensures it is a function before calling it.

Stack trace:
```
/app/node_modules/@google-cloud/trace-agent/build/src/trace-plugin-loader.js:112
                    if (!!semver.prerelease(version)) {
                                 ^

TypeError: semver.prerelease is not a function
    at loadAndPatch (/app/node_modules/@google-cloud/trace-agent/build/src/trace-plugin-loader.js:112:34)
    at Function.Module_load [as _load] (/app/node_modules/@google-cloud/trace-agent/build/src/trace-plugin-loader.js:185:37)
    at Module.require (module.js:568:17)
    at require (internal/module.js:11:18)
    at Object.<anonymous> (/app/node_modules/methods/index.js:15:12)
    at Module._compile (module.js:624:30)
    at Object.Module._extensions..js (module.js:635:10)
    at Module.load (module.js:545:32)
    at tryModuleLoad (module.js:508:12)
    at Function.Module._load (module.js:500:3)
```