### PR TITLE
feat: hapi 17 tracing support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,70 +29,17 @@
         "through2": "2.0.3"
       }
     },
-    "@types/accepts": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/@types/accepts/-/accepts-1.3.5.tgz",
-      "integrity": "sha512-jOdnI/3qTpHABjM5cx1Hc0sKsPoYCp+DP/GJRGtDlPd7fiV9oXGGIcjW/ZOxLIvjGz8MA+uMZI9metHlgqbgwQ==",
-      "dev": true,
-      "requires": {
-        "@types/node": "9.4.6"
-      }
-    },
-    "@types/body-parser": {
-      "version": "1.16.8",
-      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.16.8.tgz",
-      "integrity": "sha512-BdN2PXxOFnTXFcyONPW6t0fHjz2fvRZHVMFpaS0wYr+Y8fWEaNOs4V8LEu/fpzQlMx+ahdndgTaGTwPC+J/EeA==",
-      "dev": true,
-      "requires": {
-        "@types/express": "4.11.1",
-        "@types/node": "9.4.6"
-      }
-    },
-    "@types/boom": {
-      "version": "4.3.9",
-      "resolved": "https://registry.npmjs.org/@types/boom/-/boom-4.3.9.tgz",
-      "integrity": "sha512-hOMq8gOURXfWAoPCGkAcQVRV1JitzZylAGvNJeu5wkSWIErWK22ZPGaHlScF+OQZqBKVpEunJA3pzBl0qaM9PQ==",
-      "dev": true
-    },
     "@types/builtin-modules": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@types/builtin-modules/-/builtin-modules-2.0.0.tgz",
       "integrity": "sha512-PqWStSS9WSjbJwG62v3AG+hjBdd1zDbQsclXOL+9CRV8nvXwRWv48cZDlSj/mR05Nk/69LV7Ca2onJBi3z2/wA==",
       "dev": true
     },
-    "@types/bunyan": {
-      "version": "1.8.4",
-      "resolved": "https://registry.npmjs.org/@types/bunyan/-/bunyan-1.8.4.tgz",
-      "integrity": "sha512-bxOF3fsm69ezKxdcJ7Oo/PsZMOJ+JIV/QJO2IADfScmR3sLulR88dpSnz6+q+9JJ1kD7dXFFgUrGRSKHLkOX7w==",
-      "dev": true,
-      "requires": {
-        "@types/events": "1.2.0",
-        "@types/node": "9.4.6"
-      }
-    },
     "@types/caseless": {
       "version": "0.12.1",
       "resolved": "https://registry.npmjs.org/@types/caseless/-/caseless-0.12.1.tgz",
       "integrity": "sha512-FhlMa34NHp9K5MY1Uz8yb+ZvuX0pnvn3jScRSNAb75KHGB8d3rEU6hqMs3Z2vjuytcMfRg6c5CHMc3wtYyD2/A==",
       "dev": true
-    },
-    "@types/catbox": {
-      "version": "7.1.6",
-      "resolved": "https://registry.npmjs.org/@types/catbox/-/catbox-7.1.6.tgz",
-      "integrity": "sha512-xcLIJdHkkqB6dyclgvFee8GjfeVYzTJAoFiOZlAnZ9R5mv/8VCnUuaQ4z/v3GrlKUL4j9YEbhOimtFawGBe4ng==",
-      "dev": true,
-      "requires": {
-        "@types/boom": "4.3.9"
-      }
-    },
-    "@types/connect": {
-      "version": "3.4.31",
-      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.31.tgz",
-      "integrity": "sha512-OPSxsP6XqA3984KWDUXq/u05Hu8VWa/2rUVlw/aDUOx87BptIep6xb3NdCxCpKLfLdjZcCE5jR+gouTul3gjdA==",
-      "dev": true,
-      "requires": {
-        "@types/node": "9.4.6"
-      }
     },
     "@types/continuation-local-storage": {
       "version": "3.2.1",
@@ -103,44 +50,11 @@
         "@types/node": "9.4.6"
       }
     },
-    "@types/cookies": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/@types/cookies/-/cookies-0.7.1.tgz",
-      "integrity": "sha512-ku6IvbucEyuC6i4zAVK/KnuzWNXdbFd1HkXlNLg/zhWDGTtQT5VhumiPruB/BHW34PWVFwyfwGftDQHfWNxu3Q==",
-      "dev": true,
-      "requires": {
-        "@types/connect": "3.4.31",
-        "@types/express": "4.11.1",
-        "@types/keygrip": "1.0.1",
-        "@types/node": "9.4.6"
-      }
-    },
     "@types/events": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@types/events/-/events-1.2.0.tgz",
       "integrity": "sha512-KEIlhXnIutzKwRbQkGWb/I4HFqBuUykAdHgDED6xqwXJfONCjF5VoE0cXEiurh3XauygxzeDzgtXUqvLkxFzzA==",
       "dev": true
-    },
-    "@types/express": {
-      "version": "4.11.1",
-      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.11.1.tgz",
-      "integrity": "sha512-ttWle8cnPA5rAelauSWeWJimtY2RsUf2aspYZs7xPHiWgOlPn6nnUfBMtrkcnjFJuIHJF4gNOdVvpLK2Zmvh6g==",
-      "dev": true,
-      "requires": {
-        "@types/body-parser": "1.16.8",
-        "@types/express-serve-static-core": "4.11.1",
-        "@types/serve-static": "1.13.1"
-      }
-    },
-    "@types/express-serve-static-core": {
-      "version": "4.11.1",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.11.1.tgz",
-      "integrity": "sha512-EehCl3tpuqiM8RUb+0255M8PhhSwTtLfmO7zBBdv0ay/VTd/zmrqDfQdZFsa5z/PVMbH2yCMZPXsnrImpATyIw==",
-      "dev": true,
-      "requires": {
-        "@types/events": "1.2.0",
-        "@types/node": "9.4.6"
-      }
     },
     "@types/extend": {
       "version": "3.0.0",
@@ -168,65 +82,10 @@
         "@types/node": "9.4.6"
       }
     },
-    "@types/hapi": {
-      "version": "16.1.14",
-      "resolved": "https://registry.npmjs.org/@types/hapi/-/hapi-16.1.14.tgz",
-      "integrity": "sha512-VeWocvlYrFINg4ZloxSPkg9qtd9aHMkH1Lt4bPqguSLSTrd51D67tcz8+crhsWsClViTylB6deRatxZzOnly7g==",
-      "dev": true,
-      "requires": {
-        "@types/boom": "4.3.9",
-        "@types/catbox": "7.1.6",
-        "@types/events": "1.2.0",
-        "@types/joi": "13.0.5",
-        "@types/mimos": "3.0.1",
-        "@types/node": "9.4.6",
-        "@types/podium": "1.0.0",
-        "@types/shot": "3.4.0"
-      }
-    },
-    "@types/http-assert": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@types/http-assert/-/http-assert-1.2.2.tgz",
-      "integrity": "sha512-x1553BFcgBVOD6y3tC/2SOVcNaf6b9eH3BvqniAZZwmHWYhyr8ffXTYygQC/hQxNI4Yfc3q0gGUvyiAHV4tRNg==",
-      "dev": true
-    },
     "@types/is": {
-      "version": "0.0.18",
-      "resolved": "https://registry.npmjs.org/@types/is/-/is-0.0.18.tgz",
-      "integrity": "sha512-A7PSzJyDwKbkJ3kvM0gfs9daFyiCwvrSmzA5ToFW1rporicAKgrpZsZJifQQob/QvMwEbwi3zF2o/Lw8K3frxw==",
-      "dev": true
-    },
-    "@types/joi": {
-      "version": "13.0.5",
-      "resolved": "https://registry.npmjs.org/@types/joi/-/joi-13.0.5.tgz",
-      "integrity": "sha512-xhGKDKk8qEK35GFYIkpQXdS03PnL+1eXt8VOHnuvuMOjNCztmTpqiDk2vlDy3GbSctSTBJCkY0PXkaRVJpl2xA==",
-      "dev": true
-    },
-    "@types/keygrip": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@types/keygrip/-/keygrip-1.0.1.tgz",
-      "integrity": "sha1-/1QEYtL7TQqIRBzq8n0oewHD2Hg=",
-      "dev": true
-    },
-    "@types/koa": {
-      "version": "2.0.44",
-      "resolved": "https://registry.npmjs.org/@types/koa/-/koa-2.0.44.tgz",
-      "integrity": "sha512-xOg6XLJdKmYriExAF0pV+HYhzftNJbpxplJgjyCwEM2LNLQPMgW4uSHXjgsqSPKsaAgM8CiR31vIeocRibFSjw==",
-      "dev": true,
-      "requires": {
-        "@types/accepts": "1.3.5",
-        "@types/cookies": "0.7.1",
-        "@types/events": "1.2.0",
-        "@types/http-assert": "1.2.2",
-        "@types/keygrip": "1.0.1",
-        "@types/koa-compose": "3.2.2",
-        "@types/node": "9.4.6"
-      }
-    },
-    "@types/koa-compose": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/@types/koa-compose/-/koa-compose-3.2.2.tgz",
-      "integrity": "sha1-3BBuAAu/kqOskA91bfRzRIh+6Ec=",
+      "version": "0.0.19",
+      "resolved": "https://registry.npmjs.org/@types/is/-/is-0.0.19.tgz",
+      "integrity": "sha512-OfsDEdzuxfkNXIlAd55eBFCag+I82Ex4jt5s4mOdVS1DHeXaB/zMdgbllTt62qRNCpdypkP36ROj4tUXJTvbZQ==",
       "dev": true
     },
     "@types/methods": {
@@ -234,27 +93,6 @@
       "resolved": "https://registry.npmjs.org/@types/methods/-/methods-1.1.0.tgz",
       "integrity": "sha512-ROomEm+QHlUmcQoDr3CBo3GRm0w4PVoFYjVT9YcfyBha/Per4deb1IpvHU7KTK7YBZCIvOYbSADoEyDnFgaWLA==",
       "dev": true
-    },
-    "@types/mime": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-2.0.0.tgz",
-      "integrity": "sha512-A2TAGbTFdBw9azHbpVd+/FkdW2T6msN1uct1O9bH3vTerEHKZhTXJUQXy+hNq1B0RagfU8U+KBdqiZpxjhOUQA==",
-      "dev": true
-    },
-    "@types/mime-db": {
-      "version": "1.27.0",
-      "resolved": "https://registry.npmjs.org/@types/mime-db/-/mime-db-1.27.0.tgz",
-      "integrity": "sha1-m8AUof0f30dknBpUxt15ZrgoR5I=",
-      "dev": true
-    },
-    "@types/mimos": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@types/mimos/-/mimos-3.0.1.tgz",
-      "integrity": "sha512-MATIRH4VMIJki8lcYUZdNQEHuAG7iQ1FWwoLgxV+4fUOly2xZYdhHtGgvQyWiTeJqq2tZbE0nOOgZD6pR0FpNQ==",
-      "dev": true,
-      "requires": {
-        "@types/mime-db": "1.27.0"
-      }
     },
     "@types/minimatch": {
       "version": "3.0.3",
@@ -298,36 +136,10 @@
       "integrity": "sha512-cnEvTAVVRqF6OQg/4SLnbxQ0slZJHqZQDve5BzGhcIQtuMpPv8T5QNS2cBPa/W0jTxciqwn7bmJAIGe/bOJ5Kw==",
       "dev": true
     },
-    "@types/pg": {
-      "version": "7.4.5",
-      "resolved": "https://registry.npmjs.org/@types/pg/-/pg-7.4.5.tgz",
-      "integrity": "sha512-DV9A1X9duAnZrF+ANT9i7Z3k+49Dfl96hJlmpz8KCZtBaB7ck3eaAX/37P/vOtpb1VBS5C7xfYI1oRnAfL71DQ==",
-      "dev": true,
-      "requires": {
-        "@types/events": "1.2.0",
-        "@types/node": "9.4.6",
-        "@types/pg-types": "1.11.4"
-      }
-    },
-    "@types/pg-types": {
-      "version": "1.11.4",
-      "resolved": "https://registry.npmjs.org/@types/pg-types/-/pg-types-1.11.4.tgz",
-      "integrity": "sha512-WdIiQmE347LGc1Vq3Ki8sk3iyCuLgnccqVzgxek6gEHp2H0p3MQ3jniIHt+bRODXKju4kNQ+mp53lmP5+/9moQ==",
-      "dev": true,
-      "requires": {
-        "moment": "2.21.0"
-      }
-    },
     "@types/pify": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@types/pify/-/pify-3.0.0.tgz",
       "integrity": "sha512-BIRcpFqRm64rVuuYCFzOF37I2IEP3sXhiCjy8NbzJkxqFY2CLiDLFPhh6Sph/eXPXctg05MayCEDmeKCOIUBFg==",
-      "dev": true
-    },
-    "@types/podium": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@types/podium/-/podium-1.0.0.tgz",
-      "integrity": "sha1-v6ohUb4rHWEJzGn3+qnawsujuyA=",
       "dev": true
     },
     "@types/proxyquire": {
@@ -348,56 +160,17 @@
         "@types/tough-cookie": "2.3.2"
       }
     },
-    "@types/restify": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/@types/restify/-/restify-5.0.7.tgz",
-      "integrity": "sha512-0bcMA32Ys6nOQnD4QD6vDvfJg7nx5Dbd+oItNFAad3lwnanm0CqxSZpPQVgVMdD4Vrq/dY7yTaEUwsXOFci2iw==",
-      "dev": true,
-      "requires": {
-        "@types/bunyan": "1.8.4",
-        "@types/node": "9.4.6",
-        "@types/spdy": "3.4.4"
-      }
-    },
     "@types/semver": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/@types/semver/-/semver-5.5.0.tgz",
       "integrity": "sha512-41qEJgBH/TWgo5NFSvBCJ1qkoi3Q6ONSF2avrHq1LVEZfYpdHmj0y9SuTK+u9ZhG1sYQKBL1AWXKyLWP4RaUoQ==",
       "dev": true
     },
-    "@types/serve-static": {
-      "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.1.tgz",
-      "integrity": "sha512-jDMH+3BQPtvqZVIcsH700Dfi8Q3MIcEx16g/VdxjoqiGR/NntekB10xdBpirMKnPe9z2C5cBmL0vte0YttOr3Q==",
-      "dev": true,
-      "requires": {
-        "@types/express-serve-static-core": "4.11.1",
-        "@types/mime": "2.0.0"
-      }
-    },
     "@types/shimmer": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@types/shimmer/-/shimmer-1.0.1.tgz",
       "integrity": "sha512-I9ouuzrWLcjM1wre7f0i780W3KHk5PxFAC5KOpvpOGNaTsaKLN8p7sqRh9THwV9cpdOA/YJC+yMhG1jonQFdRQ==",
       "dev": true
-    },
-    "@types/shot": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@types/shot/-/shot-3.4.0.tgz",
-      "integrity": "sha1-RZR3xRh9Pr0wNmCrCZ5+ng87ZW8=",
-      "dev": true,
-      "requires": {
-        "@types/node": "9.4.6"
-      }
-    },
-    "@types/spdy": {
-      "version": "3.4.4",
-      "resolved": "https://registry.npmjs.org/@types/spdy/-/spdy-3.4.4.tgz",
-      "integrity": "sha512-N9LBlbVRRYq6HgYpPkqQc3a9HJ/iEtVZToW6xlTtJiMhmRJ7jJdV7TaZQJw/Ve/1ePUsQiCTDc4JMuzzag94GA==",
-      "dev": true,
-      "requires": {
-        "@types/node": "9.4.6"
-      }
     },
     "@types/tmp": {
       "version": "0.0.33",
@@ -4246,12 +4019,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/module-details-from-path/-/module-details-from-path-1.0.3.tgz",
       "integrity": "sha1-EUyUlnPiqKNenTV4hSeqN7Z52is="
-    },
-    "moment": {
-      "version": "2.21.0",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.21.0.tgz",
-      "integrity": "sha512-TCZ36BjURTeFTM/CwRcViQlfkMvL1/vFISuNLO5GkcVm1+QHfbSiNqZuWeMFjj1/3+uAjXswgRk30j1kkLYJBQ==",
-      "dev": true
     },
     "ms": {
       "version": "2.0.0",

--- a/scripts/get-plugin-types.ts
+++ b/scripts/get-plugin-types.ts
@@ -24,7 +24,6 @@ export async function getPluginTypes() {
     if (!matches) {
       continue;
     }
-    console.log(matches);
     const [, packageName, name, version] = matches;
     const installDir = `${TYPES_DIRECTORY}/${packageName}`;
     if (await mkdirSafeP(installDir)) {

--- a/src/plugins/plugin-hapi.ts
+++ b/src/plugins/plugin-hapi.ts
@@ -20,11 +20,19 @@ import {parse as urlParse} from 'url';
 
 import {PluginTypes} from '..';
 
-import {hapi_16} from './types';
+import {hapi_16, hapi_17} from './types';
+
+// Used when patching Hapi 17.
+const ORIGINAL = Symbol();
 
 type Hapi16Module = typeof hapi_16;
-
-const SUPPORTED_VERSIONS = '8 - 16';
+type Hapi17RequestExecutePrivate = {
+  (this: hapi_17.Request): Promise<void>;
+      [ORIGINAL]?: Hapi17RequestExecutePrivate;
+};
+type Hapi17Request = hapi_17.Request&{
+  _execute: Hapi17RequestExecutePrivate;
+};
 
 function getFirstHeader(req: IncomingMessage, key: string): string|null {
   let headerValue = req.headers[key] || null;
@@ -34,87 +42,121 @@ function getFirstHeader(req: IncomingMessage, key: string): string|null {
   return headerValue;
 }
 
-function createMiddleware(api: PluginTypes.TraceAgent):
-    hapi_16.ServerExtRequestHandler {
-  return function middleware(request, reply) {
-    const req = request.raw.req;
-    const res = request.raw.res;
-    const originalEnd = res.end;
-    const options: PluginTypes.RootSpanOptions = {
-      name: req.url ? (urlParse(req.url).pathname || '') : '',
-      url: req.url,
-      traceContext:
-          getFirstHeader(req, api.constants.TRACE_CONTEXT_HEADER_NAME),
-      skipFrames: 3
-    };
-    api.runInRootSpan(options, (root) => {
-      // Set response trace context.
-      const responseTraceContext = api.getResponseTraceContext(
-          options.traceContext || null, api.isRealSpan(root));
-      if (responseTraceContext) {
-        res.setHeader(
-            api.constants.TRACE_CONTEXT_HEADER_NAME, responseTraceContext);
-      }
-
-      if (!api.isRealSpan(root)) {
-        return reply.continue();
-      }
-
-      api.wrapEmitter(req);
-      api.wrapEmitter(res);
-
-      const url = `${req.headers['X-Forwarded-Proto'] || 'http'}://${
-          req.headers.host}${req.url}`;
-
-      // we use the path part of the url as the span name and add the full
-      // url as a label
-      // req.path would be more desirable but is not set at the time our
-      // middleware runs.
-      root.addLabel(api.labels.HTTP_METHOD_LABEL_KEY, req.method);
-      root.addLabel(api.labels.HTTP_URL_LABEL_KEY, url);
-      root.addLabel(api.labels.HTTP_SOURCE_IP, req.connection.remoteAddress);
-
-      // wrap end
-      res.end = function(this: ServerResponse) {
-        res.end = originalEnd;
-        const returned = res.end.apply(this, arguments);
-
-        if (request.route && request.route.path) {
-          root.addLabel('hapi/request.route.path', request.route.path);
-        }
-        root.addLabel(api.labels.HTTP_RESPONSE_CODE_LABEL_KEY, res.statusCode);
-        root.endSpan();
-
-        return returned;
-      };
-
-      // if the event is aborted, end the span (as res.end will not be called)
-      req.once('aborted', () => {
-        root.addLabel(api.labels.ERROR_DETAILS_NAME, 'aborted');
-        root.addLabel(
-            api.labels.ERROR_DETAILS_MESSAGE, 'client aborted the request');
-        root.endSpan();
-      });
-
-      return reply.continue();
-    });
+function instrument<T>(
+    api: PluginTypes.TraceAgent, request: hapi_16.Request|hapi_17.Request,
+    continueCb: () => T): T {
+  const req = request.raw.req;
+  const res = request.raw.res;
+  const originalEnd = res.end;
+  const options: PluginTypes.RootSpanOptions = {
+    name: req.url ? (urlParse(req.url).pathname || '') : '',
+    url: req.url,
+    traceContext: getFirstHeader(req, api.constants.TRACE_CONTEXT_HEADER_NAME),
+    skipFrames: 4
   };
+  return api.runInRootSpan(options, (root) => {
+    // Set response trace context.
+    const responseTraceContext = api.getResponseTraceContext(
+        options.traceContext || null, api.isRealSpan(root));
+    if (responseTraceContext) {
+      res.setHeader(
+          api.constants.TRACE_CONTEXT_HEADER_NAME, responseTraceContext);
+    }
+
+    if (!api.isRealSpan(root)) {
+      return continueCb();
+    }
+
+    api.wrapEmitter(req);
+    api.wrapEmitter(res);
+
+    const url = `${req.headers['X-Forwarded-Proto'] || 'http'}://${
+        req.headers.host}${req.url}`;
+
+    // we use the path part of the url as the span name and add the full
+    // url as a label
+    // req.path would be more desirable but is not set at the time our
+    // middleware runs.
+    root.addLabel(api.labels.HTTP_METHOD_LABEL_KEY, req.method);
+    root.addLabel(api.labels.HTTP_URL_LABEL_KEY, url);
+    root.addLabel(api.labels.HTTP_SOURCE_IP, req.connection.remoteAddress);
+
+    // wrap end
+    res.end = function(this: ServerResponse) {
+      res.end = originalEnd;
+      const returned = res.end.apply(this, arguments);
+
+      if (request.route && request.route.path) {
+        root.addLabel('hapi/request.route.path', request.route.path);
+      }
+      root.addLabel(api.labels.HTTP_RESPONSE_CODE_LABEL_KEY, res.statusCode);
+      root.endSpan();
+
+      return returned;
+    };
+
+    // if the event is aborted, end the span (as res.end will not be called)
+    req.once('aborted', () => {
+      root.addLabel(api.labels.ERROR_DETAILS_NAME, 'aborted');
+      root.addLabel(
+          api.labels.ERROR_DETAILS_MESSAGE, 'client aborted the request');
+      root.endSpan();
+    });
+
+    return continueCb();
+  });
 }
 
-const plugin: PluginTypes.Plugin = [{
-  file: '',
-  versions: SUPPORTED_VERSIONS,
-  patch: (hapi, api) => {
-    shimmer.wrap(hapi.Server.prototype, 'connection', (connection) => {
-      return function connectionTrace(this: {}) {
-        const server: hapi_16.Server = connection.apply(this, arguments);
-        server.ext('onRequest', createMiddleware(api));
-        return server;
-      };
-    });
-  },
-  unpatch: (hapi) => {
-    shimmer.unwrap(hapi.Server.prototype, 'connection');
-  }
-} as PluginTypes.Patch<Hapi16Module>];
+const plugin: PluginTypes.Plugin = [
+  {
+    versions: '8 - 16',
+    patch(hapi, api) {
+      function createMiddleware(): hapi_16.ServerExtRequestHandler {
+        return function handler(request, reply) {
+          return instrument(api, request, () => reply.continue());
+        };
+      }
+
+      shimmer.wrap(hapi.Server.prototype, 'connection', (connection) => {
+        return function connectionTrace(this: hapi_16.Server) {
+          const server = connection.apply(this, arguments);
+          server.ext('onRequest', createMiddleware());
+          return server;
+        };
+      });
+    },
+    unpatch(hapi) {
+      shimmer.unwrap(hapi.Server.prototype, 'connection');
+    }
+  } as PluginTypes.Patch<Hapi16Module>,
+  /**
+   * In Hapi 17, the work that is done on behalf of a request stems from
+   * Request#_execute. We patch that function to ensure that context is
+   * available in every handler.
+   */
+  {
+    versions: '17',
+    file: 'lib/request.js',
+    // Request is a class name.
+    // tslint:disable-next-line:variable-name
+    patch: (Request, api) => {
+      // TODO(kjin): shimmer cannot wrap AsyncFunction objects.
+      // Once shimmer introduces this functionality, change this code to use it.
+      const origExecute = Request.prototype._execute;
+      Request.prototype._execute =
+          Object.assign(function _executeWrap(this: hapi_17.Request) {
+            return instrument(api, this, () => {
+              return origExecute.apply(this, arguments);
+            });
+          }, {[ORIGINAL]: origExecute});
+    },
+    // Request is a class name.
+    // tslint:disable-next-line:variable-name
+    unpatch: (Request) => {
+      if (Request.prototype._execute[ORIGINAL]) {
+        Request.prototype._execute = Request.prototype._execute[ORIGINAL]!;
+      }
+    }
+  } as PluginTypes.Patch<{prototype: Hapi17Request}>
+];
 export = plugin;

--- a/src/plugins/plugin-hapi.ts
+++ b/src/plugins/plugin-hapi.ts
@@ -26,10 +26,10 @@ import {hapi_16, hapi_17} from './types';
 const ORIGINAL = Symbol();
 
 type Hapi16Module = typeof hapi_16;
-type Hapi17RequestExecutePrivate = {
+interface Hapi17RequestExecutePrivate {
   (this: hapi_17.Request): Promise<void>;
-      [ORIGINAL]?: Hapi17RequestExecutePrivate;
-};
+  [ORIGINAL]?: Hapi17RequestExecutePrivate;
+}
 type Hapi17Request = hapi_17.Request&{
   _execute: Hapi17RequestExecutePrivate;
 };
@@ -110,7 +110,7 @@ function instrument<T>(
 const plugin: PluginTypes.Plugin = [
   {
     versions: '8 - 16',
-    patch(hapi, api) {
+    patch: (hapi, api) => {
       function createMiddleware(): hapi_16.ServerExtRequestHandler {
         return function handler(request, reply) {
           return instrument(api, request, () => reply.continue());
@@ -125,7 +125,7 @@ const plugin: PluginTypes.Plugin = [
         };
       });
     },
-    unpatch(hapi) {
+    unpatch: (hapi) => {
       shimmer.unwrap(hapi.Server.prototype, 'connection');
     }
   } as PluginTypes.Patch<Hapi16Module>,

--- a/src/plugins/plugin-hapi.ts
+++ b/src/plugins/plugin-hapi.ts
@@ -111,16 +111,12 @@ const plugin: PluginTypes.Plugin = [
   {
     versions: '8 - 16',
     patch: (hapi, api) => {
-      function createMiddleware(): hapi_16.ServerExtRequestHandler {
-        return function handler(request, reply) {
-          return instrument(api, request, () => reply.continue());
-        };
-      }
-
       shimmer.wrap(hapi.Server.prototype, 'connection', (connection) => {
         return function connectionTrace(this: hapi_16.Server) {
           const server = connection.apply(this, arguments);
-          server.ext('onRequest', createMiddleware());
+          server.ext('onRequest', function handler(request, reply) {
+            return instrument(api, request, () => reply.continue());
+          } as hapi_16.ServerExtRequestHandler);
           return server;
         };
       });

--- a/src/plugins/types/index.d.ts
+++ b/src/plugins/types/index.d.ts
@@ -30,6 +30,7 @@
 import * as connect_3 from './connect_3'; // connect@3
 import * as express_4 from './express_4'; // express@4
 import * as hapi_16 from './hapi_16'; // hapi@16
+import * as hapi_17 from './hapi_17'; // hapi@17
 import * as koa_2 from './koa_2'; // koa@2
 import * as pg_7 from './pg_7'; // pg@7
 import * as restify_5 from './restify_5'; // restify@5
@@ -88,6 +89,7 @@ export {
   connect_3,
   express_4,
   hapi_16,
+  hapi_17,
   koa_1,
   koa_2,
   pg_6,

--- a/test/fixtures/plugin-fixtures.json
+++ b/test/fixtures/plugin-fixtures.json
@@ -39,29 +39,9 @@
       "hapi-plugin-mysql": "^3.1.3"
     }
   },
-  "hapi10": {
-    "dependencies": {
-      "hapi": "^10.5.0"
-    }
-  },
-  "hapi11": {
-    "dependencies": {
-      "hapi": "^11.1.4"
-    }
-  },
   "hapi12": {
     "dependencies": {
       "hapi": "^12.1.0"
-    }
-  },
-  "hapi13": {
-    "dependencies": {
-      "hapi": "^13.2.1"
-    }
-  },
-  "hapi14": {
-    "dependencies": {
-      "hapi": "^14.0.0"
     }
   },
   "hapi15": {
@@ -74,14 +54,14 @@
       "hapi": "^16.0.0"
     }
   },
+  "hapi17": {
+    "dependencies": {
+      "hapi": "^17.0.0"
+    }
+  },
   "hapi8": {
     "dependencies": {
       "hapi": "^8.8.1"
-    }
-  },
-  "hapi9": {
-    "dependencies": {
-      "hapi": "^9.5.1"
     }
   },
   "knex0.10": {

--- a/test/test-mysql-pool.ts
+++ b/test/test-mysql-pool.ts
@@ -31,7 +31,7 @@ if (semver.satisfies(process.version, '>=4')) {
         samplingRate: 0,
         enhancedDatabaseReporting: true
       });
-      Hapi = require('./plugins/fixtures/hapi13');
+      Hapi = require('./plugins/fixtures/hapi16');
     });
 
     it('should work with connection pool access', function(done) {

--- a/test/web-frameworks/hapi17.ts
+++ b/test/web-frameworks/hapi17.ts
@@ -1,0 +1,85 @@
+/**
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {hapi_17} from '../../src/plugins/types';
+
+import {WebFramework, WebFrameworkAddHandlerOptions, WebFrameworkResponse} from './base';
+
+export class Hapi17 implements WebFramework {
+  static commonName = `hapi@17`;
+  static expectedTopStackFrame = '_executeWrap';
+  static versionRange = '>=7.5';
+
+  private server: hapi_17.Server;
+  // We can't add two routes on the same path.
+  // So instead of registering a new Hapi plugin per path,
+  // register only the first time -- passing a function that will iterate
+  // through a list of routes keyed under the path.
+  private routes =
+      new Map<string, Array<() => Promise<WebFrameworkResponse|void>>>();
+  private registering = Promise.resolve();
+
+  constructor() {
+    const hapi = require('../plugins/fixtures/hapi17') as typeof hapi_17;
+    this.server = new hapi.Server();
+  }
+
+  addHandler(options: WebFrameworkAddHandlerOptions): void {
+    let shouldRegister = false;
+    if (!this.routes.has(options.path)) {
+      this.routes.set(options.path, [options.fn]);
+      shouldRegister = true;
+    } else {
+      this.routes.get(options.path)!.push(options.fn);
+    }
+
+    // Only register a new plugin for the first occurrence of this path.
+    if (shouldRegister) {
+      this.registering = this.registering.then(() => this.server.register({
+        plugin: {
+          name: options.path,
+          register: async (server, registerOpts) => {
+            server.route({
+              method: 'GET',
+              path: options.path,
+              handler: async (request, h) => {
+                let result;
+                for (const handler of this.routes.get(options.path)!) {
+                  result = await handler();
+                  if (result) {
+                    return result;
+                  }
+                }
+                return h.continue;
+              }
+            });
+          }
+        }
+      }));
+    }
+  }
+
+  async listen(port: number): Promise<number> {
+    await this.registering;
+    this.server.settings.port = port;
+    await this.server.start();
+    return Number(this.server.info!.port);
+  }
+
+  shutdown(): void {
+    this.server.stop();
+  }
+}

--- a/test/web-frameworks/hapi8_16.ts
+++ b/test/web-frameworks/hapi8_16.ts
@@ -85,7 +85,7 @@ export class Hapi implements WebFramework {
 
 const makeHapiClass = (version: number) => class extends Hapi {
   static commonName = `hapi@${version}`;
-  static expectedTopStackFrame = 'middleware';
+  static expectedTopStackFrame = 'handler';
   static versionRange = '*';
 
   constructor() {


### PR DESCRIPTION
This PR adds support for tracing Hapi 17. `GCLOUD_TRACE_NEW_CONTEXT` must be set.

Fixes #601