### PR TITLE
fix: add support for pg 7 changes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -298,6 +298,26 @@
       "integrity": "sha512-cnEvTAVVRqF6OQg/4SLnbxQ0slZJHqZQDve5BzGhcIQtuMpPv8T5QNS2cBPa/W0jTxciqwn7bmJAIGe/bOJ5Kw==",
       "dev": true
     },
+    "@types/pg": {
+      "version": "7.4.5",
+      "resolved": "https://registry.npmjs.org/@types/pg/-/pg-7.4.5.tgz",
+      "integrity": "sha512-DV9A1X9duAnZrF+ANT9i7Z3k+49Dfl96hJlmpz8KCZtBaB7ck3eaAX/37P/vOtpb1VBS5C7xfYI1oRnAfL71DQ==",
+      "dev": true,
+      "requires": {
+        "@types/events": "1.2.0",
+        "@types/node": "9.4.6",
+        "@types/pg-types": "1.11.4"
+      }
+    },
+    "@types/pg-types": {
+      "version": "1.11.4",
+      "resolved": "https://registry.npmjs.org/@types/pg-types/-/pg-types-1.11.4.tgz",
+      "integrity": "sha512-WdIiQmE347LGc1Vq3Ki8sk3iyCuLgnccqVzgxek6gEHp2H0p3MQ3jniIHt+bRODXKju4kNQ+mp53lmP5+/9moQ==",
+      "dev": true,
+      "requires": {
+        "moment": "2.21.0"
+      }
+    },
     "@types/pify": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@types/pify/-/pify-3.0.0.tgz",
@@ -4226,6 +4246,12 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/module-details-from-path/-/module-details-from-path-1.0.3.tgz",
       "integrity": "sha1-EUyUlnPiqKNenTV4hSeqN7Z52is="
+    },
+    "moment": {
+      "version": "2.21.0",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.21.0.tgz",
+      "integrity": "sha512-TCZ36BjURTeFTM/CwRcViQlfkMvL1/vFISuNLO5GkcVm1+QHfbSiNqZuWeMFjj1/3+uAjXswgRk30j1kkLYJBQ==",
+      "dev": true
     },
     "ms": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "@types/nock": "^9.1.2",
     "@types/node": "^9.4.6",
     "@types/once": "^1.4.0",
+    "@types/pg": "^7.4.5",
     "@types/pify": "^3.0.0",
     "@types/proxyquire": "^1.3.28",
     "@types/request": "^2.0.8",

--- a/src/plugins/plugin-pg.ts
+++ b/src/plugins/plugin-pg.ts
@@ -14,69 +14,181 @@
  * limitations under the License.
  */
 
+import {EventEmitter} from 'events';
 import * as shimmer from 'shimmer';
 import {Readable} from 'stream';
 
 import {Patch, Plugin} from '../plugin-types';
 
-import {pg_6 as pg} from './types';
+import {pg_6, pg_7} from './types';
 
-const SUPPORTED_VERSIONS = '^6.x || ^7.x';
+// TS: Client#query also accepts a callback as a last argument, but TS cannot
+// detect this as it's a dependent type. So we don't specify it here.
+type PG7QueryArguments =
+    [{submit?: Function} & pg_7.QueryConfig]|[string]|[string, {}];
+type PG7QueryReturnValue = (pg_7.QueryConfig&({submit: Function}&EventEmitter)|
+                            pg_7.Query)|Promise<pg_7.QueryResult>;
 
 // tslint:disable-next-line:no-any
 function isSubmittable(obj: any): obj is {submit: Function} {
   return typeof obj.submit === 'function';
 }
 
-const plugin: Plugin = [{
-  file: 'lib/client.js',
-  versions: SUPPORTED_VERSIONS,
-  // TS: Client is a class name.
-  // tslint:disable-next-line:variable-name
-  patch: (Client, api) => {
-    shimmer.wrap(Client.prototype, 'query', (query) => {
-      return function query_trace(this: pg.Client) {
-        const span = api.createChildSpan({name: 'pg-query'});
-        const pgQuery: pg.QueryReturnValue = query.apply(this, arguments);
-        if (!api.isRealSpan(span)) {
-          return pgQuery;
-        }
-        if (api.enhancedDatabaseReportingEnabled()) {
-          if (pgQuery.text) {
-            span.addLabel('query', pgQuery.text);
+const plugin: Plugin = [
+  {
+    file: 'lib/client.js',
+    versions: '^6.x',
+    // TS: Client is a class name.
+    // tslint:disable-next-line:variable-name
+    patch: (Client, api) => {
+      shimmer.wrap(Client.prototype, 'query', (query) => {
+        return function query_trace(this: pg_6.Client) {
+          const span = api.createChildSpan({name: 'pg-query'});
+          const pgQuery: pg_6.QueryReturnValue = query.apply(this, arguments);
+          if (!api.isRealSpan(span)) {
+            return pgQuery;
           }
-          if (pgQuery.values) {
-            span.addLabel('values', pgQuery.values);
-          }
-        }
-        api.wrapEmitter(pgQuery);
-        const done = pgQuery.callback;
-        pgQuery.callback = api.wrap((err, res) => {
           if (api.enhancedDatabaseReportingEnabled()) {
-            if (err) {
-              span.addLabel('error', err);
-            }
-            if (res) {
-              span.addLabel('row_count', res.rowCount);
-              span.addLabel('oid', res.oid);
-              span.addLabel('rows', res.rows);
-              span.addLabel('fields', res.fields);
+            span.addLabel('query', pgQuery.text);
+            if (pgQuery.values) {
+              span.addLabel('values', pgQuery.values);
             }
           }
-          span.endSpan();
-          if (done) {
-            done(err, res);
+          api.wrapEmitter(pgQuery);
+          const done = pgQuery.callback;
+          pgQuery.callback = api.wrap((err, res) => {
+            if (api.enhancedDatabaseReportingEnabled()) {
+              if (err) {
+                span.addLabel('error', err);
+              }
+              if (res) {
+                span.addLabel('row_count', res.rowCount);
+                span.addLabel('oid', res.oid);
+                span.addLabel('rows', res.rows);
+                span.addLabel('fields', res.fields);
+              }
+            }
+            span.endSpan();
+            if (done) {
+              done(err, res);
+            }
+          });
+          return pgQuery;
+        };
+      });
+    },
+    // TS: Client is a class name.
+    // tslint:disable-next-line:variable-name
+    unpatch(Client) {
+      shimmer.unwrap(Client.prototype, 'query');
+    }
+  } as Patch<typeof pg_6.Client>,
+  {
+    file: 'lib/client.js',
+    versions: '^7.x',
+    // TS: Client is a class name.
+    // tslint:disable-next-line:variable-name
+    patch: (Client, api) => {
+      shimmer.wrap(Client.prototype, 'query', (query) => {
+        return function query_trace(this: pg_7.Client) {
+          const span = api.createChildSpan({name: 'pg-query'});
+          if (!api.isRealSpan(span)) {
+            return query.apply(this, arguments);
           }
-        });
-        return pgQuery;
-      };
-    });
-  },
-  // TS: Client is a class name.
-  // tslint:disable-next-line:variable-name
-  unpatch(Client) {
-    shimmer.unwrap(Client.prototype, 'query');
-  }
-} as Patch<typeof pg.Client>];
+          const args: PG7QueryArguments =
+              Array.prototype.slice.call(arguments, 0);
+
+          // In 7.x, the value of pgQuery depends on how the query() was called.
+          // It can be one of:
+          // - (query: pg.Submittable) => EventEmitter
+          //   - Note: return value is the same as the argument.
+          // - ([*], callback: (err, res: pg.Result) => void) => void
+          // - ([*]) => Promise<pg.Result>
+          // where [*] is one of:
+          // - ...[query: { text: string, values?: Array<any> }]
+          // - ...[text: string, values?: Array<any>]
+          // See: https://node-postgres.com/guides/upgrading
+
+          if (args.length >= 1) {
+            // Extract query text and values, if needed.
+            if (api.enhancedDatabaseReportingEnabled()) {
+              const queryObj = args[0];
+              if (typeof queryObj === 'object') {
+                if (queryObj.text) {
+                  span.addLabel('query', queryObj.text);
+                }
+                if (queryObj.values) {
+                  span.addLabel('values', queryObj.values);
+                }
+              } else if (typeof queryObj === 'string') {
+                span.addLabel('query', queryObj);
+                if (args.length >= 2 && typeof args[1] !== 'function') {
+                  span.addLabel('values', args[1]);
+                }
+              }
+            }
+
+            // If we received a callback, bind it to the current context,
+            // optionally adding labels as well.
+            const callback = args[args.length - 1];
+            if (typeof callback === 'function') {
+              args[args.length - 1] = api.wrap((err, res) => {
+                if (api.enhancedDatabaseReportingEnabled()) {
+                  if (err) {
+                    span.addLabel('error', err);
+                  }
+                  if (res) {
+                    span.addLabel('row_count', res.rowCount);
+                    span.addLabel('oid', res.oid);
+                    span.addLabel('rows', res.rows);
+                    span.addLabel('fields', res.fields);
+                  }
+                }
+                span.endSpan();
+                // TS: Type cast is safe as we know that callback is a Function.
+                (callback as (err: Error, res: pg_7.QueryArrayResult) => void)(
+                    err, res);
+              });
+            }
+          }
+
+          let pgQuery: PG7QueryReturnValue = query.apply(this, args);
+          if (pgQuery) {
+            if (pgQuery instanceof EventEmitter) {
+              api.wrapEmitter(pgQuery);
+            } else if (typeof pgQuery.then === 'function') {
+              // Ensure that the span is ended, optionally adding labels as
+              // well.
+              pgQuery = pgQuery.then(
+                  (res) => {
+                    if (api.enhancedDatabaseReportingEnabled()) {
+                      span.addLabel('row_count', res.rowCount);
+                      span.addLabel('oid', res.oid);
+                      span.addLabel('rows', res.rows);
+                      span.addLabel('fields', res.fields);
+                    }
+                    span.endSpan();
+                    return res;
+                  },
+                  (err) => {
+                    if (api.enhancedDatabaseReportingEnabled()) {
+                      span.addLabel('error', err);
+                    }
+                    span.endSpan();
+                    throw err;
+                  });
+            }
+          }
+          return pgQuery;
+        };
+      });
+    },
+    // TS: Client is a class name.
+    // tslint:disable-next-line:variable-name
+    unpatch(Client) {
+      shimmer.unwrap(Client.prototype, 'query');
+    }
+  } as Patch<typeof pg_7.Client>
+];
 
 export = plugin;

--- a/src/plugins/types/index.d.ts
+++ b/src/plugins/types/index.d.ts
@@ -43,7 +43,7 @@ declare namespace pg_6 {
   // https://github.com/brianc/node-postgres/blob/v6.4.2/lib/client.js#L355
   type QueryReturnValue = (
     pg_7.QueryConfig &
-    { callback?: (err: Error, res: pg_7.QueryResult) => void }
+    { callback?: (err: Error|null, res?: pg_7.QueryResult) => void }
   ) & (({ submit: Function } & Readable) | (pg_7.Query & PromiseLike<any>));
 
   class Client {

--- a/src/plugins/types/index.d.ts
+++ b/src/plugins/types/index.d.ts
@@ -2,12 +2,14 @@ import * as connect_3 from 'connect'; // connect@3
 import * as express_4 from 'express'; // express@4
 import * as hapi_16 from 'hapi'; // hapi@16
 import * as koa_2 from 'koa'; // koa@2
+import * as pg_7 from 'pg'; // pg@7
 import * as restify_5 from 'restify'; // restify@5
-
-//---koa@1---//
 
 import { EventEmitter } from 'events';
 import { Server } from 'http';
+import { Readable } from 'stream';
+
+//---koa@1---//
 
 declare class koa_1 extends EventEmitter {
   use(middleware: koa_1.Middleware): this;
@@ -28,6 +30,27 @@ declare namespace koa_1 {
   interface Context extends koa_2.Context {}
 }
 
+//---pg@6---//
+
+declare namespace pg_6 {
+  // PG 6's method signature for Client#query differs from that of PG 7 in that
+  // the return value is either a Submittable if one was passed in, or a
+  // pg.Query object instead. (In PG 6, pg.Query is PromiseLike and contains
+  // values passed in as the query configuration.)
+  //
+  // References:
+  // https://node-postgres.com/guides/upgrading#client-query-on
+  // https://github.com/brianc/node-postgres/blob/v6.4.2/lib/client.js#L355
+  type QueryReturnValue = (
+    pg_7.QueryConfig &
+    { callback?: (err: Error, res: pg_7.QueryResult) => void }
+  ) & (({ submit: Function } & Readable) | (pg_7.Query & PromiseLike<any>));
+
+  class Client {
+    query(...args: any[]): QueryReturnValue;
+  }
+}
+
 //---exports---//
 
 export {
@@ -36,5 +59,7 @@ export {
   hapi_16,
   koa_1,
   koa_2,
+  pg_6,
+  pg_7,
   restify_5
 };

--- a/test/fixtures/plugin-fixtures.json
+++ b/test/fixtures/plugin-fixtures.json
@@ -152,6 +152,11 @@
       "pg": "^6.1.2"
     }
   },
+  "pg7": {
+    "dependencies": {
+      "pg": "^7.4.1"
+    }
+  },
   "redis0.12": {
     "dependencies": {
       "redis": "^0.12.1"

--- a/test/plugins/test-trace-pg.ts
+++ b/test/plugins/test-trace-pg.ts
@@ -16,127 +16,187 @@
 'use strict';
 
 import { TraceLabels } from '../../src/trace-labels';
+import { FORCE_NEW } from '../../src/util';
 
 var common = require('./common'/*.js*/);
 var assert = require('assert');
 
-describe('test-trace-pg', function() {
-  var traceApi;
-  var pool;
-  var client;
-  var releaseClient;
-  before(function() {
-    traceApi = require('../../..').start({
-      projectId: '0',
-      samplingRate: 0,
-      enhancedDatabaseReporting: true
-    });
-    var pg = require('./fixtures/pg6');
-    pool = new pg.Pool(require('../pg-config'/*.js*/));
-  });
+var pgVersions = ['6', '7'];
 
-  beforeEach(function(done) {
-    pool.connect(function(err, c, release) {
-      client = c;
-      releaseClient = release;
-      assert(!err);
-      client.query('CREATE TABLE t (name text NOT NULL, id text NOT NULL)', [],
-          function(err, res) {
+pgVersions.forEach(pgVersion => {
+  describe(`test-trace-pg (v${pgVersion})`, function() {
+    var pg;
+    var traceApi;
+    var pool;
+    var client;
+    var releaseClient;
+    before(function() {
+      traceApi = require('../../..').start({
+        projectId: '0',
+        samplingRate: 0,
+        enhancedDatabaseReporting: true,
+        [FORCE_NEW]: true
+      });
+      pg = require(`./fixtures/pg${pgVersion}`);
+      pool = new pg.Pool(require('../pg-config'/*.js*/));
+    });
+
+    beforeEach(function(done) {
+      pool.connect(function(err, c, release) {
+        client = c;
+        releaseClient = release;
         assert(!err);
+        client.query('CREATE TABLE t (name text NOT NULL, id text NOT NULL)', [],
+            function(err, res) {
+          assert(!err);
+          common.cleanTraces();
+          done();
+        });
+      });
+    });
+
+    afterEach(function(done) {
+      client.query('DROP TABLE t', [], function(err, res) {
+        assert(!err);
+        releaseClient();
         common.cleanTraces();
         done();
       });
     });
-  });
 
-  afterEach(function(done) {
-    client.query('DROP TABLE t', [], function(err, res) {
-      assert(!err);
-      releaseClient();
-      common.cleanTraces();
-      done();
-    });
-  });
-
-  it('should perform basic operations', function(done) {
-    common.runInTransaction(function(endRootSpan) {
-      client.query('INSERT INTO t (name, id) VALUES($1, $2)',
-          ['test_name', 'test_id'], function(err, res) {
-        endRootSpan();
-        assert(!err);
-        var span = common.getMatchingSpan(function (span) {
-          return span.name === 'pg-query';
+    it('should perform basic operations', function(done) {
+      common.runInTransaction(function(endRootSpan) {
+        client.query('INSERT INTO t (name, id) VALUES($1, $2)',
+            ['test_name', 'test_id'], function(err, res) {
+          endRootSpan();
+          assert(!err);
+          var span = common.getMatchingSpan(function (span) {
+            return span.name === 'pg-query';
+          });
+          assert.equal(span.labels.query, 'INSERT INTO t (name, id) VALUES($1, $2)');
+          assert.equal(span.labels.values, '[ \'test_name\', \'test_id\' ]');
+          assert.equal(span.labels.row_count, '1');
+          assert.equal(span.labels.oid, '0');
+          assert.equal(span.labels.rows, '[]');
+          assert.equal(span.labels.fields, '[]');
+          done();
         });
-        assert.equal(span.labels.query, 'INSERT INTO t (name, id) VALUES($1, $2)');
-        assert.equal(span.labels.values, '[ \'test_name\', \'test_id\' ]');
-        assert.equal(span.labels.row_count, '1');
-        assert.equal(span.labels.oid, '0');
-        assert.equal(span.labels.rows, '[]');
-        assert.equal(span.labels.fields, '[]');
-        done();
       });
     });
-  });
 
-  it('should propagate context', function(done) {
-    common.runInTransaction(function(endRootSpan) {
-      client.query('INSERT INTO t (name, id) VALUES($1, $2)',
-          ['test_name', 'test_id'], function(err, res) {
-        assert.ok(common.hasContext());
-        endRootSpan();
-        done();
+    it('should perform basic operations with promises', function(done) {
+      common.runInTransaction(function(endRootSpan) {
+        client.query('INSERT INTO t (name, id) VALUES($1, $2)',
+            ['test_name', 'test_id'])
+          .then((res) => {
+            endRootSpan();
+            var span = common.getMatchingSpan(function (span) {
+              return span.name === 'pg-query';
+            });
+            assert.equal(span.labels.query, 'INSERT INTO t (name, id) VALUES($1, $2)');
+            assert.equal(span.labels.values, '[ \'test_name\', \'test_id\' ]');
+            assert.equal(span.labels.row_count, '1');
+            assert.equal(span.labels.oid, '0');
+            assert.equal(span.labels.rows, '[]');
+            assert.equal(span.labels.fields, '[]');
+            done();
+          }, (err) => {
+            assert.fail('Error not expected');
+          });
       });
     });
-  });
 
-  it('should remove trace frames from stack', function(done) {
-    common.runInTransaction(function(endRootSpan) {
-      client.query('SELECT $1::int AS number', [1], function(err, res) {
-        endRootSpan();
-        assert(!err);
-        var span = common.getMatchingSpan(function (span) {
-          return span.name === 'pg-query';
+    it('should propagate context', function(done) {
+      common.runInTransaction(function(endRootSpan) {
+        client.query('INSERT INTO t (name, id) VALUES($1, $2)',
+            ['test_name', 'test_id'], function(err, res) {
+          assert.ok(common.hasContext());
+          endRootSpan();
+          done();
         });
-        var labels = span.labels;
-        var stackTrace = JSON.parse(labels[TraceLabels.STACK_TRACE_DETAILS_KEY]);
-        // Ensure that our patch is on top of the stack
-        assert(
-          stackTrace.stack_frame[0].method_name.indexOf('query_trace') !== -1);
-        done();
       });
     });
-  });
 
-  it('should work with events', function(done) {
-    common.runInTransaction(function(endRootSpan) {
-      var query = client.query('SELECT $1::int AS number', [1]);
-      query.on('row', function(row) {
-        assert.strictEqual(row.number, 1);
-      });
-      query.on('end', function() {
-        endRootSpan();
-        var span = common.getMatchingSpan(function (span) {
-          return span.name === 'pg-query';
-        });
-        assert.equal(span.labels.query, 'SELECT $1::int AS number');
-        assert.equal(span.labels.values, '[ \'1\' ]');
-        done();
+    it('should propagate context with promises', function(done) {
+      common.runInTransaction(function(endRootSpan) {
+        client.query('INSERT INTO t (name, id) VALUES($1, $2)',
+            ['test_name', 'test_id'])
+          .then((res) => {
+            assert.ok(common.hasContext());
+            endRootSpan();
+            done();
+          });
       });
     });
-  });
 
-  it('should work without events or callback', function(done) {
-    common.runInTransaction(function(endRootSpan) {
-      client.query('SELECT $1::int AS number', [1]);
-      setTimeout(function() {
-        endRootSpan();
-        var span = common.getMatchingSpan(function (span) {
-          return span.name === 'pg-query';
+    it('should remove trace frames from stack', function(done) {
+      common.runInTransaction(function(endRootSpan) {
+        client.query('SELECT $1::int AS number', [1], function(err, res) {
+          endRootSpan();
+          assert(!err);
+          var span = common.getMatchingSpan(function (span) {
+            return span.name === 'pg-query';
+          });
+          var labels = span.labels;
+          var stackTrace = JSON.parse(labels[TraceLabels.STACK_TRACE_DETAILS_KEY]);
+          // Ensure that our patch is on top of the stack
+          assert(
+            stackTrace.stack_frame[0].method_name.indexOf('query_trace') !== -1);
+          done();
         });
-        assert.equal(span.labels.query, 'SELECT $1::int AS number');
-        assert.equal(span.labels.values, '[ \'1\' ]');
-        done();
-      }, 50);
+      });
+    });
+
+    it('should work with events', function(done) {
+      common.runInTransaction(function(endRootSpan) {
+        var query = client.query(new pg.Query('SELECT $1::int AS number', [1]));
+        query.on('row', function(row) {
+          assert.strictEqual(row.number, 1);
+        });
+        query.on('end', function() {
+          endRootSpan();
+          var span = common.getMatchingSpan(function (span) {
+            return span.name === 'pg-query';
+          });
+          assert.equal(span.labels.query, 'SELECT $1::int AS number');
+          assert.equal(span.labels.values, '[ 1 ]');
+          done();
+        });
+      });
+    });
+
+    it('should work with generic Submittables', function(done) {
+      common.runInTransaction(function(endRootSpan) {
+        let submitCalled = false;
+        client.query({
+          submit: (connection) => {
+            // Indicate that the next item may be processed.
+            connection.emit('readyForQuery');
+            submitCalled = true;
+            endRootSpan();
+            common.getMatchingSpan(function (span) {
+              return span.name === 'pg-query';
+            });
+            done();
+          },
+          handleReadyForQuery: () => {}
+        });
+      });
+    });
+
+    it('should work without events or callback', function(done) {
+      common.runInTransaction(function(endRootSpan) {
+        client.query('SELECT $1::int AS number', [1]);
+        setTimeout(function() {
+          endRootSpan();
+          var span = common.getMatchingSpan(function (span) {
+            return span.name === 'pg-query';
+          });
+          assert.equal(span.labels.query, 'SELECT $1::int AS number');
+          assert.equal(span.labels.values, '[ 1 ]');
+          done();
+        }, 50);
+      });
     });
   });
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,6 +15,7 @@
     "src/plugins/plugin-http2.ts",
     "src/plugins/plugin-https.ts",
     "src/plugins/plugin-koa.ts",
+    "src/plugins/plugin-pg.ts",
     "src/plugins/plugin-restify.ts",
     "test/plugins/test-trace-google-gax.ts",
     "test/plugins/test-trace-http2.ts",


### PR DESCRIPTION
This PR converts the PostGreSQL tracing plugin to TypeScript, makes changes to support the new API in pg@7, adds a few more tests, and changes the way `value` labels are collected.

* **chore: add pg7 to test fixtures**
  * This changes a JSON file that specifies the list of modules to be installed as test fixtures, adding `pg@7`.
* **refactor: port plugin-pg to typescript**
  * This converts `plugin-pg.ts` to ES6 + type annotations, and installs `pg@7` types. There should be no behavioral change.
* **fix: add support for pg 7**
  * This adds a patch for `pg@7`, based on [source code](https://github.com/brianc/node-postgres) and the [upgrade guide](https://node-postgres.com/guides/upgrading).
  * __Differences in a nutshell__
    * In `pg@6`, an object is _always_ returned by `Client#query`, and is simultaneously a `Promise[Like]`, an `EventEmitter`, and an object `{ text: string; values?: Array, callback?: Function }`.
    * In `pg@7`, the return value of `Client#query` is _either_ a `Promise`, `EventEmitter`, _or_ `undefined`, depending on the input parameters.
* **fix: get pg 6 query values before call**
  * Currently, we get query `values` from the output object of `Client#query`; in `pg@7`, these fields are not guaranteed to exist, so we must gather them from input parameters instead. However, there is a mismatch between `values` gotten from input and output; output `values` are coerced to strings and escaped to avoid SQL injection. So to keep things consistent, we now _also_ get `values` from the inputs to `Client#query` in `pg@6`. (I don't think that these values being unescaped should pose a threat because their values are simply stored, not executed; feel free to dispute that.)
* **test: modify tests**
  * Modify tests to support both v6 and v7, and also add new test cases for previously uncovered scenarios: promises and generic `Submittable`s. _Converting this test to idiomatic TypeScript is out of the scope of this PR._