### PR TITLE
refactor: externalize singleton accessors from trace writer

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -33,7 +33,7 @@ import * as PluginTypes from './plugin-types';
 import {PluginLoaderConfig} from './trace-plugin-loader';
 import * as pluginLoader from './trace-plugin-loader';
 import {TraceAgent} from './trace-api';
-import {traceWriter, TraceWriterSingletonConfig} from './trace-writer';
+import {traceWriter, TraceWriterConfig} from './trace-writer';
 import * as traceUtil from './util';
 
 export {Config, PluginTypes};
@@ -57,10 +57,9 @@ interface TopLevelConfig {
   forceNewAgent_: boolean;
 }
 
-// TraceWriterSingletonConfig = TraceWriterConfig & { forceNewAgent_: boolean }
 // PluginLoaderConfig extends TraceAgentConfig
-type NormalizedConfig =
-    TraceWriterSingletonConfig&PluginLoaderConfig&TopLevelConfig;
+type NormalizedConfig = TraceWriterConfig&PluginLoaderConfig&TopLevelConfig&
+    {forceNewAgent_: boolean};
 
 /**
  * Normalizes the user-provided configuration object by adding default values

--- a/src/index.ts
+++ b/src/index.ts
@@ -162,7 +162,7 @@ export function start(projectConfig?: Config): PluginTypes.TraceAgent {
   }
   // CLS namespace for context propagation
   cls.createNamespace();
-  traceWriter.create(logger, config, (err) => {
+  traceWriter.create(logger, config).initialize((err) => {
     if (err) {
       stop();
     }

--- a/src/trace-writer.ts
+++ b/src/trace-writer.ts
@@ -22,6 +22,7 @@ import * as util from 'util';
 import {Constants} from './constants';
 import {SpanKind, Trace} from './trace';
 import {TraceLabels} from './trace-labels';
+import {Singleton} from './util';
 
 const pjson = require('../../package.json');
 
@@ -340,26 +341,4 @@ export class TraceWriter extends common.Service {
   }
 }
 
-export type TraceWriterSingletonConfig = TraceWriterConfig&{
-  forceNewAgent_: boolean;
-};
-
-// Singleton
-let singleton: TraceWriter;
-
-export const traceWriter = {
-  create(logger: common.Logger, config: TraceWriterSingletonConfig):
-      TraceWriter {
-        if (!singleton || config.forceNewAgent_) {
-          singleton = new TraceWriter(logger, config);
-        }
-        return singleton;
-      },
-
-  get(): TraceWriter {
-    if (!singleton) {
-      throw new Error('TraceWriter singleton was not initialized.');
-    }
-    return singleton;
-  }
-};
+export const traceWriter = new Singleton(TraceWriter);

--- a/src/trace-writer.ts
+++ b/src/trace-writer.ts
@@ -348,19 +348,13 @@ export type TraceWriterSingletonConfig = TraceWriterConfig&{
 let singleton: TraceWriter;
 
 export const traceWriter = {
-  create(
-      logger: common.Logger, config: TraceWriterSingletonConfig,
-      cb?: (err?: Error) => void): TraceWriter {
-    if (!cb) {
-      // tslint:disable-next-line:no-empty
-      cb = () => {};
-    }
-    if (!singleton || config.forceNewAgent_) {
-      singleton = new TraceWriter(logger, config);
-      singleton.initialize(cb);
-    }
-    return singleton;
-  },
+  create(logger: common.Logger, config: TraceWriterSingletonConfig):
+      TraceWriter {
+        if (!singleton || config.forceNewAgent_) {
+          singleton = new TraceWriter(logger, config);
+        }
+        return singleton;
+      },
 
   get(): TraceWriter {
     if (!singleton) {

--- a/src/util.ts
+++ b/src/util.ts
@@ -42,22 +42,24 @@ interface PackageJson {
   version: string;
 }
 
-export interface ClassOf<T, Config> {
+export interface Constructor<T, Config> {
   new(logger: Logger, config: Config): T;
   prototype: T;
   name: string;
 }
 
 /**
- * An class that provides access to a singleton.
+ * A class that provides access to a singleton.
+ * We assume that any such singleton is always constructed with two arguments:
+ * A logger and an arbitrary configuration object.
  * Instances of this type should only be constructed in module scope.
  */
 export class Singleton<T, Config> {
   private singleton: T|null = null;
 
-  constructor(private implementation: ClassOf<T, Config>) {}
+  constructor(private implementation: Constructor<T, Config>) {}
 
-  create(logger: Logger, config: Config&{forceNewAgent_: boolean}): T {
+  create(logger: Logger, config: Config&{forceNewAgent_?: boolean}): T {
     if (!this.singleton || config.forceNewAgent_) {
       this.singleton = new this.implementation(logger, config);
       return this.singleton;

--- a/test/test-config-credentials.ts
+++ b/test/test-config-credentials.ts
@@ -47,12 +47,13 @@ describe('Credentials Configuration', () => {
   before(() => {
     savedProject = process.env.GCLOUD_PROJECT;
     process.env.GCLOUD_PROJECT = '0';
-    trace.enableTraceWriter();
+    trace.setTraceWriterEnabled(true);
     disableNetConnect();
   });
 
   after(() => {
     process.env.GCLOUD_PROJECT = savedProject;
+    trace.setTraceWriterEnabled(false);
     enableNetConnect();
   });
 

--- a/test/test-trace-api.ts
+++ b/test/test-trace-api.ts
@@ -77,7 +77,7 @@ describe('Trace Interface', function() {
       Object.assign(defaultConfig, {
         projectId: '0',
         forceNewAgent_: false
-      }), function(err) {
+      })).initialize(function(err) {
         assert.ok(!err);
         done();
       });

--- a/test/test-trace-writer.ts
+++ b/test/test-trace-writer.ts
@@ -107,7 +107,8 @@ describe('TraceWriter', function() {
         serviceContext: {},
         onUncaughtException: 'ignore',
         forceNewAgent_: true
-      } as createTraceWriterOptions, function() {
+      } as createTraceWriterOptions);
+      writer.initialize(function() {
         var spanData = createFakeTrace('fake span');
         writer.defaultLabels = {
           fakeKey: 'value'
@@ -328,7 +329,7 @@ describe('TraceWriter', function() {
           forceNewAgent_: true,
           onUncaughtException: 'ignore',
           serviceContext: {}
-        }, testCase.config), function(err) {
+        }, testCase.config)).initialize(function(err) {
           testCase.assertResults(err, traceWriter.get());
           done();
         });

--- a/test/trace.ts
+++ b/test/trace.ts
@@ -95,7 +95,6 @@ export function disableTraceWriter() {
                 throw new Error('Trace Writer already created.');
               }
               singleton = new TestTraceWriter(logger, config);
-              singleton.initialize(cb || (() => {}));
               return singleton;
             });
 

--- a/test/trace.ts
+++ b/test/trace.ts
@@ -38,7 +38,7 @@ import * as trace from '../src';
 import {Config, PluginTypes} from '../src';
 import {RootSpanData} from '../src/span-data';
 import {Trace, TraceSpan} from '../src/trace';
-import {LabelObject, TraceWriter, traceWriter, TraceWriterConfig, TraceWriterSingletonConfig} from '../src/trace-writer';
+import {LabelObject, TraceWriter, traceWriter, TraceWriterConfig} from '../src/trace-writer';
 
 export {Config, PluginTypes};
 
@@ -61,9 +61,11 @@ class TestTraceWriter extends TraceWriter {
     });
   }
 }
+setTraceWriterEnabled(false);
 
-let singleton: TraceWriter|null = null;
-disableTraceWriter();
+export function setTraceWriterEnabled(enabled: boolean) {
+  traceWriter['implementation'] = enabled ? TraceWriter : TestTraceWriter;
+}
 
 export type Predicate<T> = (value: T) => boolean;
 
@@ -74,37 +76,6 @@ export function start(projectConfig?: Config): PluginTypes.TraceAgent {
 
 export function get(): PluginTypes.TraceAgent {
   return trace.get();
-}
-
-export function enableTraceWriter() {
-  if (traceWriter.get.__wrapped) {
-    assert.ok(!singleton);
-    shimmer.massUnwrap([traceWriter], ['create', 'get']);
-  }
-}
-
-export function disableTraceWriter() {
-  if (!traceWriter.get.__wrapped) {
-    assert.throws(traceWriter.get);
-    shimmer.wrap(
-        traceWriter, 'create',
-        () =>
-            (logger: common.Logger, config: TraceWriterSingletonConfig,
-             cb?: (err?: Error) => void): TraceWriter => {
-              if (singleton) {
-                throw new Error('Trace Writer already created.');
-              }
-              singleton = new TestTraceWriter(logger, config);
-              return singleton;
-            });
-
-    shimmer.wrap(traceWriter, 'get', () => (): TraceWriter => {
-      if (!singleton) {
-        throw new Error('Trace Writer not initialized.');
-      }
-      return singleton;
-    });
-  }
 }
 
 export function getTraces(predicate?: Predicate<TraceSpan[]>): string[] {


### PR DESCRIPTION
This change adds a class that abstracts the "singleton" concept and uses it for the TraceWriter singleton. This makes singletons (including the future PluginLoader class) easier to mock.

I recommend looking at each commit separately