### PR TITLE
Change span ID to use random bytes

### DIFF
--- a/src/span-data.ts
+++ b/src/span-data.ts
@@ -42,11 +42,13 @@ interface StackFrame {
   column_number?: number;
 }
 
-// This evaluates to a large whole number such that any fractional number
-// between 0 and 1 multiplied by it will always give a whole number.
-const SPAN_ID_MAX = (1 << 30) * (1 << 30);
+// Span IDs in the X-Cloud-Trace-Context header are 64-bit unsigned integers
+// This is the largest JavaScript number that is less than the max unsigned
+// 64-bit int, that is less than 2^64-1.
+const SPAN_ID_MAX = 18446744073709550000;
 
 function randomSpanId() {
+  // No rounding is needed because SPAN_ID_MAX is bigger than 1 / Number.EPSILON
   return String(Math.random() * SPAN_ID_MAX);
 }
 

--- a/src/span-data.ts
+++ b/src/span-data.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import * as crypto from 'crypto';
 import * as util from 'util';
 
 import {Constants} from './constants';
@@ -43,21 +42,12 @@ interface StackFrame {
   column_number?: number;
 }
 
-// Use 6 bytes of randomness only as JS numbers are doubles not 64-bit ints.
-const SPAN_ID_RANDOM_BYTES = 6;
-
-// Use the faster crypto.randomFillSync when available (Node 7+) falling back to
-// using crypto.randomBytes.
-const spanIdBuffer = Buffer.alloc(SPAN_ID_RANDOM_BYTES);
-const randomFillSync = crypto.randomFillSync;
-const randomBytes = crypto.randomBytes;
-const spanRandomBuffer = randomFillSync ?
-    () => randomFillSync(spanIdBuffer) :
-    () => randomBytes(SPAN_ID_RANDOM_BYTES);
+// This evaluates to a large whole number such that any fractional number
+// between 0 and 1 multiplied by it will always give a whole number.
+const SPAN_ID_MAX = (1 << 30) * (1 << 30);
 
 function randomSpanId() {
-  // tslint:disable-next-line:ban Needed to parse hexadecimal.
-  return parseInt(spanRandomBuffer().toString('hex'), 16).toString();
+  return String(Math.random() * SPAN_ID_MAX);
 }
 
 export class SpanData implements SpanDataInterface {

--- a/src/span-data.ts
+++ b/src/span-data.ts
@@ -44,21 +44,21 @@ interface StackFrame {
 }
 
 // Use 6 bytes of randomness only as JS numbers are doubles not 64-bit ints.
-const spanIdBuffer = Buffer.alloc(6);
-function randomSpanIdWithRandomFillSync() {
-  // tslint:disable-next-line:ban Needed to parse hexadecimal.
-  return parseInt(crypto.randomFillSync(spanIdBuffer).toString('hex'), 16)
-      .toString();
-}
+const SPAN_ID_RANDOM_BYTES = 6;
 
-function randomSpanIdWithRandomBytes() {
-  // tslint:disable-next-line:ban Needed to parse hexadecimal.
-  return parseInt(crypto.randomBytes(6).toString('hex'), 16).toString();
-}
+// Use the faster crypto.randomFillSync when available (Node 7+) falling back to
+// using crypto.randomBytes.
+const spanIdBuffer = Buffer.alloc(SPAN_ID_RANDOM_BYTES);
+const randomFillSync = crypto.randomFillSync;
+const randomBytes = crypto.randomBytes;
+const spanRandomBuffer = randomFillSync ?
+    () => randomFillSync(spanIdBuffer) :
+    () => randomBytes(SPAN_ID_RANDOM_BYTES);
 
-// randomFillSync is faster than randomBytes but was introduced in Node 7.
-const randomSpanId = crypto.randomFillSync ? randomSpanIdWithRandomFillSync :
-                                             randomSpanIdWithRandomBytes;
+function randomSpanId() {
+  // tslint:disable-next-line:ban Needed to parse hexadecimal.
+  return parseInt(spanRandomBuffer().toString('hex'), 16).toString();
+}
 
 export class SpanData implements SpanDataInterface {
   readonly span: TraceSpan;

--- a/src/span-data.ts
+++ b/src/span-data.ts
@@ -45,6 +45,7 @@ interface StackFrame {
 
 function randomSpanId() {
   // Use 6 bytes of randomness only as JS numbers are doubles not 64-bit ints.
+  // tslint:disable-next-line:ban Needed to parse hexadecimal.
   return parseInt(randomBytes(6).toString('hex'), 16).toString();
 }
 

--- a/src/span-data.ts
+++ b/src/span-data.ts
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import * as util from 'util';
 import * as crypto from 'crypto';
+import * as util from 'util';
 
 import {Constants} from './constants';
 import {SpanData as SpanDataInterface} from './plugin-types';

--- a/src/span-data.ts
+++ b/src/span-data.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {randomFillSync} from 'crypto';
+import * as crypto from 'crypto';
 import * as util from 'util';
 
 import {Constants} from './constants';
@@ -43,12 +43,22 @@ interface StackFrame {
   column_number?: number;
 }
 
+// Use 6 bytes of randomness only as JS numbers are doubles not 64-bit ints.
 const spanIdBuffer = Buffer.alloc(6);
-function randomSpanId() {
-  // Use 6 bytes of randomness only as JS numbers are doubles not 64-bit ints.
+function randomSpanIdWithRandomFillSync() {
   // tslint:disable-next-line:ban Needed to parse hexadecimal.
-  return parseInt(randomFillSync(spanIdBuffer).toString('hex'), 16).toString();
+  return parseInt(crypto.randomFillSync(spanIdBuffer).toString('hex'), 16)
+      .toString();
 }
+
+function randomSpanIdWithRandomBytes() {
+  // tslint:disable-next-line:ban Needed to parse hexadecimal.
+  return parseInt(crypto.randomBytes(6).toString('hex'), 16).toString();
+}
+
+// randomFillSync is faster than randomBytes but was introduced in Node 7.
+const randomSpanId = crypto.randomFillSync ? randomSpanIdWithRandomFillSync :
+                                             randomSpanIdWithRandomBytes;
 
 export class SpanData implements SpanDataInterface {
   readonly span: TraceSpan;

--- a/src/span-data.ts
+++ b/src/span-data.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import {randomBytes} from 'crypto';
 import * as util from 'util';
 
 import {Constants} from './constants';
@@ -42,8 +43,10 @@ interface StackFrame {
   column_number?: number;
 }
 
-// Auto-incrementing integer
-let uid = 1;
+function randomSpanId() {
+  // Use 6 bytes of randomness only as JS numbers are doubles not 64-bit ints.
+  return parseInt(randomBytes(6).toString('hex'), 16).toString();
+}
 
 export class SpanData implements SpanDataInterface {
   readonly span: TraceSpan;
@@ -60,10 +63,9 @@ export class SpanData implements SpanDataInterface {
   constructor(
       readonly trace: Trace, spanName: string, parentSpanId: string,
       private readonly isRoot: boolean, skipFrames: number) {
-    const spanId = '' + (uid++);
     spanName =
         traceUtil.truncate(spanName, Constants.TRACE_SERVICE_SPAN_NAME_LIMIT);
-    this.span = new TraceSpan(spanName, spanId, parentSpanId);
+    this.span = new TraceSpan(spanName, randomSpanId(), parentSpanId);
     trace.spans.push(this.span);
     if (traceWriter.get().getConfig().stackTraceLimit > 0) {
       // This is a mechanism to get the structured stack trace out of V8.

--- a/src/span-data.ts
+++ b/src/span-data.ts
@@ -55,6 +55,11 @@ const spanRandomBuffer = randomFillSync ?
     () => randomFillSync(spanIdBuffer) :
     () => randomBytes(SPAN_ID_RANDOM_BYTES);
 
+function randomSpanId() {
+  // tslint:disable-next-line:ban Needed to parse hexadecimal.
+  return parseInt(spanRandomBuffer().toString('hex'), 16).toString();
+}
+
 export class SpanData implements SpanDataInterface {
   readonly span: TraceSpan;
 

--- a/src/span-data.ts
+++ b/src/span-data.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {randomBytes} from 'crypto';
+import {randomFillSync} from 'crypto';
 import * as util from 'util';
 
 import {Constants} from './constants';
@@ -43,10 +43,11 @@ interface StackFrame {
   column_number?: number;
 }
 
+const spanIdBuffer = Buffer.alloc(6);
 function randomSpanId() {
   // Use 6 bytes of randomness only as JS numbers are doubles not 64-bit ints.
   // tslint:disable-next-line:ban Needed to parse hexadecimal.
-  return parseInt(randomBytes(6).toString('hex'), 16).toString();
+  return parseInt(randomFillSync(spanIdBuffer).toString('hex'), 16).toString();
 }
 
 export class SpanData implements SpanDataInterface {

--- a/test/test-span-data.ts
+++ b/test/test-span-data.ts
@@ -71,7 +71,7 @@ describe('SpanData', function() {
         assert.ok(typeof spanId === 'string');
         assert.ok(spanId.match(/\d+/));
         assert.ok(Number(spanId) > 0);
-        assert.equal(Number(spanId).toString(), spanId);
+        assert.strictEqual(Number(spanId).toString(), spanId);
       }
     });
   });

--- a/test/test-span-data.ts
+++ b/test/test-span-data.ts
@@ -58,14 +58,14 @@ describe('SpanData', function() {
 
   it('generates unique numeric span ID strings', function() {
     cls.getNamespace().run(function() {
-      const spans = [];
-      const spanIds = new Set<string>();
-      const rootSpanData = createRootSpanData('hi');
-      const numSpanIdsToCheck = 5;
-      for (let i = 0; i < numSpanIdsToCheck; i++) {
-        const spanData = new SpanData(
+      var spans = [];
+      var spanIds = new Set<string>();
+      var rootSpanData = createRootSpanData('hi');
+      var numSpanIdsToCheck = 5;
+      for (var i = 0; i < numSpanIdsToCheck; i++) {
+        var spanData = new SpanData(
             rootSpanData.trace, 'child', rootSpanData.span.spanId, false, 0);
-        const spanId = spanData.span.spanId;
+        var spanId = spanData.span.spanId;
         spanIds.add(spanId);
         // Check that the span IDs are numeric positive number strings
         assert.ok(typeof spanId === 'string');

--- a/test/test-span-data.ts
+++ b/test/test-span-data.ts
@@ -56,6 +56,26 @@ describe('SpanData', function() {
     });
   });
 
+  it('generates unique numeric span ID strings', function() {
+    cls.getNamespace().run(function() {
+      const spans = [];
+      const spanIds = new Set<string>();
+      const rootSpanData = createRootSpanData('hi');
+      const numSpanIdsToCheck = 5;
+      for (let i = 0; i < numSpanIdsToCheck; i++) {
+        const spanData = new SpanData(
+            rootSpanData.trace, 'child', rootSpanData.span.spanId, false, 0);
+        const spanId = spanData.span.spanId;
+        spanIds.add(spanId);
+        // Check that the span IDs are numeric positive number strings
+        assert.ok(typeof spanId === 'string');
+        assert.ok(spanId.match(/\d+/));
+        assert.ok(Number(spanId) > 0);
+        assert.equal(Number(spanId).toString(), spanId);
+      }
+    });
+  });
+
   it('converts label values to strings', function() {
     cls.getNamespace().run(function() {
       var spanData = createRootSpanData('name', 1, 2);

--- a/test/test-trace-header-context.ts
+++ b/test/test-trace-header-context.ts
@@ -113,8 +113,10 @@ describe('test-trace-header-context', function() {
       const receivedTraceContext =
           req.headers[Constants.TRACE_CONTEXT_HEADER_NAME];
       const receivedTraceId = receivedTraceContext.split('/')[0];
-      const [receivedSpanId, receivedTraceOptions] =
+      const receivedSpanIdAndOptions =
           receivedTraceContext.split('/')[1].split(';');
+      const receivedSpanId = receivedSpanIdAndOptions[0];
+      const receivedTraceOptions = receivedSpanIdAndOptions[1];
       // Trace ID and trace options should be the same in sender and receiver.
       assert.equal(receivedTraceId, sentTraceId);
       assert.equal(receivedTraceOptions, sentTraceOptions);

--- a/test/test-trace-header-context.ts
+++ b/test/test-trace-header-context.ts
@@ -118,19 +118,19 @@ describe('test-trace-header-context', function() {
       var receivedSpanId = receivedSpanIdAndOptions[0];
       var receivedTraceOptions = receivedSpanIdAndOptions[1];
       // Trace ID and trace options should be the same in sender and receiver.
-      assert.equal(receivedTraceId, sentTraceId);
-      assert.equal(receivedTraceOptions, sentTraceOptions);
+      assert.strictEqual(receivedTraceId, sentTraceId);
+      assert.strictEqual(receivedTraceOptions, sentTraceOptions);
       // Span ID should be different as receiver generates a new span ID.
-      assert.notEqual(receivedSpanId, sentSpanId);
+      assert.notStrictEqual(receivedSpanId, sentSpanId);
 
       res.send(common.serverRes);
       var traces = common.getTraces();
-      assert.equal(traces.length, 2);
-      assert.equal(traces[0].spans.length, 2);
-      assert.equal(traces[1].spans.length, 1);
-      assert.equal(traces[0].spans[0].name, '/');
-      assert.equal(traces[0].spans[1].name, 'localhost');
-      assert.equal(traces[1].spans[0].name, '/self');
+      assert.strictEqual(traces.length, 2);
+      assert.strictEqual(traces[0].spans.length, 2);
+      assert.strictEqual(traces[1].spans.length, 1);
+      assert.strictEqual(traces[0].spans[0].name, '/');
+      assert.strictEqual(traces[0].spans[1].name, 'localhost');
+      assert.strictEqual(traces[1].spans[0].name, '/self');
       common.cleanTraces();
       server.close();
       done();

--- a/test/test-trace-header-context.ts
+++ b/test/test-trace-header-context.ts
@@ -99,24 +99,24 @@ describe('test-trace-header-context', function() {
   });
 
   it('should parse incoming header', function(done) {
-    const app = express();
-    let server;
-    const sentTraceId = '0000000000000000000000000000000a';
-    const sentSpanId = '2';
-    const sentTraceOptions = 'o=1';
-    const sentTraceContext = `${sentTraceId}/${sentSpanId};${sentTraceOptions}`;
+    var app = express();
+    var server;
+    var sentTraceId = '0000000000000000000000000000000a';
+    var sentSpanId = '2';
+    var sentTraceOptions = 'o=1';
+    var sentTraceContext = `${sentTraceId}/${sentSpanId};${sentTraceOptions}`;
     app.get('/', function(req, res) {
       http.get({port: common.serverPort, path: '/self'});
       res.send(common.serverRes);
     });
     app.get('/self', function(req, res) {
-      const receivedTraceContext =
+      var receivedTraceContext =
           req.headers[Constants.TRACE_CONTEXT_HEADER_NAME];
-      const receivedTraceId = receivedTraceContext.split('/')[0];
-      const receivedSpanIdAndOptions =
+      var receivedTraceId = receivedTraceContext.split('/')[0];
+      var receivedSpanIdAndOptions =
           receivedTraceContext.split('/')[1].split(';');
-      const receivedSpanId = receivedSpanIdAndOptions[0];
-      const receivedTraceOptions = receivedSpanIdAndOptions[1];
+      var receivedSpanId = receivedSpanIdAndOptions[0];
+      var receivedTraceOptions = receivedSpanIdAndOptions[1];
       // Trace ID and trace options should be the same in sender and receiver.
       assert.equal(receivedTraceId, sentTraceId);
       assert.equal(receivedTraceOptions, sentTraceOptions);
@@ -136,7 +136,7 @@ describe('test-trace-header-context', function() {
       done();
     });
     server = app.listen(common.serverPort, function() {
-      const headers = {};
+      var headers = {};
       headers[Constants.TRACE_CONTEXT_HEADER_NAME] = sentTraceContext;
       http.get({port: common.serverPort, headers: headers});
     });


### PR DESCRIPTION
While running a test application that was composed of multiple Node.js apps, each with tracing enabled, we found that span IDs would conflict when the multiple apps were simultaneously started, because each started their span IDs at index 1. This switches to use secure randomness for span IDs to help ensure uniqueness even when multiple Node apps are started at the same time.