### PR TITLE
fix: allow non-objects for plugins to disable automatic tracing

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -89,7 +89,7 @@ function initConfig(projectConfig: Forceable<Config>):
   // 4. Default Config (as specified in './config')
   const config = extend(
       true, {[FORCE_NEW]: projectConfig[FORCE_NEW]}, defaultConfig,
-      envSetConfig, projectConfig, envConfig, {plugins: {/**/}});
+      envSetConfig, projectConfig, envConfig, {plugins: {}});
   // The empty plugins object guarantees that plugins is a plain object,
   // even if it's explicitly specified in the config to be a non-object.
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -89,7 +89,9 @@ function initConfig(projectConfig: Forceable<Config>):
   // 4. Default Config (as specified in './config')
   const config = extend(
       true, {[FORCE_NEW]: projectConfig[FORCE_NEW]}, defaultConfig,
-      envSetConfig, projectConfig, envConfig);
+      envSetConfig, projectConfig, envConfig, {plugins: {/**/}});
+  // The empty plugins object guarantees that plugins is a plain object,
+  // even if it's explicitly specified in the config to be a non-object.
 
   // Enforce the upper limit for the label value size.
   if (config.maximumLabelValueSize >

--- a/test/plugins/test-trace-http2.ts
+++ b/test/plugins/test-trace-http2.ts
@@ -244,9 +244,15 @@ describe('test-trace-http2', () => {
           assert.equal(
               span.labels[TraceLabels.ERROR_DETAILS_NAME],
               'Error [ERR_HTTP2_STREAM_ERROR]');
-          assert.equal(
-              span.labels[TraceLabels.ERROR_DETAILS_MESSAGE],
-              'Stream closed with error code 2');
+          if (semver.satisfies(process.version, '>=9.11')) {
+            assert.equal(
+                span.labels[TraceLabels.ERROR_DETAILS_MESSAGE],
+                'Stream closed with error code NGHTTP2_INTERNAL_ERROR');
+          } else {
+            assert.equal(
+                span.labels[TraceLabels.ERROR_DETAILS_MESSAGE],
+                'Stream closed with error code 2');
+          }
           session.destroy();
           server.close();
           done();

--- a/test/test-config-plugins.ts
+++ b/test/test-config-plugins.ts
@@ -65,6 +65,11 @@ describe('Configuration: Plugins', () => {
         e => assert.ok(plugins![e].includes(`plugin-${e}.js`)));
   });
 
+  it('should handle non-object', () => {
+    trace.start({plugins: false as {}});
+    assert.deepStrictEqual(plugins, {});
+  });
+
   it('should overwrite builtin plugins correctly', () => {
     trace.start({plugins: {express: 'foo'}});
     assert.ok(plugins);


### PR DESCRIPTION
Fixes #719 

This change allows users to disable automatic tracing by passing a non-object value (such as `false`) for the value of `config.plugins`. It takes advantage of `extend`'s behavior of allowing non-object values to override object values, and vice versa.

Since we do not recommend disabling plugins I have not documented this feature.