### PR TITLE
fix: fix log messages and ignore falsey env vars

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -69,16 +69,18 @@ function initConfig(projectConfig: Forceable<Config>):
     Forceable<NormalizedConfig> {
   const envConfig = {
     logLevel: Number(process.env.GCLOUD_TRACE_LOGLEVEL) || undefined,
-    projectId: process.env.GCLOUD_PROJECT,
+    projectId: process.env.GCLOUD_PROJECT || undefined,
     serviceContext: {
-      service: process.env.GAE_SERVICE || process.env.GAE_MODULE_NAME,
-      version: process.env.GAE_VERSION || process.env.GAE_MODULE_VERSION,
-      minorVersion: process.env.GAE_MINOR_VERSION
+      service:
+          process.env.GAE_SERVICE || process.env.GAE_MODULE_NAME || undefined,
+      version: process.env.GAE_VERSION || process.env.GAE_MODULE_VERSION ||
+          undefined,
+      minorVersion: process.env.GAE_MINOR_VERSION || undefined
     }
   };
 
   let envSetConfig: Config = {};
-  if (process.env.hasOwnProperty('GCLOUD_TRACE_CONFIG')) {
+  if (!!process.env.GCLOUD_TRACE_CONFIG) {
     envSetConfig =
         require(path.resolve(process.env.GCLOUD_TRACE_CONFIG!)) as Config;
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -67,6 +67,8 @@ type NormalizedConfig = TraceWriterConfig&PluginLoaderConfig&TopLevelConfig;
  */
 function initConfig(projectConfig: Forceable<Config>):
     Forceable<NormalizedConfig> {
+  // `|| undefined` prevents environmental variables that are empty strings
+  // from overriding values provided in the config object passed to start().
   const envConfig = {
     logLevel: Number(process.env.GCLOUD_TRACE_LOGLEVEL) || undefined,
     projectId: process.env.GCLOUD_PROJECT || undefined,

--- a/src/trace-api.ts
+++ b/src/trace-api.ts
@@ -135,6 +135,8 @@ export class TraceAgent implements TraceAgentInterface {
     }
 
     return this.namespace!.runAndReturn(() => {
+      this.logger!.info(`TraceApi#runInRootSpan: [${
+          this.pluginName}] Created root span [${options.name}]`);
       // Attempt to read incoming trace context.
       let incomingTraceContext: IncomingTraceContext = {};
       if (isString(options.traceContext) && !this.config!.ignoreContextHeader) {
@@ -205,7 +207,7 @@ export class TraceAgent implements TraceAgentInterface {
         // with continuously growing number of child spans. The second case
         // seems to have some value, but isn't representable. The user probably
         // needs a custom outer span that encompasses the entirety of work.
-        this.logger!.warn(`TraceApi#createChildspan: [${
+        this.logger!.warn(`TraceApi#createChildSpan: [${
             this.pluginName}] Creating phantom child span [${
             options.name}] because root span [${
             rootSpan.span.name}] was already closed.`);
@@ -219,6 +221,8 @@ export class TraceAgent implements TraceAgentInterface {
           options.name,         /* Span name */
           rootSpan.span.spanId, /* Parent's span ID */
           skipFrames);          /* # of frames to skip in stack trace */
+      this.logger!.info(`TraceApi#createChildSpan: [${
+          this.pluginName}] Created child span [${options.name}]`);
       return childContext;
     } else if (rootSpan.type === SpanDataType.UNTRACED) {
       // Context wasn't lost, but there's no root span, indicating that this
@@ -226,7 +230,7 @@ export class TraceAgent implements TraceAgentInterface {
       return UNTRACED_SPAN;
     } else {
       // Context was lost.
-      this.logger!.warn(`TraceApi#createChildspan: [${
+      this.logger!.warn(`TraceApi#createChildSpan: [${
           this.pluginName}] Creating phantom child span [${
           options.name}] because there is no root span.`);
       return UNCORRELATED_SPAN;

--- a/src/trace-writer.ts
+++ b/src/trace-writer.ts
@@ -321,7 +321,7 @@ export class TraceWriter extends common.Service {
     // Privatize and clear the buffer.
     const buffer = this.buffer;
     this.buffer = [];
-    this.logger.debug('TraceWriter#flushBufffer: Flushing traces', buffer);
+    this.logger.debug('TraceWriter#flushBuffer: Flushing traces', buffer);
     this.publish(`{"traces":[${buffer.join()}]}`);
   }
 
@@ -334,7 +334,7 @@ export class TraceWriter extends common.Service {
     const uri = `https://cloudtrace.googleapis.com/v1/projects/${
         this.config.projectId}/traces`;
     const options = {method: 'PATCH', uri, body: json, headers};
-    this.logger.debug('TraceWriter#publish: Publishing to ' + uri);
+    this.logger.info('TraceWriter#publish: Publishing to ' + uri);
     this.request(options, (err, body?, response?) => {
       const statusCode = (response && response.statusCode) || 'unknown';
       if (err) {


### PR DESCRIPTION
This change causes the Trace Agent to now ignore empty string environmental variables. Formerly,

```
GCLOUD_PROJECT= node app.js
```

would initialize the `projectId` field to an empty string.

This change also fixes a few log message contents, and adds two info-level log messages for when new spans are created.