### PR TITLE
fix: restore context when a function run with a given context throws

### DIFF
--- a/src/cls/async-hooks.ts
+++ b/src/cls/async-hooks.ts
@@ -86,10 +86,12 @@ export class AsyncHooksCLS<Context extends {}> implements CLS<Context> {
   runWithNewContext<T>(fn: Func<T>): T {
     const oldContext = this.currentContext.value;
     this.currentContext.value = this.defaultContext;
-    // TODO(kjin) Handle the case where fn throws. Context: PR #708
-    const res = fn();
-    this.currentContext.value = oldContext;
-    return res;
+    try {
+      const res = fn();
+      return res;
+    } finally {
+      this.currentContext.value = oldContext;
+    }
   }
 
   bindWithCurrentContext<T>(fn: Func<T>): Func<T> {
@@ -101,10 +103,12 @@ export class AsyncHooksCLS<Context extends {}> implements CLS<Context> {
     const contextWrapper: ContextWrapped<Func<T>> = function(this: {}) {
       const oldContext = current.value;
       current.value = boundContext;
-      // TODO(kjin) Handle the case where fn throws. Context: PR #708
-      const res = fn.apply(this, arguments) as T;
-      current.value = oldContext;
-      return res;
+      try {
+        const res = fn.apply(this, arguments) as T;
+        return res;
+      } finally {
+        current.value = oldContext;
+      }
     };
     contextWrapper[WRAPPED] = true;
     Object.defineProperty(contextWrapper, 'length', {

--- a/src/cls/async-hooks.ts
+++ b/src/cls/async-hooks.ts
@@ -87,8 +87,7 @@ export class AsyncHooksCLS<Context extends {}> implements CLS<Context> {
     const oldContext = this.currentContext.value;
     this.currentContext.value = this.defaultContext;
     try {
-      const res = fn();
-      return res;
+      return fn();
     } finally {
       this.currentContext.value = oldContext;
     }
@@ -104,8 +103,7 @@ export class AsyncHooksCLS<Context extends {}> implements CLS<Context> {
       const oldContext = current.value;
       current.value = boundContext;
       try {
-        const res = fn.apply(this, arguments) as T;
-        return res;
+        return fn.apply(this, arguments) as T;
       } finally {
         current.value = oldContext;
       }

--- a/test/test-cls.ts
+++ b/test/test-cls.ts
@@ -130,6 +130,32 @@ describe('Continuation-Local Storage', () => {
           });
         });
 
+        it('Corrects context when function run with new context throws', () => {
+          try {
+            c.runWithNewContext(() => {
+              c.setContext('modified');
+              throw new Error();
+            });
+          } catch (e) {
+            assert.strictEqual(c.getContext(), 'default');
+          }
+        });
+
+        it('Corrects context when function bound to a context throws', () => {
+          let runLater = () => {
+            c.setContext('modified');
+            throw new Error();
+          };
+          c.runWithNewContext(() => {
+            runLater = c.bindWithCurrentContext(runLater);
+          });
+          try {
+            runLater();
+          } catch (e) {
+            assert.strictEqual(c.getContext(), 'default');
+          }
+        });
+
         it('Can be used to patch event emitters to propagate context', () => {
           const ee = new EventEmitter();
           assert.strictEqual(c.getContext(), 'default');


### PR DESCRIPTION
Addresses a TODO from #708: in two different cases, a function is accepted by the tracing API; we currently do not do any restoration of context if that function throws (in other words, the newly added tests would fail). This PR addresses that.