### PR TITLE
fix: fix a failing http2 test in Node 9.4.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -293,7 +293,7 @@
       "integrity": "sha1-oz4N+dzptCTRyY/E/evYV43O7H4=",
       "dev": true,
       "requires": {
-        "@types/node": "8.0.58"
+        "@types/node": "9.3.0"
       }
     },
     "@types/extend": {
@@ -308,7 +308,7 @@
       "integrity": "sha512-JAMFhOaHIciYVh8fb5/83nmuO/AHwmto+Hq7a9y8FzLDcC1KCU344XDOMEmahnrTFlHjgh4L0WJFczNIX2GxnQ==",
       "dev": true,
       "requires": {
-        "@types/node": "8.0.58"
+        "@types/node": "9.3.0"
       }
     },
     "@types/glob": {
@@ -318,7 +318,7 @@
       "dev": true,
       "requires": {
         "@types/minimatch": "3.0.1",
-        "@types/node": "8.0.58"
+        "@types/node": "9.3.0"
       }
     },
     "@types/is": {
@@ -351,13 +351,13 @@
       "integrity": "sha1-dJQyUR9q10fQTpiDexjMqQRVZ/s=",
       "dev": true,
       "requires": {
-        "@types/node": "8.0.58"
+        "@types/node": "9.3.0"
       }
     },
     "@types/node": {
-      "version": "8.0.58",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-8.0.58.tgz",
-      "integrity": "sha512-V746iUU7eHNdzQipoACuguDlVhC7IHK8CES1jSkuFt352wwA84BCWPXaGekBd7R5XdNK5ReHONDVKxlL9IreAw==",
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-9.3.0.tgz",
+      "integrity": "sha512-wNBfvNjzsJl4tswIZKXCFQY0lss9nKUyJnG6T94X/eqjRgI2jHZ4evdjhQYBSan/vGtF6XVXPApOmNH2rf0KKw==",
       "dev": true
     },
     "@types/once": {
@@ -385,7 +385,7 @@
       "dev": true,
       "requires": {
         "@types/form-data": "2.2.1",
-        "@types/node": "8.0.58"
+        "@types/node": "9.3.0"
       }
     },
     "@types/semver": {
@@ -418,7 +418,7 @@
       "integrity": "sha1-EhrOJl9Vac5A9PbQ/3ijOMcyp1Q=",
       "dev": true,
       "requires": {
-        "@types/node": "8.0.58"
+        "@types/node": "9.3.0"
       }
     },
     "JSONStream": {
@@ -4155,9 +4155,9 @@
       }
     },
     "js-green-licenses": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/js-green-licenses/-/js-green-licenses-0.2.0.tgz",
-      "integrity": "sha512-AkUDqKfvOREpd+ZbZRIdP5YRbEyNsyxMBgvMrfjs4zk5TpYJondN+Xcvm57tj7e1cgYaoBg5yx9g99eXEoYuqA==",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/js-green-licenses/-/js-green-licenses-0.3.1.tgz",
+      "integrity": "sha512-pFWoi11NZuQPt0emRrQKVi+DVjLUYSE+v/cbMzWIrce+2CvkQ5PQUHwJwXua835Q4RpJMe2BxR66VU7BC1Tusg==",
       "dev": true,
       "requires": {
         "argparse": "1.0.9",
@@ -4166,7 +4166,8 @@
         "package-json": "4.0.1",
         "pify": "3.0.0",
         "spdx-correct": "2.0.4",
-        "spdx-satisfies": "0.1.3"
+        "spdx-satisfies": "0.1.3",
+        "strip-json-comments": "2.0.1"
       },
       "dependencies": {
         "spdx-correct": {

--- a/src/plugins/plugin-http2.ts
+++ b/src/plugins/plugin-http2.ts
@@ -178,7 +178,6 @@ function unpatchHttp2(h2: NodeJS.Module) {
   shimmer.unwrap(h2, 'connect');
 }
 
-// TODO(kjin): Node 9.4+ introduces incompatible changes
 module.exports = [
   {
     file: 'http2',

--- a/src/plugins/plugin-http2.ts
+++ b/src/plugins/plugin-http2.ts
@@ -182,7 +182,6 @@ function unpatchHttp2(h2: NodeJS.Module) {
 module.exports = [
   {
     file: 'http2',
-    versions: '<9.4.0',
     patch: patchHttp2,
     unpatch: unpatchHttp2,
   },

--- a/test/plugins/test-trace-http2.ts
+++ b/test/plugins/test-trace-http2.ts
@@ -323,7 +323,7 @@ describe('test-trace-http2', () => {
 });
 
 describe('test-trace-secure-http2', () => {
-  if (semver.satisfies(process.version, '<8 || >=9.4')) {
+  if (semver.satisfies(process.version, '<8')) {
     console.log(
         'Skipping test-trace-secure-http2 on Node.js version ' +
         process.version);


### PR DESCRIPTION
Node 9.4.0 removed `rstStream...()` methods and added `close()`. Modify
the test accordingly.