### PR TITLE
feat: expand grpc supported versions to <2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
     "@google-cloud/common": {
       "version": "0.15.1",
       "resolved": "https://registry.npmjs.org/@google-cloud/common/-/common-0.15.1.tgz",
-      "integrity": "sha1-pveVNd5ibMDgWwzNqdsMNgmeR6M=",
+      "integrity": "sha512-cnVtHLvyiSQvb1RzXWDp7PA1sA8Jmc47+wp/xwHwdGOlQZfKog5iluZ0C/LB8iklFXpcTwlNMorqLuZ/qH0DDA==",
       "requires": {
         "array-uniq": "1.0.3",
         "arrify": "1.0.1",
@@ -293,13 +293,13 @@
       "integrity": "sha1-oz4N+dzptCTRyY/E/evYV43O7H4=",
       "dev": true,
       "requires": {
-        "@types/node": "9.3.0"
+        "@types/node": "9.4.6"
       }
     },
     "@types/extend": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@types/extend/-/extend-3.0.0.tgz",
-      "integrity": "sha1-0mnlrxRjzWNEJyq9gUyKgzuRTQc=",
+      "integrity": "sha512-Eo8NQCbgjlMPQarlFAE3vpyCvFda4dg1Ob5ZJb6BJI9x4NAZVWowyMNB8GJJDgDI4lr2oqiQvXlPB0Fn1NoXnQ==",
       "dev": true
     },
     "@types/form-data": {
@@ -308,7 +308,7 @@
       "integrity": "sha512-JAMFhOaHIciYVh8fb5/83nmuO/AHwmto+Hq7a9y8FzLDcC1KCU344XDOMEmahnrTFlHjgh4L0WJFczNIX2GxnQ==",
       "dev": true,
       "requires": {
-        "@types/node": "9.3.0"
+        "@types/node": "9.4.6"
       }
     },
     "@types/glob": {
@@ -318,7 +318,7 @@
       "dev": true,
       "requires": {
         "@types/minimatch": "3.0.1",
-        "@types/node": "9.3.0"
+        "@types/node": "9.4.6"
       }
     },
     "@types/is": {
@@ -354,34 +354,34 @@
     "@types/ncp": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@types/ncp/-/ncp-2.0.1.tgz",
-      "integrity": "sha1-dJQyUR9q10fQTpiDexjMqQRVZ/s=",
+      "integrity": "sha512-TeiJ7uvv/92ugSqZ0v9l0eNXzutlki0aK+R1K5bfA5SYUil46ITlxLW4iNTCf55P4L5weCmaOdtxGeGWvudwPg==",
       "dev": true,
       "requires": {
-        "@types/node": "9.3.0"
+        "@types/node": "9.4.6"
       }
     },
     "@types/node": {
-      "version": "9.3.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-9.3.0.tgz",
-      "integrity": "sha512-wNBfvNjzsJl4tswIZKXCFQY0lss9nKUyJnG6T94X/eqjRgI2jHZ4evdjhQYBSan/vGtF6XVXPApOmNH2rf0KKw==",
+      "version": "9.4.6",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-9.4.6.tgz",
+      "integrity": "sha512-CTUtLb6WqCCgp6P59QintjHWqzf4VL1uPA27bipLAPxFqrtK1gEYllePzTICGqQ8rYsCbpnsNypXjjDzGAAjEQ==",
       "dev": true
     },
     "@types/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/@types/once/-/once-1.4.0.tgz",
-      "integrity": "sha1-e/49maCVHzFBusJhfJgnUleIuPU=",
+      "integrity": "sha512-cnEvTAVVRqF6OQg/4SLnbxQ0slZJHqZQDve5BzGhcIQtuMpPv8T5QNS2cBPa/W0jTxciqwn7bmJAIGe/bOJ5Kw==",
       "dev": true
     },
     "@types/pify": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@types/pify/-/pify-3.0.0.tgz",
-      "integrity": "sha1-4X2Vwn500jBevAaw+NKMsC+WEv4=",
+      "integrity": "sha512-BIRcpFqRm64rVuuYCFzOF37I2IEP3sXhiCjy8NbzJkxqFY2CLiDLFPhh6Sph/eXPXctg05MayCEDmeKCOIUBFg==",
       "dev": true
     },
     "@types/proxyquire": {
       "version": "1.3.28",
       "resolved": "https://registry.npmjs.org/@types/proxyquire/-/proxyquire-1.3.28.tgz",
-      "integrity": "sha1-BaZHuw2P5I/I7cwZPkPMeTEPqn0=",
+      "integrity": "sha512-SQaNzWQ2YZSr7FqAyPPiA3FYpux2Lqh3HWMZQk47x3xbMCqgC/w0dY3dw9rGqlweDDkrySQBcaScXWeR+Yb11Q==",
       "dev": true
     },
     "@types/request": {
@@ -391,7 +391,7 @@
       "dev": true,
       "requires": {
         "@types/form-data": "2.2.1",
-        "@types/node": "9.3.0"
+        "@types/node": "9.4.6"
       }
     },
     "@types/semver": {
@@ -427,10 +427,10 @@
     "@types/uuid": {
       "version": "3.4.3",
       "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-3.4.3.tgz",
-      "integrity": "sha1-EhrOJl9Vac5A9PbQ/3ijOMcyp1Q=",
+      "integrity": "sha512-5fRLCYhLtDb3hMWqQyH10qtF+Ud2JnNCXTCZ+9ktNdCcgslcuXkDTkFcJNk++MT29yDntDnlF1+jD+uVGumsbw==",
       "dev": true,
       "requires": {
-        "@types/node": "9.3.0"
+        "@types/node": "9.4.6"
       }
     },
     "JSONStream": {
@@ -442,12 +442,6 @@
         "jsonparse": "1.3.1",
         "through": "2.3.8"
       }
-    },
-    "abbrev": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz",
-      "integrity": "sha1-kbR5JYinc4wl813W9jdSovh3YTU=",
-      "dev": true
     },
     "accepts": {
       "version": "1.3.4",
@@ -563,15 +557,6 @@
       "integrity": "sha1-GTxfCoZUGkxm+6Hi3DhYM2LqXo8=",
       "dev": true
     },
-    "argparse": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
-      "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
-      "dev": true,
-      "requires": {
-        "sprintf-js": "1.0.3"
-      }
-    },
     "arguejs": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/arguejs/-/arguejs-0.2.3.tgz",
@@ -678,16 +663,6 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
       "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4="
-    },
-    "axios": {
-      "version": "0.17.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.17.1.tgz",
-      "integrity": "sha1-LY4+XQvb1zJ/kbyBT1xXZg+Bgk0=",
-      "dev": true,
-      "requires": {
-        "follow-redirects": "1.3.0",
-        "is-buffer": "1.1.5"
-      }
     },
     "babel-code-frame": {
       "version": "6.26.0",
@@ -863,12 +838,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
       "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
-      "dev": true
-    },
-    "builtins": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/builtins/-/builtins-1.0.3.tgz",
-      "integrity": "sha1-y5T662HIaWRR2zZTThQi+U8K7og=",
       "dev": true
     },
     "bytebuffer": {
@@ -1347,7 +1316,7 @@
     "continuation-local-storage": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/continuation-local-storage/-/continuation-local-storage-3.2.1.tgz",
-      "integrity": "sha1-EfYT906RT+mzTJKtLSj+auHbf/s=",
+      "integrity": "sha512-jx44cconVqkCEEyLSKWwkvUXwO561jXMa3LPjTPsm5QR22PA0/mhe33FT4Xb5y74JDvt/Cq+5lm8S8rskLv9ZA==",
       "requires": {
         "async-listener": "0.6.8",
         "emitter-listener": "1.1.1"
@@ -1688,12 +1657,6 @@
       "integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8=",
       "dev": true
     },
-    "deep-is": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
-      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
-      "dev": true
-    },
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
@@ -1905,31 +1868,6 @@
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
       "dev": true
     },
-    "escodegen": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.8.1.tgz",
-      "integrity": "sha1-WltTr0aTEQvrsIZ6o0MN07cKEBg=",
-      "dev": true,
-      "requires": {
-        "esprima": "2.7.3",
-        "estraverse": "1.9.3",
-        "esutils": "2.0.2",
-        "optionator": "0.8.2",
-        "source-map": "0.2.0"
-      }
-    },
-    "esprima": {
-      "version": "2.7.3",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
-      "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE=",
-      "dev": true
-    },
-    "estraverse": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz",
-      "integrity": "sha1-r2fy3JIlgkFZUJJgkaQAXSnJu0Q=",
-      "dev": true
-    },
     "esutils": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
@@ -2032,12 +1970,6 @@
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
       "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
     },
-    "fast-levenshtein": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
-      "dev": true
-    },
     "figures": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
@@ -2080,26 +2012,6 @@
       "requires": {
         "path-exists": "2.1.0",
         "pinkie-promise": "2.0.1"
-      }
-    },
-    "follow-redirects": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.3.0.tgz",
-      "integrity": "sha1-9oSHH8EW0uMp/aVe9naH9Pq8kFw=",
-      "dev": true,
-      "requires": {
-        "debug": "3.1.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        }
       }
     },
     "forever-agent": {
@@ -2349,7 +2261,7 @@
     "glob": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-      "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
+      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
       "dev": true,
       "requires": {
         "fs.realpath": "1.0.0",
@@ -2540,7 +2452,7 @@
     "got": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/got/-/got-7.1.0.tgz",
-      "integrity": "sha1-BUUP2ECU5rvqVvRRpDqcKJFmOFo=",
+      "integrity": "sha512-Y5WMo7xKKq1muPsxD+KmrR8DH5auG7fBdDVueZwETwV6VytKyU9OX/ddpq2/1hp1vIPvVb4T81dKQz3BivkNLw==",
       "dev": true,
       "requires": {
         "decompress-response": "3.3.0",
@@ -4092,70 +4004,6 @@
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
       "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
     },
-    "istanbul": {
-      "version": "0.4.5",
-      "resolved": "https://registry.npmjs.org/istanbul/-/istanbul-0.4.5.tgz",
-      "integrity": "sha1-ZcfXPUxNqE1POsMQuRj7C4Azczs=",
-      "dev": true,
-      "requires": {
-        "abbrev": "1.0.9",
-        "async": "1.5.2",
-        "escodegen": "1.8.1",
-        "esprima": "2.7.3",
-        "glob": "5.0.15",
-        "handlebars": "4.0.10",
-        "js-yaml": "3.10.0",
-        "mkdirp": "0.5.1",
-        "nopt": "3.0.6",
-        "once": "1.4.0",
-        "resolve": "1.1.7",
-        "supports-color": "3.2.3",
-        "which": "1.3.0",
-        "wordwrap": "1.0.0"
-      },
-      "dependencies": {
-        "async": {
-          "version": "1.5.2",
-          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
-          "dev": true
-        },
-        "glob": {
-          "version": "5.0.15",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
-          "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
-          "dev": true,
-          "requires": {
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
-          }
-        },
-        "has-flag": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-          "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
-          "dev": true
-        },
-        "resolve": {
-          "version": "1.1.7",
-          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
-          "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
-          "dev": true
-        },
-        "supports-color": {
-          "version": "3.2.3",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-          "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-          "dev": true,
-          "requires": {
-            "has-flag": "1.0.0"
-          }
-        }
-      }
-    },
     "isurl": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isurl/-/isurl-1.0.0.tgz",
@@ -4166,73 +4014,11 @@
         "is-object": "1.0.1"
       }
     },
-    "js-green-licenses": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/js-green-licenses/-/js-green-licenses-0.3.1.tgz",
-      "integrity": "sha512-pFWoi11NZuQPt0emRrQKVi+DVjLUYSE+v/cbMzWIrce+2CvkQ5PQUHwJwXua835Q4RpJMe2BxR66VU7BC1Tusg==",
-      "dev": true,
-      "requires": {
-        "argparse": "1.0.9",
-        "axios": "0.17.1",
-        "npm-package-arg": "6.0.0",
-        "package-json": "4.0.1",
-        "pify": "3.0.0",
-        "spdx-correct": "2.0.4",
-        "spdx-satisfies": "0.1.3",
-        "strip-json-comments": "2.0.1"
-      },
-      "dependencies": {
-        "spdx-correct": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-2.0.4.tgz",
-          "integrity": "sha512-c+4gPpt9YDhz7cHlz5UrsHzxxRi4ksclxnEEKsuGT9JdwSC+ZNmsGbYRzzgxyZaBYpcWnlu+4lPcdLKx4DOCmA==",
-          "dev": true,
-          "requires": {
-            "spdx-expression-parse": "2.0.2",
-            "spdx-license-ids": "2.0.1"
-          }
-        },
-        "spdx-expression-parse": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-2.0.2.tgz",
-          "integrity": "sha512-oFxOkWCfFS0ltNp0H66gXlU4NF6bxg7RkoTYR0413t+yTY9zyj+AIWsjtN8dcVp6703ijDYBWBIARlJ7DkyP9Q==",
-          "dev": true,
-          "requires": {
-            "spdx-exceptions": "2.1.0",
-            "spdx-license-ids": "2.0.1"
-          }
-        },
-        "spdx-license-ids": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-2.0.1.tgz",
-          "integrity": "sha1-AgF7zDU07k/+9tWNIOfT6aHDyOw=",
-          "dev": true
-        }
-      }
-    },
     "js-tokens": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
       "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
       "dev": true
-    },
-    "js-yaml": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.10.0.tgz",
-      "integrity": "sha512-O2v52ffjLa9VeM43J4XocZE//WT9N0IiwDa3KSHH7Tu8CtH+1qM8SIZvnsTh6v+4yFy5KUY3BHUVwjpfAWsjIA==",
-      "dev": true,
-      "requires": {
-        "argparse": "1.0.9",
-        "esprima": "4.0.0"
-      },
-      "dependencies": {
-        "esprima": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
-          "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw==",
-          "dev": true
-        }
-      }
     },
     "jsbn": {
       "version": "0.1.1",
@@ -4453,16 +4239,6 @@
       "dev": true,
       "requires": {
         "invert-kv": "1.0.0"
-      }
-    },
-    "levn": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
-      "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
-      "dev": true,
-      "requires": {
-        "prelude-ls": "1.1.2",
-        "type-check": "0.3.2"
       }
     },
     "list-stream": {
@@ -4892,15 +4668,6 @@
       "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.7.1.tgz",
       "integrity": "sha1-naYR6giYL0uUIGs760zJZl8gwwA="
     },
-    "nopt": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
-      "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
-      "dev": true,
-      "requires": {
-        "abbrev": "1.0.9"
-      }
-    },
     "normalize-package-data": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
@@ -4911,18 +4678,6 @@
         "is-builtin-module": "1.0.0",
         "semver": "5.4.1",
         "validate-npm-package-license": "3.0.1"
-      }
-    },
-    "npm-package-arg": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-6.0.0.tgz",
-      "integrity": "sha512-hwC7g81KLgRmchv9ol6f3Fx4Yyc9ARX5X5niDHVILgpuvf08JRIgOZcEfpFXli3BgESoTrkauqorXm6UbvSgSg==",
-      "dev": true,
-      "requires": {
-        "hosted-git-info": "2.5.0",
-        "osenv": "0.1.4",
-        "semver": "5.4.1",
-        "validate-npm-package-name": "3.0.0"
       }
     },
     "npm-run-path": {
@@ -6601,30 +6356,10 @@
         }
       }
     },
-    "optionator": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
-      "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
-      "dev": true,
-      "requires": {
-        "deep-is": "0.1.3",
-        "fast-levenshtein": "2.0.6",
-        "levn": "0.3.0",
-        "prelude-ls": "1.1.2",
-        "type-check": "0.3.2",
-        "wordwrap": "1.0.0"
-      }
-    },
     "optjs": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/optjs/-/optjs-3.2.2.tgz",
       "integrity": "sha1-aabOicRCpEQDFBrS+bNwvVu29O4=",
-      "dev": true
-    },
-    "os-homedir": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
       "dev": true
     },
     "os-locale": {
@@ -6641,16 +6376,6 @@
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
       "dev": true
-    },
-    "osenv": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz",
-      "integrity": "sha1-Qv5tWVPfBsgGS+bxdsPQWqqjRkQ=",
-      "dev": true,
-      "requires": {
-        "os-homedir": "1.0.2",
-        "os-tmpdir": "1.0.2"
-      }
     },
     "p-cancelable": {
       "version": "0.3.0",
@@ -6836,12 +6561,6 @@
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/pkg-to-id/-/pkg-to-id-0.0.3.tgz",
       "integrity": "sha1-NP8zbP9TwnqL9IS8fj0x6mwczKg=",
-      "dev": true
-    },
-    "prelude-ls": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
       "dev": true
     },
     "prepend-http": {
@@ -7057,7 +6776,7 @@
     "request": {
       "version": "2.83.0",
       "resolved": "https://registry.npmjs.org/request/-/request-2.83.0.tgz",
-      "integrity": "sha1-ygtl2gLtYpNYh4COb1EDgQNOM1Y=",
+      "integrity": "sha512-lR3gD69osqm6EYLk9wB/G1W/laGWjzH90t1vEa2xuxHD5KUrSzp9pUSfTm+YC5Nxt2T8nMPEvKlhbQayU7bgFw==",
       "requires": {
         "aws-sign2": "0.7.0",
         "aws4": "1.6.0",
@@ -7254,7 +6973,7 @@
     "shimmer": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/shimmer/-/shimmer-1.2.0.tgz",
-      "integrity": "sha1-+Wb3VVeJdj502IQRk2haXnhzZmU="
+      "integrity": "sha512-xTCx2vohXC2EWWDqY/zb4+5Mu28D+HYNSOuFzsyRDRvI/e1ICb69afwaUwfjr+25ZXldbOLyp+iDUZHq8UnTag=="
     },
     "signal-exit": {
       "version": "3.0.2",
@@ -7268,16 +6987,6 @@
       "integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
       "requires": {
         "hoek": "4.2.0"
-      }
-    },
-    "source-map": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz",
-      "integrity": "sha1-2rc/vPwrqBm03gO9b26qSBZLP50=",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "amdefine": "1.0.1"
       }
     },
     "source-map-support": {
@@ -7297,16 +7006,6 @@
         }
       }
     },
-    "spdx-compare": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/spdx-compare/-/spdx-compare-0.1.2.tgz",
-      "integrity": "sha1-sGrz6jSvdDfZGp9Enq8tLpPDyPs=",
-      "dev": true,
-      "requires": {
-        "spdx-expression-parse": "1.0.4",
-        "spdx-ranges": "1.0.1"
-      }
-    },
     "spdx-correct": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
@@ -7315,12 +7014,6 @@
       "requires": {
         "spdx-license-ids": "1.2.2"
       }
-    },
-    "spdx-exceptions": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.1.0.tgz",
-      "integrity": "sha512-4K1NsmrlCU1JJgUrtgEeTVyfx8VaYea9J9LvARxhbHtVtohPs/gFGG5yy49beySjlIMhhXZ4QqujIZEfS4l6Cg==",
-      "dev": true
     },
     "spdx-expression-parse": {
       "version": "1.0.4",
@@ -7333,22 +7026,6 @@
       "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
       "integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc=",
       "dev": true
-    },
-    "spdx-ranges": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/spdx-ranges/-/spdx-ranges-1.0.1.tgz",
-      "integrity": "sha1-D07se46kjtIC43S7iULo0Y3AET4=",
-      "dev": true
-    },
-    "spdx-satisfies": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/spdx-satisfies/-/spdx-satisfies-0.1.3.tgz",
-      "integrity": "sha1-Z6HydOYRXUquKK/kdNt2FkvhC9w=",
-      "dev": true,
-      "requires": {
-        "spdx-compare": "0.1.2",
-        "spdx-expression-parse": "1.0.4"
-      }
     },
     "split": {
       "version": "1.0.1",
@@ -7376,12 +7053,6 @@
       "requires": {
         "through2": "2.0.3"
       }
-    },
-    "sprintf-js": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
-      "dev": true
     },
     "sshpk": {
       "version": "1.13.1",
@@ -7694,13 +7365,13 @@
     "timekeeper": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/timekeeper/-/timekeeper-2.0.0.tgz",
-      "integrity": "sha1-6veg3P3JXUZYucw9IRByBsxOLu0=",
+      "integrity": "sha512-DVH+iEKcVwU3JkZK0Z86qFx8osIG05U1H/F6lAE+iPfvElioM9HPVd2ZKmoI4zS0AWsDogOXl/BuKWXNadI/fw==",
       "dev": true
     },
     "tmp": {
       "version": "0.0.33",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-      "integrity": "sha1-bTQzWIl2jSGyvNoKonfO07G/rfk=",
+      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
       "dev": true,
       "requires": {
         "os-tmpdir": "1.0.2"
@@ -7871,15 +7542,6 @@
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
       "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
       "optional": true
-    },
-    "type-check": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
-      "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
-      "dev": true,
-      "requires": {
-        "prelude-ls": "1.1.2"
-      }
     },
     "type-detect": {
       "version": "1.0.0",
@@ -8107,15 +7769,6 @@
         "spdx-expression-parse": "1.0.4"
       }
     },
-    "validate-npm-package-name": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-3.0.0.tgz",
-      "integrity": "sha1-X6kS2B630MdK/BQN5zF/DKffQ34=",
-      "dev": true,
-      "requires": {
-        "builtins": "1.0.3"
-      }
-    },
     "vary": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
@@ -8160,12 +7813,6 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.4.tgz",
       "integrity": "sha1-+OGqHuWlPsW/FR/6CXQqatdpeHY=",
-      "dev": true
-    },
-    "wordwrap": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-      "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
       "dev": true
     },
     "wrap-ansi": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -287,12 +287,104 @@
       "integrity": "sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA=",
       "dev": true
     },
+    "@types/accepts": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/@types/accepts/-/accepts-1.3.5.tgz",
+      "integrity": "sha512-jOdnI/3qTpHABjM5cx1Hc0sKsPoYCp+DP/GJRGtDlPd7fiV9oXGGIcjW/ZOxLIvjGz8MA+uMZI9metHlgqbgwQ==",
+      "dev": true,
+      "requires": {
+        "@types/node": "9.4.6"
+      }
+    },
+    "@types/body-parser": {
+      "version": "1.16.8",
+      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.16.8.tgz",
+      "integrity": "sha512-BdN2PXxOFnTXFcyONPW6t0fHjz2fvRZHVMFpaS0wYr+Y8fWEaNOs4V8LEu/fpzQlMx+ahdndgTaGTwPC+J/EeA==",
+      "dev": true,
+      "requires": {
+        "@types/express": "4.11.1",
+        "@types/node": "9.4.6"
+      }
+    },
+    "@types/boom": {
+      "version": "4.3.9",
+      "resolved": "https://registry.npmjs.org/@types/boom/-/boom-4.3.9.tgz",
+      "integrity": "sha512-hOMq8gOURXfWAoPCGkAcQVRV1JitzZylAGvNJeu5wkSWIErWK22ZPGaHlScF+OQZqBKVpEunJA3pzBl0qaM9PQ==",
+      "dev": true
+    },
+    "@types/bunyan": {
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/@types/bunyan/-/bunyan-1.8.4.tgz",
+      "integrity": "sha512-bxOF3fsm69ezKxdcJ7Oo/PsZMOJ+JIV/QJO2IADfScmR3sLulR88dpSnz6+q+9JJ1kD7dXFFgUrGRSKHLkOX7w==",
+      "dev": true,
+      "requires": {
+        "@types/events": "1.1.0",
+        "@types/node": "9.4.6"
+      }
+    },
+    "@types/catbox": {
+      "version": "7.1.5",
+      "resolved": "https://registry.npmjs.org/@types/catbox/-/catbox-7.1.5.tgz",
+      "integrity": "sha512-eNeqRgx2k3ILl/gIPzOP3GoCXs1fXTF2Mtro346AZF5ADk/Uyz7jAXx5z5k6naVgMYDZwrbPZLKj6kWpfwzyMw==",
+      "dev": true,
+      "requires": {
+        "@types/boom": "4.3.9"
+      }
+    },
+    "@types/connect": {
+      "version": "3.4.31",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.31.tgz",
+      "integrity": "sha512-OPSxsP6XqA3984KWDUXq/u05Hu8VWa/2rUVlw/aDUOx87BptIep6xb3NdCxCpKLfLdjZcCE5jR+gouTul3gjdA==",
+      "dev": true,
+      "requires": {
+        "@types/node": "9.4.6"
+      }
+    },
     "@types/continuation-local-storage": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/@types/continuation-local-storage/-/continuation-local-storage-3.2.1.tgz",
       "integrity": "sha1-oz4N+dzptCTRyY/E/evYV43O7H4=",
       "dev": true,
       "requires": {
+        "@types/node": "9.4.6"
+      }
+    },
+    "@types/cookies": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@types/cookies/-/cookies-0.7.1.tgz",
+      "integrity": "sha512-ku6IvbucEyuC6i4zAVK/KnuzWNXdbFd1HkXlNLg/zhWDGTtQT5VhumiPruB/BHW34PWVFwyfwGftDQHfWNxu3Q==",
+      "dev": true,
+      "requires": {
+        "@types/connect": "3.4.31",
+        "@types/express": "4.11.1",
+        "@types/keygrip": "1.0.1",
+        "@types/node": "9.4.6"
+      }
+    },
+    "@types/events": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@types/events/-/events-1.1.0.tgz",
+      "integrity": "sha512-y3bR98mzYOo0pAZuiLari+cQyiKk3UXRuT45h1RjhfeCzqkjaVsfZJNaxdgtk7/3tzOm1ozLTqEqMP3VbI48jw==",
+      "dev": true
+    },
+    "@types/express": {
+      "version": "4.11.1",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.11.1.tgz",
+      "integrity": "sha512-ttWle8cnPA5rAelauSWeWJimtY2RsUf2aspYZs7xPHiWgOlPn6nnUfBMtrkcnjFJuIHJF4gNOdVvpLK2Zmvh6g==",
+      "dev": true,
+      "requires": {
+        "@types/body-parser": "1.16.8",
+        "@types/express-serve-static-core": "4.11.1",
+        "@types/serve-static": "1.13.1"
+      }
+    },
+    "@types/express-serve-static-core": {
+      "version": "4.11.1",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.11.1.tgz",
+      "integrity": "sha512-EehCl3tpuqiM8RUb+0255M8PhhSwTtLfmO7zBBdv0ay/VTd/zmrqDfQdZFsa5z/PVMbH2yCMZPXsnrImpATyIw==",
+      "dev": true,
+      "requires": {
+        "@types/events": "1.1.0",
         "@types/node": "9.4.6"
       }
     },
@@ -321,10 +413,65 @@
         "@types/node": "9.4.6"
       }
     },
+    "@types/hapi": {
+      "version": "16.1.13",
+      "resolved": "https://registry.npmjs.org/@types/hapi/-/hapi-16.1.13.tgz",
+      "integrity": "sha512-WmJvWPC3vx0kA+1eQ88xXzy8oouAt803BOQv85nYvbvjj3QP1Jj+y9fWdhYL8RDExI21ZbTWNX8qphcXf3KOqg==",
+      "dev": true,
+      "requires": {
+        "@types/boom": "4.3.9",
+        "@types/catbox": "7.1.5",
+        "@types/events": "1.1.0",
+        "@types/joi": "13.0.5",
+        "@types/mimos": "3.0.1",
+        "@types/node": "9.4.6",
+        "@types/podium": "1.0.0",
+        "@types/shot": "3.4.0"
+      }
+    },
+    "@types/http-assert": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@types/http-assert/-/http-assert-1.2.2.tgz",
+      "integrity": "sha512-x1553BFcgBVOD6y3tC/2SOVcNaf6b9eH3BvqniAZZwmHWYhyr8ffXTYygQC/hQxNI4Yfc3q0gGUvyiAHV4tRNg==",
+      "dev": true
+    },
     "@types/is": {
       "version": "0.0.18",
       "resolved": "https://registry.npmjs.org/@types/is/-/is-0.0.18.tgz",
       "integrity": "sha512-A7PSzJyDwKbkJ3kvM0gfs9daFyiCwvrSmzA5ToFW1rporicAKgrpZsZJifQQob/QvMwEbwi3zF2o/Lw8K3frxw==",
+      "dev": true
+    },
+    "@types/joi": {
+      "version": "13.0.5",
+      "resolved": "https://registry.npmjs.org/@types/joi/-/joi-13.0.5.tgz",
+      "integrity": "sha512-xhGKDKk8qEK35GFYIkpQXdS03PnL+1eXt8VOHnuvuMOjNCztmTpqiDk2vlDy3GbSctSTBJCkY0PXkaRVJpl2xA==",
+      "dev": true
+    },
+    "@types/keygrip": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@types/keygrip/-/keygrip-1.0.1.tgz",
+      "integrity": "sha1-/1QEYtL7TQqIRBzq8n0oewHD2Hg=",
+      "dev": true
+    },
+    "@types/koa": {
+      "version": "2.0.44",
+      "resolved": "https://registry.npmjs.org/@types/koa/-/koa-2.0.44.tgz",
+      "integrity": "sha512-xOg6XLJdKmYriExAF0pV+HYhzftNJbpxplJgjyCwEM2LNLQPMgW4uSHXjgsqSPKsaAgM8CiR31vIeocRibFSjw==",
+      "dev": true,
+      "requires": {
+        "@types/accepts": "1.3.5",
+        "@types/cookies": "0.7.1",
+        "@types/events": "1.1.0",
+        "@types/http-assert": "1.2.2",
+        "@types/keygrip": "1.0.1",
+        "@types/koa-compose": "3.2.2",
+        "@types/node": "9.4.6"
+      }
+    },
+    "@types/koa-compose": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/koa-compose/-/koa-compose-3.2.2.tgz",
+      "integrity": "sha1-3BBuAAu/kqOskA91bfRzRIh+6Ec=",
       "dev": true
     },
     "@types/long": {
@@ -338,6 +485,27 @@
       "resolved": "https://registry.npmjs.org/@types/methods/-/methods-1.1.0.tgz",
       "integrity": "sha512-ROomEm+QHlUmcQoDr3CBo3GRm0w4PVoFYjVT9YcfyBha/Per4deb1IpvHU7KTK7YBZCIvOYbSADoEyDnFgaWLA==",
       "dev": true
+    },
+    "@types/mime": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-2.0.0.tgz",
+      "integrity": "sha512-A2TAGbTFdBw9azHbpVd+/FkdW2T6msN1uct1O9bH3vTerEHKZhTXJUQXy+hNq1B0RagfU8U+KBdqiZpxjhOUQA==",
+      "dev": true
+    },
+    "@types/mime-db": {
+      "version": "1.27.0",
+      "resolved": "https://registry.npmjs.org/@types/mime-db/-/mime-db-1.27.0.tgz",
+      "integrity": "sha1-m8AUof0f30dknBpUxt15ZrgoR5I=",
+      "dev": true
+    },
+    "@types/mimos": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@types/mimos/-/mimos-3.0.1.tgz",
+      "integrity": "sha512-MATIRH4VMIJki8lcYUZdNQEHuAG7iQ1FWwoLgxV+4fUOly2xZYdhHtGgvQyWiTeJqq2tZbE0nOOgZD6pR0FpNQ==",
+      "dev": true,
+      "requires": {
+        "@types/mime-db": "1.27.0"
+      }
     },
     "@types/minimatch": {
       "version": "3.0.1",
@@ -378,6 +546,12 @@
       "integrity": "sha512-BIRcpFqRm64rVuuYCFzOF37I2IEP3sXhiCjy8NbzJkxqFY2CLiDLFPhh6Sph/eXPXctg05MayCEDmeKCOIUBFg==",
       "dev": true
     },
+    "@types/podium": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@types/podium/-/podium-1.0.0.tgz",
+      "integrity": "sha1-v6ohUb4rHWEJzGn3+qnawsujuyA=",
+      "dev": true
+    },
     "@types/proxyquire": {
       "version": "1.3.28",
       "resolved": "https://registry.npmjs.org/@types/proxyquire/-/proxyquire-1.3.28.tgz",
@@ -394,17 +568,56 @@
         "@types/node": "9.4.6"
       }
     },
+    "@types/restify": {
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/@types/restify/-/restify-5.0.7.tgz",
+      "integrity": "sha512-0bcMA32Ys6nOQnD4QD6vDvfJg7nx5Dbd+oItNFAad3lwnanm0CqxSZpPQVgVMdD4Vrq/dY7yTaEUwsXOFci2iw==",
+      "dev": true,
+      "requires": {
+        "@types/bunyan": "1.8.4",
+        "@types/node": "9.4.6",
+        "@types/spdy": "3.4.4"
+      }
+    },
     "@types/semver": {
       "version": "5.4.0",
       "resolved": "https://registry.npmjs.org/@types/semver/-/semver-5.4.0.tgz",
       "integrity": "sha1-82WFNa9/H1AqzW2n2vQF/+sffuQ=",
       "dev": true
     },
+    "@types/serve-static": {
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.1.tgz",
+      "integrity": "sha512-jDMH+3BQPtvqZVIcsH700Dfi8Q3MIcEx16g/VdxjoqiGR/NntekB10xdBpirMKnPe9z2C5cBmL0vte0YttOr3Q==",
+      "dev": true,
+      "requires": {
+        "@types/express-serve-static-core": "4.11.1",
+        "@types/mime": "2.0.0"
+      }
+    },
     "@types/shimmer": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@types/shimmer/-/shimmer-1.0.0.tgz",
       "integrity": "sha512-X4LYCZRxdpGocviGUPZg0wWZyPrWFw3puBbk7Ea4rvt68qSqV1CGiXsj/e/ZYDIPUN8zsyKgrq7hjx52Akku9A==",
       "dev": true
+    },
+    "@types/shot": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@types/shot/-/shot-3.4.0.tgz",
+      "integrity": "sha1-RZR3xRh9Pr0wNmCrCZ5+ng87ZW8=",
+      "dev": true,
+      "requires": {
+        "@types/node": "9.4.6"
+      }
+    },
+    "@types/spdy": {
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/@types/spdy/-/spdy-3.4.4.tgz",
+      "integrity": "sha512-N9LBlbVRRYq6HgYpPkqQc3a9HJ/iEtVZToW6xlTtJiMhmRJ7jJdV7TaZQJw/Ve/1ePUsQiCTDc4JMuzzag94GA==",
+      "dev": true,
+      "requires": {
+        "@types/node": "9.4.6"
+      }
     },
     "@types/strip-bom": {
       "version": "3.0.0",
@@ -557,6 +770,15 @@
       "integrity": "sha1-GTxfCoZUGkxm+6Hi3DhYM2LqXo8=",
       "dev": true
     },
+    "argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "requires": {
+        "sprintf-js": "1.0.3"
+      }
+    },
     "arguejs": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/arguejs/-/arguejs-0.2.3.tgz",
@@ -663,6 +885,16 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
       "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4="
+    },
+    "axios": {
+      "version": "0.17.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.17.1.tgz",
+      "integrity": "sha1-LY4+XQvb1zJ/kbyBT1xXZg+Bgk0=",
+      "dev": true,
+      "requires": {
+        "follow-redirects": "1.4.1",
+        "is-buffer": "1.1.5"
+      }
     },
     "babel-code-frame": {
       "version": "6.26.0",
@@ -838,6 +1070,12 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
       "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
+      "dev": true
+    },
+    "builtins": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/builtins/-/builtins-1.0.3.tgz",
+      "integrity": "sha1-y5T662HIaWRR2zZTThQi+U8K7og=",
       "dev": true
     },
     "bytebuffer": {
@@ -2012,6 +2250,26 @@
       "requires": {
         "path-exists": "2.1.0",
         "pinkie-promise": "2.0.1"
+      }
+    },
+    "follow-redirects": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.4.1.tgz",
+      "integrity": "sha512-uxYePVPogtya1ktGnAAXOacnbIuRMB4dkvqeNz2qTtTQsuzSfbDolV+wMMKxAmCx0bLgAKLbBOkjItMbbkR1vg==",
+      "dev": true,
+      "requires": {
+        "debug": "3.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
       }
     },
     "forever-agent": {
@@ -4014,6 +4272,50 @@
         "is-object": "1.0.1"
       }
     },
+    "js-green-licenses": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/js-green-licenses/-/js-green-licenses-0.4.0.tgz",
+      "integrity": "sha512-LpkL/9coWxNUmJ9/jxng3uvcLK6Qso2yaz7QBjO+atwtX/xmt8MrCtbkolYdhPZl/fq5dRs7Q7BLA8Ne3DKZ2w==",
+      "dev": true,
+      "requires": {
+        "argparse": "1.0.10",
+        "axios": "0.17.1",
+        "npm-package-arg": "6.0.0",
+        "package-json": "4.0.1",
+        "pify": "3.0.0",
+        "spdx-correct": "2.0.4",
+        "spdx-satisfies": "0.1.3",
+        "strip-json-comments": "2.0.1"
+      },
+      "dependencies": {
+        "spdx-correct": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-2.0.4.tgz",
+          "integrity": "sha512-c+4gPpt9YDhz7cHlz5UrsHzxxRi4ksclxnEEKsuGT9JdwSC+ZNmsGbYRzzgxyZaBYpcWnlu+4lPcdLKx4DOCmA==",
+          "dev": true,
+          "requires": {
+            "spdx-expression-parse": "2.0.2",
+            "spdx-license-ids": "2.0.1"
+          }
+        },
+        "spdx-expression-parse": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-2.0.2.tgz",
+          "integrity": "sha512-oFxOkWCfFS0ltNp0H66gXlU4NF6bxg7RkoTYR0413t+yTY9zyj+AIWsjtN8dcVp6703ijDYBWBIARlJ7DkyP9Q==",
+          "dev": true,
+          "requires": {
+            "spdx-exceptions": "2.1.0",
+            "spdx-license-ids": "2.0.1"
+          }
+        },
+        "spdx-license-ids": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-2.0.1.tgz",
+          "integrity": "sha1-AgF7zDU07k/+9tWNIOfT6aHDyOw=",
+          "dev": true
+        }
+      }
+    },
     "js-tokens": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
@@ -4678,6 +4980,18 @@
         "is-builtin-module": "1.0.0",
         "semver": "5.4.1",
         "validate-npm-package-license": "3.0.1"
+      }
+    },
+    "npm-package-arg": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-6.0.0.tgz",
+      "integrity": "sha512-hwC7g81KLgRmchv9ol6f3Fx4Yyc9ARX5X5niDHVILgpuvf08JRIgOZcEfpFXli3BgESoTrkauqorXm6UbvSgSg==",
+      "dev": true,
+      "requires": {
+        "hosted-git-info": "2.5.0",
+        "osenv": "0.1.5",
+        "semver": "5.4.1",
+        "validate-npm-package-name": "3.0.0"
       }
     },
     "npm-run-path": {
@@ -6362,6 +6676,12 @@
       "integrity": "sha1-aabOicRCpEQDFBrS+bNwvVu29O4=",
       "dev": true
     },
+    "os-homedir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+      "dev": true
+    },
     "os-locale": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
@@ -6376,6 +6696,16 @@
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
       "dev": true
+    },
+    "osenv": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
+      "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
+      "dev": true,
+      "requires": {
+        "os-homedir": "1.0.2",
+        "os-tmpdir": "1.0.2"
+      }
     },
     "p-cancelable": {
       "version": "0.3.0",
@@ -7006,6 +7336,16 @@
         }
       }
     },
+    "spdx-compare": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/spdx-compare/-/spdx-compare-0.1.2.tgz",
+      "integrity": "sha1-sGrz6jSvdDfZGp9Enq8tLpPDyPs=",
+      "dev": true,
+      "requires": {
+        "spdx-expression-parse": "1.0.4",
+        "spdx-ranges": "1.0.1"
+      }
+    },
     "spdx-correct": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
@@ -7014,6 +7354,12 @@
       "requires": {
         "spdx-license-ids": "1.2.2"
       }
+    },
+    "spdx-exceptions": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.1.0.tgz",
+      "integrity": "sha512-4K1NsmrlCU1JJgUrtgEeTVyfx8VaYea9J9LvARxhbHtVtohPs/gFGG5yy49beySjlIMhhXZ4QqujIZEfS4l6Cg==",
+      "dev": true
     },
     "spdx-expression-parse": {
       "version": "1.0.4",
@@ -7026,6 +7372,22 @@
       "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
       "integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc=",
       "dev": true
+    },
+    "spdx-ranges": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/spdx-ranges/-/spdx-ranges-1.0.1.tgz",
+      "integrity": "sha1-D07se46kjtIC43S7iULo0Y3AET4=",
+      "dev": true
+    },
+    "spdx-satisfies": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/spdx-satisfies/-/spdx-satisfies-0.1.3.tgz",
+      "integrity": "sha1-Z6HydOYRXUquKK/kdNt2FkvhC9w=",
+      "dev": true,
+      "requires": {
+        "spdx-compare": "0.1.2",
+        "spdx-expression-parse": "1.0.4"
+      }
     },
     "split": {
       "version": "1.0.1",
@@ -7053,6 +7415,12 @@
       "requires": {
         "through2": "2.0.3"
       }
+    },
+    "sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+      "dev": true
     },
     "sshpk": {
       "version": "1.13.1",
@@ -7767,6 +8135,15 @@
       "requires": {
         "spdx-correct": "1.0.2",
         "spdx-expression-parse": "1.0.4"
+      }
+    },
+    "validate-npm-package-name": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-3.0.0.tgz",
+      "integrity": "sha1-X6kS2B630MdK/BQN5zF/DKffQ34=",
+      "dev": true,
+      "requires": {
+        "builtins": "1.0.3"
       }
     },
     "vary": {

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "@types/methods": "^1.1.0",
     "@types/mocha": "^2.2.44",
     "@types/ncp": "^2.0.1",
-    "@types/node": "^9.3.0",
+    "@types/node": "^9.4.6",
     "@types/once": "^1.4.0",
     "@types/pify": "^3.0.0",
     "@types/proxyquire": "^1.3.28",

--- a/src/plugins/plugin-grpc.ts
+++ b/src/plugins/plugin-grpc.ts
@@ -495,19 +495,19 @@ module.exports = [
   },
   {
     file: 'src/client.js',
-    versions: '1.7 - 1.8',
+    versions: '^1.7',
     patch: patchClient,
     unpatch: unpatchClient
   },
   {
     file: 'src/metadata.js',
-    versions: '1.7 - 1.8',
+    versions: '^1.7',
     patch: patchMetadata,
     unpatch: unpatchMetadata
   },
   {
     file: 'src/server.js',
-    versions: '1.7 - 1.8',
+    versions: '^1.7',
     patch: patchServer,
     unpatch: unpatchServer
   }

--- a/test/fixtures/plugin-fixtures.json
+++ b/test/fixtures/plugin-fixtures.json
@@ -24,9 +24,9 @@
       "@google-cloud/datastore": "^1.0.2"
     }
   },
-  "google-cloud-speech0.6": {
+  "google-cloud-speech1": {
     "dependencies": {
-      "@google-cloud/speech": "^0.6.0"
+      "@google-cloud/speech": "^1.1.0"
     }
   },
   "grpc1.6": {

--- a/test/fixtures/plugin-fixtures.json
+++ b/test/fixtures/plugin-fixtures.json
@@ -34,9 +34,9 @@
       "grpc": "~1.6.0"
     }
   },
-  "grpc1.8": {
+  "grpc1.7": {
     "dependencies": {
-      "grpc": "~1.8.0"
+      "grpc": "^1.7.0"
     }
   },
   "hapi-plugin-mysql3": {

--- a/test/plugins/test-trace-google-gax.ts
+++ b/test/plugins/test-trace-google-gax.ts
@@ -31,10 +31,11 @@ describe('google-gax', function() {
       enhancedDatabaseReporting: true,
       samplingRate: 0
     });
-    speech = require('./fixtures/google-cloud-speech0.6')({
+    const SpeechClient = require('./fixtures/google-cloud-speech1').SpeechClient;
+    speech = new SpeechClient({
       projectId: '0',
       keyFilename: path.join(__dirname, '..', 'fixtures', 
-          'gcloud-credentials.json'),    
+          'gcloud-credentials.json')
     });
   });
 
@@ -52,7 +53,7 @@ describe('google-gax', function() {
           return span.kind === 'RPC_CLIENT' && span.name.indexOf('grpc:') === 0;
         });
         assert.ok(span);
-        assert.equal(span.name, 'grpc:/google.cloud.speech.v1beta1.Speech/SyncRecognize');
+        assert.equal(span.name, 'grpc:/google.cloud.speech.v1.Speech/Recognize');
         done();
       });
     });

--- a/test/plugins/test-trace-google-gax.ts
+++ b/test/plugins/test-trace-google-gax.ts
@@ -47,8 +47,6 @@ describe('google-gax', function() {
         endRootSpan();
         // Authentication will fail due to invalid credentials but a span will still be
         // generated.
-        assert.equal(err.message,
-          'Getting metadata from plugin failed with error: invalid_client');
         assert.equal(err.code, 16);
         var span = common.getMatchingSpan(function(span) {
           return span.kind === 'RPC_CLIENT' && span.name.indexOf('grpc:') === 0;

--- a/test/plugins/test-trace-grpc.ts
+++ b/test/plugins/test-trace-grpc.ts
@@ -27,7 +27,7 @@ var common = require('./common'/*.js*/);
 
 var versions = {
   grpc1_6: './fixtures/grpc1.6',
-  grpc1_8: './fixtures/grpc1.8'
+  grpc1_7: './fixtures/grpc1.7'
 };
 
 var protoFile = __dirname + '/../fixtures/test-grpc.proto';
@@ -573,9 +573,9 @@ Object.keys(versions).forEach(function(version) {
           assert(err);
           var assertTraceProperties = function(predicate) {
             var trace = common.getMatchingSpan(predicate);
-            assert(trace);
+            assert.ok(trace);
             assert.strictEqual(trace.labels.argument, '{"n":' + EMIT_ERROR + '}');
-            assert(trace.labels.error.indexOf('Error: test') !== -1);
+            assert.ok(trace.labels.error.indexOf('test') !== -1);
           };
           assertTraceProperties(grpcClientPredicate);
           assertTraceProperties(grpcServerOuterPredicate);
@@ -593,8 +593,8 @@ Object.keys(versions).forEach(function(version) {
           assert(err);
           var assertTraceProperties = function(predicate) {
             var trace = common.getMatchingSpan(predicate);
-            assert(trace);
-            assert(trace.labels.error.indexOf('Error: test') !== -1);
+            assert.ok(trace);
+            assert.ok(trace.labels.error.indexOf('test') !== -1);
           };
           assertTraceProperties(grpcClientPredicate);
           assertTraceProperties(grpcServerOuterPredicate);
@@ -615,8 +615,8 @@ Object.keys(versions).forEach(function(version) {
           endTransaction();
           var assertTraceProperties = function(predicate) {
             var trace = common.getMatchingSpan(predicate);
-            assert(trace);
-            assert(trace.labels.error.indexOf('Error: test') !== -1);
+            assert.ok(trace);
+            assert.ok(trace.labels.error.indexOf('test') !== -1);
           };
           assertTraceProperties(grpcClientPredicate);
           assertTraceProperties(grpcServerOuterPredicate);
@@ -637,8 +637,8 @@ Object.keys(versions).forEach(function(version) {
           endTransaction();
           var assertTraceProperties = function(predicate) {
             var trace = common.getMatchingSpan(predicate);
-            assert(trace);
-            assert(trace.labels.error.indexOf('Error: test') !== -1);
+            assert.ok(trace);
+            assert.ok(trace.labels.error.indexOf('test') !== -1);
           };
           assertTraceProperties(grpcClientPredicate);
           assertTraceProperties(grpcServerOuterPredicate);

--- a/test/plugins/test-trace-http2.ts
+++ b/test/plugins/test-trace-http2.ts
@@ -218,10 +218,10 @@ describe('test-trace-http2', () => {
     const server: http2.Http2SecureServer = http2.createServer();
     server.on(
         'stream',
-        // Node 9.4 removed rstWithInternalError() and uses added close().
-        (s: http2.ServerHttp2Stream&({close: (code: number) => void})) => {
+        (s: http2.ServerHttp2Stream&({rstWithInternalError: () => void})) => {
           setTimeout(() => {
             if (semver.satisfies(process.version, '>=9.4')) {
+              // Node 9.4 removed rstWithInternalError() and uses added close().
               s.close(http2.constants.NGHTTP2_INTERNAL_ERROR);
             } else {
               s.rstWithInternalError();

--- a/test/test-grpc-context.ts
+++ b/test/test-grpc-context.ts
@@ -22,7 +22,7 @@ var http = require('http');
 
 var versions = {
   grpc1_6: './plugins/fixtures/grpc1.6',
-  grpc1_8: './plugins/fixtures/grpc1.8'
+  grpc1_7: './plugins/fixtures/grpc1.7'
 };
 
 var grpcPort = 50051;


### PR DESCRIPTION
gRPC error messages changed in 1.9... otherwise there are no changes that affect Trace Agent behavior.

To avoid having to actively bump the supported versions every time, I'm expanding the list of supported versions to all of 1.x, and in the future will push a fix if the pre-release breaks before that version comes out.