### PR TITLE
test: privatize forceNewAgent_

### DIFF
--- a/src/trace-plugin-loader.ts
+++ b/src/trace-plugin-loader.ts
@@ -43,14 +43,6 @@ export interface PluginLoaderConfig extends TraceAgentConfig {
   plugins: {[pluginName: string]: string};
 }
 
-/**
- * An interface representing configuration passed to the plugin loader, which
- * includes TraceAgent configuration as well.
- */
-export interface PluginLoaderSingletonConfig extends PluginLoaderConfig {
-  forceNewAgent_: boolean;
-}
-
 export interface ModulePluginWrapperOptions {
   name: string;
   path: string;

--- a/src/util.ts
+++ b/src/util.ts
@@ -50,6 +50,10 @@ export interface Constructor<T, Config> {
   name: string;
 }
 
+export const FORCE_NEW = Symbol();
+
+export type Forceable<T> = T&{[FORCE_NEW]?: boolean};
+
 /**
  * A class that provides access to a singleton.
  * We assume that any such singleton is always constructed with two arguments:
@@ -62,8 +66,8 @@ export class Singleton<T, Config> {
 
   constructor(private implementation: Constructor<T, Config>) {}
 
-  create(logger: Logger, config: Config&{forceNewAgent_?: boolean}): T {
-    if (!this[kSingleton] || config.forceNewAgent_) {
+  create(logger: Logger, config: Forceable<Config>): T {
+    if (!this[kSingleton] || config[FORCE_NEW]) {
       this[kSingleton] = new this.implementation(logger, config);
       return this[kSingleton]!;
     } else {

--- a/src/util.ts
+++ b/src/util.ts
@@ -50,7 +50,7 @@ export interface Constructor<T, Config> {
   name: string;
 }
 
-export const FORCE_NEW = Symbol();
+export const FORCE_NEW = Symbol('force-new');
 
 export type Forceable<T> = T&{[FORCE_NEW]?: boolean};
 

--- a/test/plugins/test-trace-generic-pool.ts
+++ b/test/plugins/test-trace-generic-pool.ts
@@ -15,6 +15,8 @@
  */
 'use strict';
 
+import {FORCE_NEW} from '../../src/util';
+
 var assert = require('assert');
 var common = require('./common');
 var semver = require('semver');
@@ -30,7 +32,7 @@ describe('generic-pool2', function() {
     api = require('../../..').start({
       projectId: '0',
       samplingRate: 0,
-      forceNewAgent_: true
+      [FORCE_NEW]: true
     });
     genericPool = require('./fixtures/generic-pool2');
   });
@@ -89,7 +91,7 @@ describe('generic-pool3', function() {
     agent = require('../../..').start({
       projectId: '0',
       samplingRate: 0,
-      forceNewAgent_: true
+      [FORCE_NEW]: true
     });
     genericPool = require('./fixtures/generic-pool3');
   });

--- a/test/plugins/test-trace-grpc.ts
+++ b/test/plugins/test-trace-grpc.ts
@@ -23,6 +23,7 @@ import * as util from '../../src/util';
 import * as assert from 'assert';
 import { asBaseSpanData } from '../utils';
 import { SpanData } from '../../src/plugin-types';
+import { FORCE_NEW } from '../../src/util';
 
 var shimmer = require('shimmer');
 var common = require('./common'/*.js*/);
@@ -285,7 +286,7 @@ Object.keys(versions).forEach(function(version) {
         projectId: '0',
         samplingRate: 0,
         enhancedDatabaseReporting: true,
-        forceNewAgent_: true
+        [FORCE_NEW]: true
       });
 
       grpc = require(versions[version]);

--- a/test/test-config-credentials.ts
+++ b/test/test-config-credentials.ts
@@ -19,6 +19,7 @@ import * as nock from 'nock';
 import {disableNetConnect, enableNetConnect} from 'nock';
 import * as path from 'path';
 
+import {FORCE_NEW} from '../src/util';
 import {oauth2, patchTraces} from './nocks';
 import * as trace from './trace';
 import {plan} from './utils';
@@ -64,7 +65,7 @@ describe('Credentials Configuration', () => {
     const config = {
       bufferSize: 2,
       keyFilename: path.join('test', 'fixtures', 'gcloud-credentials.json'),
-      forceNewAgent_: true
+      [FORCE_NEW]: true
     };
     const agent = trace.start(config);
     const scope = oauth2<TestCredentials>((body) => {
@@ -87,7 +88,7 @@ describe('Credentials Configuration', () => {
     const progress = plan(done, 2);
     const credentials: TestCredentials =
         require('./fixtures/gcloud-credentials.json');
-    const config = {bufferSize: 2, credentials, forceNewAgent_: true};
+    const config = {bufferSize: 2, credentials, [FORCE_NEW]: true};
     const agent = trace.start(config);
     const scope = oauth2<TestCredentials>((body) => {
       assert.strictEqual(body.client_id, credentials.client_id);
@@ -117,7 +118,7 @@ describe('Credentials Configuration', () => {
       bufferSize: 2,
       credentials: correctCredentials,
       keyFilename: path.join('test', 'fixtures', 'gcloud-credentials.json'),
-      forceNewAgent_: true
+      [FORCE_NEW]: true
     };
     const agent = trace.start(config);
     const scope = oauth2<TestCredentials>((body) => {

--- a/test/test-config-max-label-size.ts
+++ b/test/test-config-max-label-size.ts
@@ -18,19 +18,20 @@
 
 import { Constants } from '../src/constants';
 import { traceWriter } from '../src/trace-writer';
+import { FORCE_NEW } from '../src/util';
 
 var assert = require('assert');
 var trace = require('../..');
 
 describe('maximumLabelValueSize configuration', function() {
   it('should not allow values above server maximum', function() {
-    trace.start({forceNewAgent_: true, maximumLabelValueSize: 1000000});
+    trace.start({[FORCE_NEW]: true, maximumLabelValueSize: 1000000});
     var valueMax = traceWriter.get().getConfig().maximumLabelValueSize;
     assert.strictEqual(valueMax, Constants.TRACE_SERVICE_LABEL_VALUE_LIMIT);
   });
 
   it('should not modify values below server maximum', function() {
-    trace.start({forceNewAgent_: true, maximumLabelValueSize: 10});
+    trace.start({[FORCE_NEW]: true, maximumLabelValueSize: 10});
     var valueMax = traceWriter.get().getConfig().maximumLabelValueSize;
     assert.strictEqual(valueMax, 10);
   });

--- a/test/test-env-log-level.ts
+++ b/test/test-env-log-level.ts
@@ -16,6 +16,8 @@
 
 'use strict';
 
+import {FORCE_NEW} from '../src/util';
+
 var assert = require('assert');
 var gcloudCommon = require('@google-cloud/common');
 var shimmer = require('shimmer');
@@ -47,21 +49,21 @@ describe('should respect environment variables', function() {
   });
 
   it('should respect GCLOUD_TRACE_LOGLEVEL', function() {
-    trace.start({forceNewAgent_: true});
+    trace.start({[FORCE_NEW]: true});
     assert.strictEqual(logLevel, gcloudCommon.logger.LEVELS[4]);
   });
 
   it('should prefer env to config', function() {
-    trace.start({logLevel: 2, forceNewAgent_: true});
+    trace.start({logLevel: 2, [FORCE_NEW]: true});
     assert.strictEqual(logLevel, gcloudCommon.logger.LEVELS[4]);
   });
 
   it('should fix out of bounds log level', function() {
     process.env.GCLOUD_TRACE_LOGLEVEL = '-5';
-    trace.start({forceNewAgent_: true});
+    trace.start({[FORCE_NEW]: true});
     assert.strictEqual(logLevel, gcloudCommon.logger.LEVELS[0]);
     process.env.GCLOUD_TRACE_LOGLEVEL = '300';
-    trace.start({forceNewAgent_: true});
+    trace.start({[FORCE_NEW]: true});
     assert.strictEqual(logLevel, gcloudCommon.logger.LEVELS[5]);
   });
 });

--- a/test/test-env-project-id.ts
+++ b/test/test-env-project-id.ts
@@ -16,6 +16,8 @@
 
 'use strict';
 
+import {FORCE_NEW} from '../src/util';
+
 process.env.GCLOUD_PROJECT = '1729';
 
 var trace = require('../..');
@@ -24,12 +26,12 @@ var assert = require('assert');
 
 describe('should respect environment variables', function() {
   it('should respect GCLOUD_PROJECT', function() {
-    var agent = trace.start({forceNewAgent_: true});
+    var agent = trace.start({[FORCE_NEW]: true});
     assert.equal(agent.config.projectId, 1729);
   });
 
   it('should prefer env to config', function() {
-    var agent = trace.start({projectId: 1927, forceNewAgent_: true});
+    var agent = trace.start({projectId: 1927, [FORCE_NEW]: true});
     assert.equal(agent.config.projectId, 1729);
   });
 });

--- a/test/test-index.ts
+++ b/test/test-index.ts
@@ -19,6 +19,7 @@
 import './override-gcp-metadata';
 import { TraceAgent } from '../src/trace-api';
 import { SpanDataType } from '../src/constants';
+import { FORCE_NEW } from '../src/util';
 
 var assert = require('assert');
 var nock = require('nock');
@@ -49,7 +50,7 @@ describe('index.js', function() {
   describe('in valid environment', function() {
     var agent;
     before(function() {
-      agent = trace.start({ projectId: '0', forceNewAgent_: true });
+      agent = trace.start({ projectId: '0', [FORCE_NEW]: true });
     });
 
     it('should get the agent with `Trace.get`', function() {
@@ -74,7 +75,7 @@ describe('index.js', function() {
                 .get('/computeMetadata/v1/project/project-id')
                 .times(1)
                 .reply(404, 'foo');
-    var agent = trace.start({logLevel: 0, forceNewAgent_: true});
+    var agent = trace.start({logLevel: 0, [FORCE_NEW]: true});
     setTimeout(function() {
       assert.ok(!agent.isActive());
       scope.done();
@@ -91,7 +92,7 @@ describe('index.js', function() {
     nocks.hostname(function() { return 'host1'; });
     nocks.instanceId(function() { return 'instance1'; });
 
-    var agent = trace.start({logLevel: 0, forceNewAgent_: true});
+    var agent = trace.start({logLevel: 0, [FORCE_NEW]: true});
 
     setTimeout(function() {
       assert.strictEqual(agent.getWriterProjectId(), 'project1');

--- a/test/test-invalid-project-id.ts
+++ b/test/test-invalid-project-id.ts
@@ -16,6 +16,8 @@
 
 'use strict';
 
+import {FORCE_NEW} from '../src/util';
+
 delete process.env.GCLOUD_PROJECT;
 
 var assert = require('assert');
@@ -26,7 +28,7 @@ describe('index.js', function() {
       projectId: {test: false},
       enabled: true,
       logLevel: 0,
-      forceNewAgent_: true
+      [FORCE_NEW]: true
     });
     assert(!agent.isActive());
   });

--- a/test/test-no-self-tracing.ts
+++ b/test/test-no-self-tracing.ts
@@ -16,6 +16,8 @@
 
 'use strict';
 
+import {FORCE_NEW} from '../src/util';
+
 var assert = require('assert');
 var nock = require('nock');
 var newWarn = function(error) {
@@ -35,7 +37,7 @@ describe('test-no-self-tracing', function() {
                 .get('/computeMetadata/v1/instance/hostname').reply(200)
                 .get('/computeMetadata/v1/instance/id').reply(200)
                 .get('/computeMetadata/v1/project/project-id').reply(200);
-    require('../..').start({forceNewAgent_: true});
+    require('../..').start({[FORCE_NEW]: true});
     require('http'); // Must require http to force patching of the module
     var oldWarn = common.replaceWarnLogger(newWarn);
     setTimeout(function() {
@@ -54,7 +56,7 @@ describe('test-no-self-tracing', function() {
     require('../..').start({
       projectId: '0',
       bufferSize: 1,
-      forceNewAgent_: true
+      [FORCE_NEW]: true
     });
     common.avoidTraceWriterAuth();
     require('http'); // Must require http to force patching of the module

--- a/test/test-trace-api.ts
+++ b/test/test-trace-api.ts
@@ -22,6 +22,7 @@ import { defaultConfig } from '../src/config';
 import { TraceAgent } from '../src/trace-api';
 import { traceWriter } from '../src/trace-writer';
 import * as TracingPolicy from '../src/tracing-policy';
+import { FORCE_NEW } from '../src/util';
 import { asBaseSpanData } from './utils';
 import { SpanDataType } from '../src/constants';
 
@@ -76,7 +77,7 @@ describe('Trace Interface', function() {
     traceWriter.create(logger,
       Object.assign(defaultConfig, {
         projectId: '0',
-        forceNewAgent_: false
+        [FORCE_NEW]: false
       })).initialize(function(err) {
         assert.ok(!err);
         done();

--- a/test/test-trace-writer.ts
+++ b/test/test-trace-writer.ts
@@ -18,6 +18,7 @@
 
 // Loading this file patches gcpMetadata so requests don't time out.
 import './override-gcp-metadata';
+import {FORCE_NEW} from '../src/util';
 import { Trace, SpanKind } from '../src/trace';
 import { TraceLabels } from '../src/trace-labels';
 import { traceWriter, TraceWriter, TraceWriterConfig } from '../src/trace-writer';
@@ -29,7 +30,7 @@ var nocks = require('./nocks'/*.js*/);
 var os = require('os');
 var Service = require('@google-cloud/common').Service;
 
-type createTraceWriterOptions = TraceWriterConfig & { forceNewAgent_: boolean };
+type createTraceWriterOptions = TraceWriterConfig & { [FORCE_NEW]: boolean };
 
 interface TestCase {
   description: string,
@@ -80,7 +81,7 @@ describe('TraceWriter', function() {
       projectId: 'fake project',
       serviceContext: {},
       onUncaughtException: 'ignore',
-      forceNewAgent_: true
+      [FORCE_NEW]: true
     } as createTraceWriterOptions);
     assert.ok(writer instanceof Service);
   });
@@ -93,7 +94,7 @@ describe('TraceWriter', function() {
       projectId: '0',
       serviceContext: {},
       onUncaughtException: 'ignore',
-      forceNewAgent_: true
+      [FORCE_NEW]: true
     } as createTraceWriterOptions);
     // Mocha attaches 1 exception handler
     assert.equal(process.listeners('uncaughtException').length, numListenersBeforeTraceWriter);
@@ -106,7 +107,7 @@ describe('TraceWriter', function() {
         bufferSize: 4,
         serviceContext: {},
         onUncaughtException: 'ignore',
-        forceNewAgent_: true
+        [FORCE_NEW]: true
       } as createTraceWriterOptions);
       writer.initialize(function() {
         var spanData = createFakeTrace('fake span');
@@ -137,7 +138,7 @@ describe('TraceWriter', function() {
         credentials: fakeCredentials,
         serviceContext: {},
         onUncaughtException: 'ignore',
-        forceNewAgent_: true
+        [FORCE_NEW]: true
       } as createTraceWriterOptions);
       writer.publish('{"valid": "json"}');
       setTimeout(function() {
@@ -157,7 +158,7 @@ describe('TraceWriter', function() {
         credentials: fakeCredentials,
         serviceContext: {},
         onUncaughtException: 'ignore',
-        forceNewAgent_: true
+        [FORCE_NEW]: true
       } as createTraceWriterOptions);
       writer.publish(JSON.stringify(MESSAGE));
       setTimeout(function() {
@@ -176,7 +177,7 @@ describe('TraceWriter', function() {
         flushDelaySeconds: 3600,
         serviceContext: {},
         onUncaughtException: 'ignore',
-        forceNewAgent_: true
+        [FORCE_NEW]: true
       } as createTraceWriterOptions);
       writer.publish = function() { done(); };
       for (var i = 0; i < 4; i++) {
@@ -191,7 +192,7 @@ describe('TraceWriter', function() {
         flushDelaySeconds: 0.01,
         serviceContext: {},
         onUncaughtException: 'ignore',
-        forceNewAgent_: true
+        [FORCE_NEW]: true
       } as createTraceWriterOptions);
       writer.publish = function() { published = true; };
       writer.initialize(function() {
@@ -326,7 +327,7 @@ describe('TraceWriter', function() {
         }
 
         traceWriter.create(fakeLogger, Object.assign({
-          forceNewAgent_: true,
+          [FORCE_NEW]: true,
           onUncaughtException: 'ignore',
           serviceContext: {}
         }, testCase.config)).initialize(function(err) {

--- a/test/test-unpatch.ts
+++ b/test/test-unpatch.ts
@@ -17,6 +17,7 @@
 'use strict';
 
 import './override-gcp-metadata';
+import {FORCE_NEW} from '../src/util';
 
 var assert = require('assert');
 var nock = require('nock');
@@ -43,7 +44,7 @@ describe('index.js', function() {
     // Set things up so that the trace agent won't be able to get a project id,
     // and stop.
     scope = nocks.projectId(404);
-    agent = trace.start({ forceNewAgent_: true });
+    agent = trace.start({ [FORCE_NEW]: true });
   });
 
   afterEach(function(done) {

--- a/test/test-util.ts
+++ b/test/test-util.ts
@@ -54,13 +54,12 @@ describe('Singleton', () => {
       assert.throws(() => singleton.create(logger, {}));
     });
 
-    it('creates a new instance when forceNewAgent_ is true in the config',
-       () => {
-         const singleton = new util.Singleton(MyClass);
-         const createResult1 = singleton.create(logger, {});
-         const createResult2 = singleton.create(logger, {forceNewAgent_: true});
-         assert.notStrictEqual(createResult1, createResult2);
-       });
+    it('creates a new instance when [FORCE_NEW] is true in the config', () => {
+      const singleton = new util.Singleton(MyClass);
+      const createResult1 = singleton.create(logger, {});
+      const createResult2 = singleton.create(logger, {[util.FORCE_NEW]: true});
+      assert.notStrictEqual(createResult1, createResult2);
+    });
   });
 
   describe('get', () => {
@@ -78,7 +77,7 @@ describe('Singleton', () => {
     it('does not return a stale value', () => {
       const singleton = new util.Singleton(MyClass);
       singleton.create(logger, {});
-      const createResult = singleton.create(logger, {forceNewAgent_: true});
+      const createResult = singleton.create(logger, {[util.FORCE_NEW]: true});
       const getResult = singleton.get();
       assert.strictEqual(getResult, createResult);
     });

--- a/test/trace.ts
+++ b/test/trace.ts
@@ -48,6 +48,7 @@ import {RootSpanData} from '../src/span-data';
 import {Trace, TraceSpan} from '../src/trace';
 import {PluginLoader, pluginLoader, PluginLoaderConfig} from '../src/trace-plugin-loader';
 import {LabelObject, TraceWriter, traceWriter, TraceWriterConfig} from '../src/trace-writer';
+import {FORCE_NEW} from '../src/util';
 
 import {TestLogger} from './logger';
 
@@ -86,7 +87,7 @@ export type Predicate<T> = (value: T) => boolean;
 
 export function start(projectConfig?: Config): PluginTypes.TraceAgent {
   const agent = trace.start(Object.assign(
-      {samplingRate: 0, logLevel: 4, forceNewAgent_: true}, projectConfig));
+      {samplingRate: 0, logLevel: 4, [FORCE_NEW]: true}, projectConfig));
   return agent;
 }
 


### PR DESCRIPTION
This PR makes the flag to re-create a new instance of a singleton (or the Trace Agent as a whole) a module-private symbol `util#FORCE_NEW`. Beyond hiding this from the public API, this symbol's name now more accurately describes its general role of forcing the creation of a new singleton.

Besides replacing `forceNewAgent_` occurrences with the symbol, there are no other logical changes.