### PR TITLE
feat: add rootSpan.createChildSpan and change none CLS semantics

### DIFF
--- a/src/cls.ts
+++ b/src/cls.ts
@@ -139,7 +139,7 @@ export class TraceCLS implements CLS<RootContext> {
   }
 
   enable(): void {
-    // if this.CLSClass = NoneCLS, the user specifically asked not to use
+    // if this.CLSClass = NullCLS, the user specifically asked not to use
     // any context propagation mechanism. So nothing should change.
     if (!this.enabled && this.CLSClass !== NullCLS) {
       this.logger.info('TraceCLS#enable: Enabling CLS.');

--- a/src/cls.ts
+++ b/src/cls.ts
@@ -21,7 +21,7 @@ import * as semver from 'semver';
 import {AsyncHooksCLS} from './cls/async-hooks';
 import {AsyncListenerCLS} from './cls/async-listener';
 import {CLS, Func} from './cls/base';
-import {DefaultCLS} from './cls/default';
+import {NullCLS} from './cls/null';
 import {SpanDataType} from './constants';
 import {SpanData, SpanOptions} from './plugin-types';
 import {Trace, TraceSpan} from './trace';
@@ -121,7 +121,7 @@ export class TraceCLS implements CLS<RootContext> {
         this.rootSpanStackOffset = 8;
         break;
       case TraceCLSMechanism.NONE:
-        this.CLSClass = DefaultCLS;
+        this.CLSClass = NullCLS;
         this.rootSpanStackOffset = 4;
         break;
       default:
@@ -130,7 +130,7 @@ export class TraceCLS implements CLS<RootContext> {
     }
     this.logger.info(
         `TraceCLS#constructor: Created [${config.mechanism}] CLS instance.`);
-    this.currentCLS = new DefaultCLS(TraceCLS.UNTRACED);
+    this.currentCLS = new NullCLS(TraceCLS.UNTRACED);
     this.currentCLS.enable();
   }
 
@@ -139,9 +139,9 @@ export class TraceCLS implements CLS<RootContext> {
   }
 
   enable(): void {
-    // if this.CLSClass = DefaultCLS, the user specifically asked not to use
+    // if this.CLSClass = NoneCLS, the user specifically asked not to use
     // any context propagation mechanism. So nothing should change.
-    if (!this.enabled && this.CLSClass !== DefaultCLS) {
+    if (!this.enabled && this.CLSClass !== NullCLS) {
       this.logger.info('TraceCLS#enable: Enabling CLS.');
       this.currentCLS.disable();
       this.currentCLS = new this.CLSClass(TraceCLS.UNCORRELATED);
@@ -151,10 +151,10 @@ export class TraceCLS implements CLS<RootContext> {
   }
 
   disable(): void {
-    if (this.enabled && this.CLSClass !== DefaultCLS) {
+    if (this.enabled && this.CLSClass !== NullCLS) {
       this.logger.info('TraceCLS#disable: Disabling CLS.');
       this.currentCLS.disable();
-      this.currentCLS = new DefaultCLS(TraceCLS.UNTRACED);
+      this.currentCLS = new NullCLS(TraceCLS.UNTRACED);
       this.currentCLS.enable();
     }
     this.enabled = false;

--- a/src/cls.ts
+++ b/src/cls.ts
@@ -21,8 +21,9 @@ import * as semver from 'semver';
 import {AsyncHooksCLS} from './cls/async-hooks';
 import {AsyncListenerCLS} from './cls/async-listener';
 import {CLS, Func} from './cls/base';
-import {UniversalCLS} from './cls/universal';
+import {DefaultCLS} from './cls/default';
 import {SpanDataType} from './constants';
+import {SpanData, SpanOptions} from './plugin-types';
 import {Trace, TraceSpan} from './trace';
 import {Singleton} from './util';
 
@@ -31,6 +32,7 @@ const asyncHooksAvailable = semver.satisfies(process.version, '>=8');
 export interface RealRootContext {
   readonly span: TraceSpan;
   readonly trace: Trace;
+  createChildSpan(options: SpanOptions): SpanData;
   readonly type: SpanDataType.ROOT;
 }
 
@@ -119,7 +121,7 @@ export class TraceCLS implements CLS<RootContext> {
         this.rootSpanStackOffset = 8;
         break;
       case TraceCLSMechanism.NONE:
-        this.CLSClass = UniversalCLS;
+        this.CLSClass = DefaultCLS;
         this.rootSpanStackOffset = 4;
         break;
       default:
@@ -128,7 +130,7 @@ export class TraceCLS implements CLS<RootContext> {
     }
     this.logger.info(
         `TraceCLS#constructor: Created [${config.mechanism}] CLS instance.`);
-    this.currentCLS = new UniversalCLS(TraceCLS.UNTRACED);
+    this.currentCLS = new DefaultCLS(TraceCLS.UNTRACED);
     this.currentCLS.enable();
   }
 
@@ -137,23 +139,25 @@ export class TraceCLS implements CLS<RootContext> {
   }
 
   enable(): void {
-    if (!this.enabled) {
+    // if this.CLSClass = DefaultCLS, the user specifically asked not to use
+    // any context propagation mechanism. So nothing should change.
+    if (!this.enabled && this.CLSClass !== DefaultCLS) {
       this.logger.info('TraceCLS#enable: Enabling CLS.');
-      this.enabled = true;
       this.currentCLS.disable();
       this.currentCLS = new this.CLSClass(TraceCLS.UNCORRELATED);
       this.currentCLS.enable();
     }
+    this.enabled = true;
   }
 
   disable(): void {
-    if (this.enabled) {
+    if (this.enabled && this.CLSClass !== DefaultCLS) {
       this.logger.info('TraceCLS#disable: Disabling CLS.');
-      this.enabled = false;
       this.currentCLS.disable();
-      this.currentCLS = new UniversalCLS(TraceCLS.UNTRACED);
+      this.currentCLS = new DefaultCLS(TraceCLS.UNTRACED);
       this.currentCLS.enable();
     }
+    this.enabled = false;
   }
 
   getContext(): RootContext {

--- a/src/cls/default.ts
+++ b/src/cls/default.ts
@@ -19,16 +19,13 @@ import {EventEmitter} from 'events';
 import {CLS, Func} from './base';
 
 /**
- * A trivial implementation of continuation-local storage where everything is
- * in the same continuation.
+ * A trivial implementation of continuation-local storage where context takes on
+ * a default, immutable value.
  */
-export class UniversalCLS<Context> implements CLS<Context> {
+export class DefaultCLS<Context> implements CLS<Context> {
   private enabled = false;
-  private currentContext: Context;
 
-  constructor(private readonly defaultContext: Context) {
-    this.currentContext = this.defaultContext;
-  }
+  constructor(private readonly defaultContext: Context) {}
 
   isEnabled(): boolean {
     return this.enabled;
@@ -40,18 +37,13 @@ export class UniversalCLS<Context> implements CLS<Context> {
 
   disable(): void {
     this.enabled = false;
-    this.setContext(this.defaultContext);
   }
 
   getContext(): Context {
-    return this.currentContext;
+    return this.defaultContext;
   }
 
-  setContext(value: Context): void {
-    if (this.enabled) {
-      this.currentContext = value;
-    }
-  }
+  setContext(value: Context): void {}
 
   runWithNewContext<T>(fn: Func<T>): T {
     return fn();

--- a/src/cls/null.ts
+++ b/src/cls/null.ts
@@ -22,7 +22,7 @@ import {CLS, Func} from './base';
  * A trivial implementation of continuation-local storage where context takes on
  * a default, immutable value.
  */
-export class DefaultCLS<Context> implements CLS<Context> {
+export class NullCLS<Context> implements CLS<Context> {
   private enabled = false;
 
   constructor(private readonly defaultContext: Context) {}

--- a/src/plugin-types.ts
+++ b/src/plugin-types.ts
@@ -68,7 +68,7 @@ export interface RootSpanData extends SpanData {
    * @param options Options for creating the child span.
    * @returns A new SpanData object.
    */
-  createChildSpan(options: SpanOptions): SpanData;
+  createChildSpan(options?: SpanOptions): SpanData;
 }
 
 /**
@@ -148,7 +148,7 @@ export interface TraceAgent {
    * @param options Options for creating the child span.
    * @returns A new SpanData object.
    */
-  createChildSpan(options: SpanOptions): SpanData;
+  createChildSpan(options?: SpanOptions): SpanData;
 
   /**
    * Returns whether a given span is real or not by checking its SpanDataType.

--- a/src/plugin-types.ts
+++ b/src/plugin-types.ts
@@ -56,6 +56,22 @@ export interface SpanData {
 }
 
 /**
+ * Represents the root span within a trace.
+ */
+export interface RootSpanData extends SpanData {
+  /**
+   * Creates and starts a child span under this root span.
+   * If the root span is a real span (type = ROOT), the child span will be as
+   * well (type = CHILD).
+   * Otherwise, if the root span's type is UNTRACED or UNCORRELATED, the child
+   * span will be of the same type.
+   * @param options Options for creating the child span.
+   * @returns A new SpanData object.
+   */
+  createChildSpan(options: SpanOptions): SpanData;
+}
+
+/**
  * An interface that describes the available options for creating a span in
  * general.
  */
@@ -105,7 +121,7 @@ export interface TraceAgent {
    * a phantom SpanData object.
    * @returns The return value of calling fn.
    */
-  runInRootSpan<T>(options: RootSpanOptions, fn: (span: SpanData) => T): T;
+  runInRootSpan<T>(options: RootSpanOptions, fn: (span: RootSpanData) => T): T;
 
   /**
    * Returns a unique identifier for the currently active context. This can be
@@ -125,11 +141,11 @@ export interface TraceAgent {
   getWriterProjectId(): string|null;
 
   /**
-   * Creates and returns a new SpanData object nested within the root span.
-   * If there is no root span, a phantom SpanData object will be
-   * returned instead.
-   * @param options An object that specifies options for how the child
-   * span is created and propagated.
+   * Creates and returns a new SpanData object nested within the current root
+   * span, which is detected automatically.
+   * If the root span is a phantom span or doesn't exist, the child span will
+   * be a phantom span as well.
+   * @param options Options for creating the child span.
    * @returns A new SpanData object.
    */
   createChildSpan(options: SpanOptions): SpanData;

--- a/src/plugin-types.ts
+++ b/src/plugin-types.ts
@@ -26,6 +26,7 @@ export interface TraceAgentExtension { _google_trace_patched: boolean; }
 
 /**
  * Represents a trace span.
+ * TODO(kjin): This should be called `Span`.
  */
 export interface SpanData {
   /**

--- a/src/span-data.ts
+++ b/src/span-data.ts
@@ -121,7 +121,7 @@ export class RootSpanData extends BaseSpanData implements types.RootSpanData {
     this.span.kind = SpanKind.RPC_SERVER;
   }
 
-  createChildSpan(options: SpanOptions): SpanData {
+  createChildSpan(options?: SpanOptions): SpanData {
     options = options || {name: ''};
     const skipFrames = options.skipFrames ? options.skipFrames + 1 : 1;
     return new ChildSpanData(

--- a/src/span-data.ts
+++ b/src/span-data.ts
@@ -45,7 +45,7 @@ function randomSpanId() {
 /**
  * Represents a real trace span.
  */
-export abstract class BaseSpanData implements types.SpanData {
+export abstract class BaseSpanData implements SpanData {
   readonly span: TraceSpan;
   abstract readonly type: SpanDataType;
 

--- a/src/span-data.ts
+++ b/src/span-data.ts
@@ -18,7 +18,8 @@ import * as crypto from 'crypto';
 import * as util from 'util';
 
 import {Constants, SpanDataType} from './constants';
-import {SpanData as SpanData} from './plugin-types';
+import * as types from './plugin-types';
+import {SpanData, SpanOptions} from './plugin-types';
 import {SpanKind, Trace, TraceSpan} from './trace';
 import {TraceLabels} from './trace-labels';
 import {traceWriter} from './trace-writer';
@@ -44,7 +45,7 @@ function randomSpanId() {
 /**
  * Represents a real trace span.
  */
-export abstract class BaseSpanData implements SpanData {
+export abstract class BaseSpanData implements types.SpanData {
   readonly span: TraceSpan;
   abstract readonly type: SpanDataType;
 
@@ -110,7 +111,7 @@ export abstract class BaseSpanData implements SpanData {
 /**
  * Represents a real root span, which corresponds to an incoming request.
  */
-export class RootSpanData extends BaseSpanData {
+export class RootSpanData extends BaseSpanData implements types.RootSpanData {
   readonly type = SpanDataType.ROOT;
 
   constructor(
@@ -118,6 +119,16 @@ export class RootSpanData extends BaseSpanData {
       skipFrames: number) {
     super(trace, spanName, parentSpanId, skipFrames);
     this.span.kind = SpanKind.RPC_SERVER;
+  }
+
+  createChildSpan(options: SpanOptions): SpanData {
+    options = options || {name: ''};
+    const skipFrames = options.skipFrames ? options.skipFrames + 1 : 1;
+    return new ChildSpanData(
+        this.trace,       /* Trace object */
+        options.name,     /* Span name */
+        this.span.spanId, /* Parent's span ID */
+        skipFrames);      /* # of frames to skip in stack trace */
   }
 
   endSpan() {
@@ -156,14 +167,39 @@ function createPhantomSpanData<T extends SpanDataType>(spanType: T): SpanData&
 }
 
 /**
- * A virtual trace span that indicates that a real trace span couldn't be
- * created because context was lost.
+ * A virtual trace span that indicates that a real child span couldn't be
+ * created because the correct root span couldn't be determined.
  */
-export const UNCORRELATED_SPAN =
+export const UNCORRELATED_CHILD_SPAN =
     createPhantomSpanData(SpanDataType.UNCORRELATED);
 
 /**
- * A virtual trace span that indicates that a real trace span couldn't be
+ * A virtual trace span that indicates that a real child span couldn't be
+ * created because the corresponding root span was disallowed by user
+ * configuration.
+ */
+export const UNTRACED_CHILD_SPAN = createPhantomSpanData(SpanDataType.UNTRACED);
+
+/**
+ * A virtual trace span that indicates that a real root span couldn't be
+ * created because an active root span context already exists.
+ */
+export const UNCORRELATED_ROOT_SPAN = Object.freeze(Object.assign(
+    {
+      createChildSpan() {
+        return UNCORRELATED_CHILD_SPAN;
+      }
+    },
+    UNCORRELATED_CHILD_SPAN));
+
+/**
+ * A virtual trace span that indicates that a real root span couldn't be
  * created because it was disallowed by user configuration.
  */
-export const UNTRACED_SPAN = createPhantomSpanData(SpanDataType.UNTRACED);
+export const UNTRACED_ROOT_SPAN = Object.freeze(Object.assign(
+    {
+      createChildSpan() {
+        return UNTRACED_CHILD_SPAN;
+      }
+    },
+    UNTRACED_CHILD_SPAN));

--- a/src/trace-api.ts
+++ b/src/trace-api.ts
@@ -21,8 +21,8 @@ import * as uuid from 'uuid';
 
 import {cls} from './cls';
 import {Constants, SpanDataType} from './constants';
-import {Func, RootSpanOptions, SpanData, SpanOptions, TraceAgent as TraceAgentInterface} from './plugin-types';
-import {ChildSpanData, RootSpanData, UNCORRELATED_SPAN, UNTRACED_SPAN} from './span-data';
+import {Func, RootSpanData as RootSpanDataInterface, RootSpanOptions, SpanData, SpanOptions, TraceAgent as TraceAgentInterface} from './plugin-types';
+import {ChildSpanData, RootSpanData, UNCORRELATED_CHILD_SPAN, UNCORRELATED_ROOT_SPAN, UNTRACED_CHILD_SPAN, UNTRACED_ROOT_SPAN} from './span-data';
 import {SpanKind, Trace} from './trace';
 import {TraceLabels} from './trace-labels';
 import * as TracingPolicy from './tracing-policy';
@@ -121,18 +121,20 @@ export class TraceAgent implements TraceAgentInterface {
     return !!this.config && this.config.enhancedDatabaseReporting;
   }
 
-  runInRootSpan<T>(options: RootSpanOptions, fn: (span: SpanData) => T): T {
+  runInRootSpan<T>(
+      options: RootSpanOptions, fn: (span: RootSpanDataInterface) => T): T {
     if (!this.isActive()) {
-      return fn(UNTRACED_SPAN);
+      return fn(UNTRACED_ROOT_SPAN);
     }
 
-    // TODO validate options
+    options = options || {name: ''};
+
     // Don't create a root span if we are already in a root span
     const rootSpan = cls.get().getContext();
     if (rootSpan.type === SpanDataType.ROOT && !rootSpan.span.endTime) {
       this.logger!.warn(`TraceApi#runInRootSpan: [${
           this.pluginName}] Cannot create nested root spans.`);
-      return fn(UNCORRELATED_SPAN);
+      return fn(UNCORRELATED_ROOT_SPAN);
     }
 
     return cls.get().runWithNewContext(() => {
@@ -155,8 +157,8 @@ export class TraceAgent implements TraceAgentInterface {
           !!(incomingTraceContext.options &
              Constants.TRACE_OPTIONS_TRACE_ENABLED);
       if (!locallyAllowed || !remotelyAllowed) {
-        cls.get().setContext(UNTRACED_SPAN);
-        return fn(UNTRACED_SPAN);
+        cls.get().setContext(UNTRACED_ROOT_SPAN);
+        return fn(UNTRACED_ROOT_SPAN);
       }
 
       // Create a new root span, and invoke fn with it.
@@ -195,7 +197,7 @@ export class TraceAgent implements TraceAgentInterface {
 
   createChildSpan(options: SpanOptions): SpanData {
     if (!this.isActive()) {
-      return UNTRACED_SPAN;
+      return UNTRACED_CHILD_SPAN;
     }
 
     const rootSpan = cls.get().getContext();
@@ -212,29 +214,27 @@ export class TraceAgent implements TraceAgentInterface {
             this.pluginName}] Creating phantom child span [${
             options.name}] because root span [${
             rootSpan.span.name}] was already closed.`);
-        return UNCORRELATED_SPAN;
+        return UNCORRELATED_CHILD_SPAN;
       }
       // Create a new child span and return it.
       options = options || {name: ''};
-      const skipFrames = options.skipFrames ? options.skipFrames + 1 : 1;
-      const childContext = new ChildSpanData(
-          rootSpan.trace,       /* Trace object */
-          options.name,         /* Span name */
-          rootSpan.span.spanId, /* Parent's span ID */
-          skipFrames);          /* # of frames to skip in stack trace */
+      const childContext = rootSpan.createChildSpan({
+        name: options.name,
+        skipFrames: options.skipFrames ? options.skipFrames + 1 : 1
+      });
       this.logger!.info(`TraceApi#createChildSpan: [${
           this.pluginName}] Created child span [${options.name}]`);
       return childContext;
     } else if (rootSpan.type === SpanDataType.UNTRACED) {
       // Context wasn't lost, but there's no root span, indicating that this
       // request should not be traced.
-      return UNTRACED_SPAN;
+      return UNTRACED_CHILD_SPAN;
     } else {
       // Context was lost.
       this.logger!.warn(`TraceApi#createChildSpan: [${
           this.pluginName}] Creating phantom child span [${
           options.name}] because there is no root span.`);
-      return UNCORRELATED_SPAN;
+      return UNCORRELATED_CHILD_SPAN;
     }
   }
 

--- a/src/trace-api.ts
+++ b/src/trace-api.ts
@@ -195,11 +195,12 @@ export class TraceAgent implements TraceAgentInterface {
     }
   }
 
-  createChildSpan(options: SpanOptions): SpanData {
+  createChildSpan(options?: SpanOptions): SpanData {
     if (!this.isActive()) {
       return UNTRACED_CHILD_SPAN;
     }
 
+    options = options || {name: ''};
     const rootSpan = cls.get().getContext();
     if (rootSpan.type === SpanDataType.ROOT) {
       if (!!rootSpan.span.endTime) {
@@ -217,7 +218,6 @@ export class TraceAgent implements TraceAgentInterface {
         return UNCORRELATED_CHILD_SPAN;
       }
       // Create a new child span and return it.
-      options = options || {name: ''};
       const childContext = rootSpan.createChildSpan({
         name: options.name,
         skipFrames: options.skipFrames ? options.skipFrames + 1 : 1

--- a/test/plugins/test-trace-grpc.ts
+++ b/test/plugins/test-trace-grpc.ts
@@ -21,7 +21,7 @@ import { TraceLabels } from '../../src/trace-labels';
 import * as TracingPolicy from '../../src/tracing-policy';
 import * as util from '../../src/util';
 import * as assert from 'assert';
-import { asBaseSpanData } from '../utils';
+import { asRootSpanData } from '../utils';
 import { SpanData } from '../../src/plugin-types';
 import { FORCE_NEW } from '../../src/util';
 
@@ -55,7 +55,7 @@ function checkServerMetadata(metadata) {
     assert.ok(/[a-f0-9]{32}\/[0-9]+;o=1/.test(traceContext));
     var parsedContext = util.parseContextFromHeader(traceContext);
     assert.ok(parsedContext);
-    var root = asBaseSpanData(cls.get().getContext() as SpanData);
+    var root = asRootSpanData(cls.get().getContext() as SpanData);
     assert.strictEqual(root.span.parentSpanId, parsedContext!.spanId);
   }
 }

--- a/test/plugins/test-trace-http.ts
+++ b/test/plugins/test-trace-http.ts
@@ -116,6 +116,7 @@ for (const nodule of Object.keys(servers) as Array<keyof typeof servers>) {
   describe(`${nodule} client tracing`, () => {
     let http: {get: HttpRequest; request: HttpRequest;};
     before(() => {
+      trace.setCLS();
       trace.setPluginLoader();
       trace.start({
         plugins: {

--- a/test/test-cls.ts
+++ b/test/test-cls.ts
@@ -24,7 +24,7 @@ import {TraceCLS, TraceCLSConfig, TraceCLSMechanism} from '../src/cls';
 import {AsyncHooksCLS} from '../src/cls/async-hooks';
 import {AsyncListenerCLS} from '../src/cls/async-listener';
 import {CLS} from '../src/cls/base';
-import {DefaultCLS} from '../src/cls/default';
+import {NullCLS} from '../src/cls/null';
 import {SpanDataType} from '../src/constants';
 import {createStackTrace, FORCE_NEW} from '../src/util';
 
@@ -39,7 +39,7 @@ describe('Continuation-Local Storage', () => {
   const asyncAwaitSupported = semver.satisfies(process.version, '>=8');
 
   describe('No-op implementation', () => {
-    const clazz = DefaultCLS;
+    const clazz = NullCLS;
     let instance: CLS<string>;
 
     beforeEach(() => {

--- a/test/test-trace-api-none-cls.ts
+++ b/test/test-trace-api-none-cls.ts
@@ -1,0 +1,78 @@
+/**
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as assert from 'assert';
+
+import {SpanDataType} from '../src/constants';
+import {TraceAgent} from '../src/plugin-types';
+
+import * as trace from './trace';
+import {asChildSpanData, asRootSpanData} from './utils';
+
+const identity = <T>(x: T) => x;
+
+describe('Custom Trace API with CLS disabled', () => {
+  let traceApi: TraceAgent;
+
+  before(() => {
+    trace.setCLS();
+  });
+
+  after(() => {
+    trace.setCLS(trace.TestCLS);
+  });
+
+  beforeEach(() => {
+    traceApi = trace.start({clsMechanism: 'none'});
+  });
+
+  afterEach(() => {
+    trace.clearTraceData();
+  });
+
+  it('should allow root spans to be created without constraints', () => {
+    traceApi.runInRootSpan({name: 'root1'}, root1 => {
+      assert.strictEqual(root1.type, SpanDataType.ROOT);
+      traceApi.runInRootSpan({name: 'root2'}, root2 => {
+        assert.strictEqual(root2.type, SpanDataType.ROOT);
+        assert.notStrictEqual(
+            asRootSpanData(root2).trace.traceId,
+            asRootSpanData(root1).trace.traceId);
+        root2.endSpan();
+      });
+      root1.endSpan();
+    });
+  });
+
+  it('should allow child spans to be created using root span API', () => {
+    const root =
+        asRootSpanData(traceApi.runInRootSpan({name: 'root'}, identity));
+    const child = asChildSpanData(root.createChildSpan({name: 'child'}));
+    assert.strictEqual(child.span.parentSpanId, root.span.spanId);
+    assert.strictEqual(child.trace.traceId, root.trace.traceId);
+    child.endSpan();
+    root.endSpan();
+  });
+
+  it('should create phantom child spans thru trace API', () => {
+    const root =
+        asRootSpanData(traceApi.runInRootSpan({name: 'root'}, identity));
+    const child = traceApi.createChildSpan({name: 'child'});
+    assert.strictEqual(child.type, SpanDataType.UNTRACED);
+    child.endSpan();
+    root.endSpan();
+  });
+});

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -20,7 +20,7 @@ import * as assert from 'assert';
 
 import {SpanDataType} from '../src/constants';
 import {SpanData} from '../src/plugin-types';
-import {BaseSpanData} from '../src/span-data';
+import {ChildSpanData, RootSpanData} from '../src/span-data';
 import {TraceSpan} from '../src/trace';
 
 /**
@@ -55,10 +55,14 @@ export function assertSpanDuration(span: TraceSpan, bounds: [number, number]) {
           bounds[0]}, ${bounds[1]}] ms`);
 }
 
-export function asBaseSpanData(arg: SpanData): BaseSpanData {
-  assert.notStrictEqual(arg.type, SpanDataType.UNCORRELATED);
-  assert.notStrictEqual(arg.type, SpanDataType.UNTRACED);
-  return arg as BaseSpanData;
+export function asRootSpanData(arg: SpanData): RootSpanData {
+  assert.strictEqual(arg.type, SpanDataType.ROOT);
+  return arg as RootSpanData;
+}
+
+export function asChildSpanData(arg: SpanData): ChildSpanData {
+  assert.strictEqual(arg.type, SpanDataType.CHILD);
+  return arg as ChildSpanData;
 }
 
 export function plan(done: MochaDone, num: number): MochaDone {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -29,6 +29,7 @@
     "test/test-config-plugins.ts",
     "test/test-modules-loaded-before-agent.ts",
     "test/test-plugin-loader.ts",
+    "test/test-trace-api-none-cls.ts",
     "test/test-trace-cluster.ts",
     "test/test-trace-web-frameworks.ts",
     "test/test-util.ts",


### PR DESCRIPTION
Fixes #719

This PR does two things:

* In #728, a new `config.clsMechanism` option was added where, when set to `'none'`, a barebones CLS mechanism would be used where when a root span was started, it became the only possible active root span context until it was ended. This PR changes this so that root span context will _never_ be written when `clsMechanism` is set to `'none'`. Instead, the root span context always has a default value of `UNTRACED`. This affects the behavior of the custom tracing API in the following ways:
  * `traceApi.runInRootSpan` will _always_ return a root span (unless disallowed by the trace policy), even if run within a function passed to another call to `runInRootSpan`.
  * `traceApi.createChildSpan` will _always_ return an `UNTRACED` child span. This is because root spans can no longer be automatically determined from the root context.
* To address the second difference above, there is now a `rootSpan.createChildSpan` which takes the same options as `traceApi.createChildSpan`. When `clsMechanism` is set to `'none'`, the latter will not work, but the former will; when `clsMechanism` is set to/defaults to `'auto'`, they should behave the same way.