### PR TITLE
chore: update @types/shimmer definitions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -486,9 +486,9 @@
       }
     },
     "@types/shimmer": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@types/shimmer/-/shimmer-1.0.0.tgz",
-      "integrity": "sha512-X4LYCZRxdpGocviGUPZg0wWZyPrWFw3puBbk7Ea4rvt68qSqV1CGiXsj/e/ZYDIPUN8zsyKgrq7hjx52Akku9A==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@types/shimmer/-/shimmer-1.0.1.tgz",
+      "integrity": "sha512-I9ouuzrWLcjM1wre7f0i780W3KHk5PxFAC5KOpvpOGNaTsaKLN8p7sqRh9THwV9cpdOA/YJC+yMhG1jonQFdRQ==",
       "dev": true
     },
     "@types/shot": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -416,6 +416,15 @@
         "@types/node": "9.4.6"
       }
     },
+    "@types/nock": {
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/@types/nock/-/nock-9.1.2.tgz",
+      "integrity": "sha512-Vdd1dRTUT5S1ONTcAMmQ2PCzIQccKMOpgu9T+knvJeGRCt29j3tcz9oRC1AM6OXD81+8U4mVuWzHklTlQW7W+w==",
+      "dev": true,
+      "requires": {
+        "@types/node": "9.4.6"
+      }
+    },
     "@types/node": {
       "version": "9.4.6",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-9.4.6.tgz",

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "@types/request": "^2.0.8",
     "@types/restify": "^5.0.7",
     "@types/semver": "^5.4.0",
-    "@types/shimmer": "^1.0.0",
+    "@types/shimmer": "^1.0.1",
     "@types/tmp": "0.0.33",
     "@types/uuid": "^3.4.3",
     "axios": "^0.17.1",

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "@types/methods": "^1.1.0",
     "@types/mocha": "^2.2.44",
     "@types/ncp": "^2.0.1",
+    "@types/nock": "^9.1.2",
     "@types/node": "^9.4.6",
     "@types/once": "^1.4.0",
     "@types/pify": "^3.0.0",

--- a/src/plugins/plugin-express.ts
+++ b/src/plugins/plugin-express.ts
@@ -24,7 +24,9 @@ import {express_4} from './types';
 // application is an undocumented member of the express object.
 type Express4Module = typeof express_4&{application: express_4.Application};
 
-const methods = httpMethods.concat('use', 'route', 'param', 'all');
+const methods: Array<keyof express_4.Application> =
+    (httpMethods as Array<keyof express_4.Application>)
+        .concat('use', 'route', 'param', 'all');
 
 const SUPPORTED_VERSIONS = '4.x';
 

--- a/src/plugins/plugin-hapi.ts
+++ b/src/plugins/plugin-hapi.ts
@@ -105,14 +105,13 @@ const plugin: PluginTypes.Plugin = [{
   file: '',
   versions: SUPPORTED_VERSIONS,
   patch: (hapi, api) => {
-    shimmer.wrap<typeof hapi.Server.prototype.connection>(
-        hapi.Server.prototype, 'connection', (connection) => {
-          return function connectionTrace(this: {}) {
-            const server: hapi_16.Server = connection.apply(this, arguments);
-            server.ext('onRequest', createMiddleware(api));
-            return server;
-          };
-        });
+    shimmer.wrap(hapi.Server.prototype, 'connection', (connection) => {
+      return function connectionTrace(this: {}) {
+        const server: hapi_16.Server = connection.apply(this, arguments);
+        server.ext('onRequest', createMiddleware(api));
+        return server;
+      };
+    });
   },
   unpatch: (hapi) => {
     shimmer.unwrap(hapi.Server.prototype, 'connection');

--- a/src/plugins/plugin-koa.ts
+++ b/src/plugins/plugin-koa.ts
@@ -138,7 +138,7 @@ function createMiddleware2x(api: PluginTypes.TraceAgent): koa_2.Middleware {
 function patchUse<T>(
     koa: KoaModule<T>, api: PluginTypes.TraceAgent,
     createMiddlewareFunction: CreateMiddlewareFn<T>) {
-  shimmer.wrap<typeof koa.prototype.use>(koa.prototype, 'use', (use) => {
+  shimmer.wrap(koa.prototype, 'use', (use) => {
     return function useTrace(this: typeof koa.prototype&
                              PluginTypes.TraceAgentExtension):
         typeof koa.prototype {

--- a/src/plugins/plugin-restify.ts
+++ b/src/plugins/plugin-restify.ts
@@ -35,7 +35,7 @@ function unpatchRestify(restify: Restify5) {
 }
 
 function patchRestify(restify: Restify5, api: PluginTypes.TraceAgent) {
-  shimmer.wrap<CreateServerFn>(restify, 'createServer', createServerWrap);
+  shimmer.wrap(restify, 'createServer', createServerWrap);
 
   function createServerWrap(createServer: CreateServerFn): CreateServerFn {
     return function createServerTrace(this: {}) {

--- a/test/plugins/test-trace-datastore.ts
+++ b/test/plugins/test-trace-datastore.ts
@@ -33,8 +33,7 @@ describe('test-trace-datastore', function() {
   });
 
   // This does a gcloud.datastore.get() request that makes a gRPC 'lookup' call.
-  // It attempts to authenticate using Google Auth by connecting to
-  // 'accounts.google.com:443/o/oauth2/token', but fails because of Nock.
+  // It attempts to authenticate using Google Auth, but fails because of Nock.
   // An auth error is returned, and a trace span for the gRPC call is created
   // with an error.
   it('should create gRPC spans', function(done) {
@@ -53,8 +52,6 @@ describe('test-trace-datastore', function() {
         endTransaction();
         assert(err);
         assert.strictEqual(err.code, 16); // 16 = Status.UNAUTHENTICATED
-        assert.notStrictEqual(
-            err.message.indexOf('accounts.google.com:443/o/oauth2/token'), -1);
         var trace = common.getMatchingSpan(grpcPredicate);
         assert(trace);
         assert.notStrictEqual(trace.labels.argument.indexOf(

--- a/test/test-trace-writer.ts
+++ b/test/test-trace-writer.ts
@@ -92,6 +92,7 @@ describe('TraceWriter', function() {
     const numListenersBeforeTraceWriter = process.listeners('uncaughtException').length;
     traceWriter.create(fakeLogger, {
       projectId: '0',
+      serviceContext: {},
       onUncaughtException: 'ignore',
       forceNewAgent_: true
     } as createTraceWriterOptions);

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -52,3 +52,19 @@ export function assertSpanDuration(span: TraceSpan, bounds: [number, number]) {
               spanDuration} ms is not in the acceptable expected range of [${
               bounds[0]}, ${bounds[1]}] ms`);
     }
+
+export function plan(done: MochaDone, num: number): MochaDone {
+  return (err?: Error) => {
+    if (err) {
+      num = 0;
+      setImmediate(done, err);
+    } else {
+      num--;
+      if (num === 0) {
+        setImmediate(done);
+      } else if (num < 0) {
+        throw new Error('done called too many times');
+      }
+    }
+  };
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,6 +17,8 @@
     "src/plugins/plugin-koa.ts",
     "src/plugins/plugin-restify.ts",
     "test/plugins/test-trace-http2.ts",
+    "test/nocks.ts",
+    "test/test-config-credentials.ts",
     "test/test-trace-cluster.ts",
     "test/test-trace-web-frameworks.ts",
     "test/trace.ts",


### PR DESCRIPTION
The [new typedefs for @types/shimmer](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/23877) is breaking but includes changes that allow us to more precisely specify types for functions being patched. This change upgrades to them and fixes a small typo that was exposed as a result.