### PR TITLE
fix: rewrite all log messages

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -38,10 +38,9 @@ import * as traceUtil from './util';
 
 export {Config, PluginTypes};
 
-const modulesLoadedBeforeTrace: string[] = [];
-
 const traceAgent = new TraceAgent('Custom Span API');
 
+const modulesLoadedBeforeTrace: string[] = [];
 const traceModuleName = path.join('@google-cloud', 'trace-agent');
 for (let i = 0; i < filesLoadedBeforeTrace.length; i++) {
   const moduleName = traceUtil.packageNameFromPath(filesLoadedBeforeTrace[i]);
@@ -159,9 +158,12 @@ export function start(projectConfig?: Config): PluginTypes.TraceAgent {
 
   if (modulesLoadedBeforeTrace.length > 0) {
     logger.error(
-        'Tracing might not work as the following modules ' +
-        'were loaded before the trace agent was initialized: ' +
-        JSON.stringify(modulesLoadedBeforeTrace));
+        'TraceAgent#start: Tracing might not work as the following modules',
+        'were loaded before the trace agent was initialized:',
+        `[${modulesLoadedBeforeTrace.sort().join(', ')}]`);
+    // Stop storing these entries in memory
+    filesLoadedBeforeTrace.length = 0;
+    modulesLoadedBeforeTrace.length = 0;
   }
   // CLS namespace for context propagation
   cls.createNamespace();
@@ -177,7 +179,7 @@ export function start(projectConfig?: Config): PluginTypes.TraceAgent {
   if (typeof config.projectId !== 'string' &&
       typeof config.projectId !== 'undefined') {
     logger.error(
-        'config.projectId, if provided, must be a string. ' +
+        'TraceAgent#start: config.projectId, if provided, must be a string.',
         'Disabling trace agent.');
     stop();
     return traceAgent;
@@ -186,7 +188,7 @@ export function start(projectConfig?: Config): PluginTypes.TraceAgent {
   // Make trace agent available globally without requiring package
   global._google_trace_agent = traceAgent;
 
-  logger.info('trace agent activated');
+  logger.info('TraceAgent#start: Trace Agent activated.');
   return traceAgent;
 }
 

--- a/src/trace-api.ts
+++ b/src/trace-api.ts
@@ -129,7 +129,8 @@ export class TraceAgent implements TraceAgentInterface {
     // TODO validate options
     // Don't create a root span if we are already in a root span
     if (cls.getRootContext().type === SpanDataType.ROOT) {
-      this.logger!.warn(this.pluginName + ': Cannot create nested root spans.');
+      this.logger!.warn(`TraceApi#runInRootSpan: [${
+          this.pluginName}] Cannot create nested root spans.`);
       return fn(UNCORRELATED_SPAN);
     }
 
@@ -204,9 +205,10 @@ export class TraceAgent implements TraceAgentInterface {
         // with continuously growing number of child spans. The second case
         // seems to have some value, but isn't representable. The user probably
         // needs a custom outer span that encompasses the entirety of work.
-        this.logger!.warn(
-            this.pluginName + ': creating child for an already closed span',
-            options.name, rootSpan.span.name);
+        this.logger!.warn(`TraceApi#createChildspan: [${
+            this.pluginName}] Creating phantom child span [${
+            options.name}] because root span [${
+            rootSpan.span.name}] was already closed.`);
         return UNCORRELATED_SPAN;
       }
       // Create a new child span and return it.
@@ -224,9 +226,9 @@ export class TraceAgent implements TraceAgentInterface {
       return UNTRACED_SPAN;
     } else {
       // Context was lost.
-      this.logger!.warn(
-          this.pluginName + ': Attempted to create child span ' +
-          'without root');
+      this.logger!.warn(`TraceApi#createChildspan: [${
+          this.pluginName}] Creating phantom child span [${
+          options.name}] because there is no root span.`);
       return UNCORRELATED_SPAN;
     }
   }

--- a/test/test-modules-loaded-before-agent.ts
+++ b/test/test-modules-loaded-before-agent.ts
@@ -39,7 +39,7 @@ describe('modules loaded before agent', () => {
     trace.start();
     assert.strictEqual(
         logger.getNumLogsWith(
-            'error', /modules.*loaded.*before.*trace agent.*: .*"shimmer"/),
+            'error', /modules.*loaded.*before.*trace agent.*: .*shimmer/),
         1);
   });
 });


### PR DESCRIPTION
This change rewrites all log messages (except for those emitted from the Plugin Loader, which were already re-written in #686) to include class/function name, and generally be more descriptive.
Closes #675