### PR TITLE
refactor: move stack frame creation to utils

### DIFF
--- a/test/test-trace-web-frameworks.ts
+++ b/test/test-trace-web-frameworks.ts
@@ -20,9 +20,9 @@ import * as semver from 'semver';
 
 import * as cls from '../src/cls';
 import {Constants} from '../src/constants';
-import {StackFrame} from '../src/span-data';
 import {TraceLabels} from '../src/trace-labels';
 import {TraceSpan} from '../src/trace-span';
+import {StackFrame} from '../src/util';
 
 import * as trace from './trace';
 import {assertSpanDuration, DEFAULT_SPAN_DURATION, isServerSpan, wait} from './utils';

--- a/test/trace.ts
+++ b/test/trace.ts
@@ -66,22 +66,21 @@ let singleton: TraceWriter|null = null;
 
 traceWriter.create =
     (logger: common.Logger, config: TraceWriterSingletonConfig,
-     cb?: (err?: Error) => void):
-        TraceWriter => {
-          if (singleton) {
-            throw new Error('Trace Writer already created.');
-          }
-          singleton = new TestTraceWriter(logger, config);
-          singleton.initialize(cb || (() => {}));
-          return singleton;
-        },
+     cb?: (err?: Error) => void): TraceWriter => {
+      if (singleton) {
+        throw new Error('Trace Writer already created.');
+      }
+      singleton = new TestTraceWriter(logger, config);
+      singleton.initialize(cb || (() => {}));
+      return singleton;
+    };
 
-        traceWriter.get = (): TraceWriter => {
-          if (!singleton) {
-            throw new Error('Trace Writer not initialized.');
-          }
-          return singleton;
-        };
+traceWriter.get = (): TraceWriter => {
+  if (!singleton) {
+    throw new Error('Trace Writer not initialized.');
+  }
+  return singleton;
+};
 
 export type Predicate<T> = (value: T) => boolean;
 


### PR DESCRIPTION
This change simply moves `StackFrame` creation to utils, to make `SpanData` code simpler.