### PR TITLE
refactor: use setHeader to set trace context header

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,7 +96,6 @@
     "is": "^3.2.0",
     "lodash.findindex": "^4.4.0",
     "lodash.isequal": "^4.0.0",
-    "lodash.merge": "^4.6.0",
     "methods": "^1.1.1",
     "semver": "^5.4.1",
     "shimmer": "^1.2.0",

--- a/src/plugins/plugin-http.ts
+++ b/src/plugins/plugin-http.ts
@@ -82,14 +82,7 @@ function makeRequestTrace(request, api) {
                                   options.method);
     requestLifecycleSpan.addLabel(api.labels.HTTP_URL_LABEL_KEY, uri);
 
-    var headers = options.headers ? Object.assign({}, options.headers) : {};
-    headers[api.constants.TRACE_CONTEXT_HEADER_NAME] =
-        requestLifecycleSpan.getTraceContext();
-    // Clone the options object to pass to request options,
-    // using the new set of headers.
-    var requestOptions = Object.assign({}, options, { headers: headers });
-
-    var req = request.call(this, requestOptions, function(res) {
+    var req = request.call(this, options, function(res) {
       api.wrapEmitter(res);
       var numBytes = 0;
       var listenerAttached = false;
@@ -123,6 +116,8 @@ function makeRequestTrace(request, api) {
         return callback(res);
       }
     });
+    req.setHeader(api.constants.TRACE_CONTEXT_HEADER_NAME,
+        requestLifecycleSpan.getTraceContext());
     api.wrapEmitter(req);
     req.on('error', function (e) {
       if (e) {

--- a/src/plugins/plugin-http2.ts
+++ b/src/plugins/plugin-http2.ts
@@ -178,9 +178,11 @@ function unpatchHttp2(h2: NodeJS.Module) {
   shimmer.unwrap(h2, 'connect');
 }
 
+// TODO(kjin): Node 9.4+ introduces incompatible changes
 module.exports = [
   {
     file: 'http2',
+    versions: '<9.4.0',
     patch: patchHttp2,
     unpatch: unpatchHttp2,
   },

--- a/test/plugins/test-trace-http2.ts
+++ b/test/plugins/test-trace-http2.ts
@@ -33,7 +33,7 @@ import {TraceLabels} from '../../src/trace-labels';
 import {TraceSpan} from '../../src/trace-span';
 
 describe('test-trace-http2', () => {
-  if (semver.satisfies(process.version, '<8')) {
+  if (semver.satisfies(process.version, '<8 || >=9.4')) {
     console.log(
         'Skipping test-trace-http2 on Node.js version ' + process.version);
     return;
@@ -316,7 +316,7 @@ describe('test-trace-http2', () => {
 });
 
 describe('test-trace-secure-http2', () => {
-  if (semver.satisfies(process.version, '<8')) {
+  if (semver.satisfies(process.version, '<8 || >=9.4')) {
     console.log(
         'Skipping test-trace-secure-http2 on Node.js version ' +
         process.version);


### PR DESCRIPTION
Fixes #639 

The HTTP tracing plugin should not be trying to clone the HTTP request options object if it's not even clear if the request is being traced. This change ~~moves the clone to after this check has been made~~ removes the `merge` call in favor of using `setHeader` to mutate headers after `http.request` has been called.