### PR TITLE
refactor: make logger always last arg

### DIFF
--- a/src/cls.ts
+++ b/src/cls.ts
@@ -106,7 +106,7 @@ export class TraceCLS implements CLS<RootContext> {
    */
   readonly rootSpanStackOffset: number;
 
-  constructor(private readonly logger: Logger, config: TraceCLSConfig) {
+  constructor(config: TraceCLSConfig, private readonly logger: Logger) {
     switch (config.mechanism) {
       case TraceCLSMechanism.ASYNC_HOOKS:
         if (!asyncHooksAvailable) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -186,17 +186,17 @@ export function start(projectConfig?: Config): PluginTypes.TraceAgent {
                                 m as TraceCLSMechanism,
       [FORCE_NEW]: config[FORCE_NEW]
     };
-    cls.create(logger, clsConfig).enable();
+    cls.create(clsConfig, logger).enable();
 
-    traceWriter.create(logger, config).initialize((err) => {
+    traceWriter.create(config, logger).initialize((err) => {
       if (err) {
         stop();
       }
     });
 
-    traceAgent.enable(logger, config);
+    traceAgent.enable(config, logger);
 
-    pluginLoader.create(logger, config).activate();
+    pluginLoader.create(config, logger).activate();
   } catch (e) {
     logger.error(
         'TraceAgent#start: Disabling the Trace Agent for the',

--- a/src/trace-api.ts
+++ b/src/trace-api.ts
@@ -81,12 +81,12 @@ export class TraceAgent implements TraceAgentInterface {
    * Enables this instance. This function is only for internal use and
    * unit tests. A separate TraceWriter instance should be initialized
    * beforehand.
-   * @param logger A logger object.
    * @param config An object specifying how this instance should
    * be configured.
+   * @param logger A logger object.
    * @private
    */
-  enable(logger: Logger, config: TraceAgentConfig) {
+  enable(config: TraceAgentConfig, logger: Logger) {
     this.logger = logger;
     this.config = config;
     this.policy = TracingPolicy.createTracePolicy(config);

--- a/src/trace-writer.ts
+++ b/src/trace-writer.ts
@@ -66,12 +66,12 @@ export class TraceWriter extends common.Service {
 
   /**
    * Constructs a new TraceWriter instance.
-   * @param logger The Trace Agent's logger object.
    * @param config A config object containing information about
    *   authorization credentials.
+   * @param logger The Trace Agent's logger object.
    * @constructor
    */
-  constructor(logger: common.Logger, config: TraceWriterConfig) {
+  constructor(config: TraceWriterConfig, logger: common.Logger) {
     super(
         {
           packageJson: pjson,

--- a/src/util.ts
+++ b/src/util.ts
@@ -45,7 +45,7 @@ interface PackageJson {
 }
 
 export interface Constructor<T, Config> {
-  new(logger: Logger, config: Config): T;
+  new(config: Config, logger: Logger): T;
   prototype: T;
   name: string;
 }
@@ -57,7 +57,7 @@ export type Forceable<T> = T&{[FORCE_NEW]?: boolean};
 /**
  * A class that provides access to a singleton.
  * We assume that any such singleton is always constructed with two arguments:
- * A logger and an arbitrary configuration object.
+ * An arbitrary configuration object and a logger.
  * Instances of this type should only be constructed in module scope.
  */
 export class Singleton<T, Config> {
@@ -66,9 +66,9 @@ export class Singleton<T, Config> {
 
   constructor(private implementation: Constructor<T, Config>) {}
 
-  create(logger: Logger, config: Forceable<Config>): T {
+  create(config: Forceable<Config>, logger: Logger): T {
     if (!this[kSingleton] || config[FORCE_NEW]) {
-      this[kSingleton] = new this.implementation(logger, config);
+      this[kSingleton] = new this.implementation(config, logger);
       return this[kSingleton]!;
     } else {
       throw new Error(`${this.implementation.name} has already been created.`);

--- a/src/util.ts
+++ b/src/util.ts
@@ -44,8 +44,8 @@ interface PackageJson {
   version: string;
 }
 
-export interface Constructor<T, Config> {
-  new(config: Config, logger: Logger): T;
+export interface Constructor<T, ConfigType, LoggerType> {
+  new(config: ConfigType, logger: LoggerType): T;
   prototype: T;
   name: string;
 }
@@ -60,13 +60,13 @@ export type Forceable<T> = T&{[FORCE_NEW]?: boolean};
  * An arbitrary configuration object and a logger.
  * Instances of this type should only be constructed in module scope.
  */
-export class Singleton<T, Config> {
+export class Singleton<T, ConfigType, LoggerType> {
   // Note: private[symbol] is enforced by clang-format.
   private[kSingleton]: T|null = null;
 
-  constructor(private implementation: Constructor<T, Config>) {}
+  constructor(private implementation: Constructor<T, ConfigType, LoggerType>) {}
 
-  create(config: Forceable<Config>, logger: Logger): T {
+  create(config: Forceable<ConfigType>, logger: LoggerType): T {
     if (!this[kSingleton] || config[FORCE_NEW]) {
       this[kSingleton] = new this.implementation(config, logger);
       return this[kSingleton]!;

--- a/test/plugins/common.ts
+++ b/test/plugins/common.ts
@@ -70,11 +70,11 @@ shimmer.wrap(trace, 'start', function(original) {
   return function() {
     var result = original.apply(this, arguments);
     testTraceAgent = new TraceAgent('test');
-    testTraceAgent.enable(logger(), {
+    testTraceAgent.enable({
       enhancedDatabaseReporting: false,
       ignoreContextHeader: false,
       samplingRate: 0
-    });
+    }, logger());
     testTraceAgent.policy = new TracingPolicy.TraceAllPolicy();
     return result;
   };

--- a/test/test-cls.ts
+++ b/test/test-cls.ts
@@ -283,7 +283,7 @@ describe('Continuation-Local Storage', () => {
 
         beforeEach(() => {
           try {
-            c = new TraceCLS(logger, testCase.config);
+            c = new TraceCLS(testCase.config, logger);
             c.enable();
           } catch {
             c = {disable: () => {}} as TraceCLS;
@@ -343,7 +343,7 @@ describe('Continuation-Local Storage', () => {
         const logger = new TestLogger();
 
         it('throws', () => {
-          assert.throws(() => new TraceCLS(logger, testCase));
+          assert.throws(() => new TraceCLS(testCase, logger));
         });
       });
     }

--- a/test/test-config-cls.ts
+++ b/test/test-config-cls.ts
@@ -31,8 +31,8 @@ describe('Behavior set by config for context propagation mechanism', () => {
   let capturedConfig: TraceCLSConfig|null;
 
   class CaptureConfigTestCLS extends trace.TestCLS {
-    constructor(logger: Logger, config: TraceCLSConfig) {
-      super(logger, config);
+    constructor(config: TraceCLSConfig, logger: Logger) {
+      super(config, logger);
       // Capture the config object passed into this constructor.
       capturedConfig = config;
     }

--- a/test/test-config-plugins.ts
+++ b/test/test-config-plugins.ts
@@ -27,8 +27,8 @@ describe('Configuration: Plugins', () => {
   let plugins: {[pluginName: string]: string}|null;
 
   class ConfigTestPluginLoader extends PluginLoader {
-    constructor(logger: Logger, config: PluginLoaderConfig) {
-      super(logger, config);
+    constructor(config: PluginLoaderConfig, logger: Logger) {
+      super(config, logger);
       plugins = config.plugins;
     }
   }

--- a/test/test-plugin-loader.ts
+++ b/test/test-plugin-loader.ts
@@ -40,7 +40,6 @@ describe('Trace Plugin Loader', () => {
   let logger: TestLogger;
   const makePluginLoader = (config: SimplePluginLoaderConfig) => {
     return new PluginLoader(
-        logger,
         Object.assign(
             {
               samplingRate: 0,
@@ -49,7 +48,8 @@ describe('Trace Plugin Loader', () => {
               ignoreContextHeader: false,
               projectId: '0'
             },
-            config));
+            config),
+        logger);
   };
 
   before(() => {

--- a/test/test-trace-api.ts
+++ b/test/test-trace-api.ts
@@ -74,12 +74,12 @@ function assertAPISurface(traceAPI) {
 
 describe('Trace Interface', function() {
   before(function(done) {
-    cls.create(logger, { mechanism: TraceCLSMechanism.ASYNC_LISTENER }).enable();
-    traceWriter.create(logger,
+    cls.create({ mechanism: TraceCLSMechanism.ASYNC_LISTENER }, logger).enable();
+    traceWriter.create(
       Object.assign(defaultConfig, {
         projectId: '0',
         [FORCE_NEW]: false
-      })).initialize(function(err) {
+      }), logger).initialize(function(err) {
         assert.ok(!err);
         done();
       });

--- a/test/test-trace-api.ts
+++ b/test/test-trace-api.ts
@@ -38,10 +38,10 @@ nock.disableNetConnect();
 
 function createTraceAgent(policy?, config?) {
   var result = new TraceAgent('test');
-  result.enable(logger, config || {
+  result.enable(config || {
     enhancedDatabaseReporting: false,
     ignoreContextHeader: false
-  });
+  }, logger);
   result.policy = policy || new TracingPolicy.TraceAllPolicy();
   return result;
 }

--- a/test/test-util.ts
+++ b/test/test-util.ts
@@ -32,32 +32,32 @@ const notNull = <T>(x: T|null|undefined): T => {
 describe('Singleton', () => {
   const logger = new TestLogger();
   class MyClass {
-    constructor(public logger: Logger, public config: {}) {}
+    constructor(public config: {}, public logger: Logger) {}
   }
 
   describe('create', () => {
     it('creates an instance of the given class', () => {
-      const createResult = new util.Singleton(MyClass).create(logger, {});
+      const createResult = new util.Singleton(MyClass).create({}, logger);
       assert.ok(createResult instanceof MyClass);
     });
 
     it('passes arguments to the underlying constructor', () => {
       const config = {};
-      const createResult = new util.Singleton(MyClass).create(logger, config);
+      const createResult = new util.Singleton(MyClass).create(config, logger);
       assert.strictEqual(createResult.logger, logger);
       assert.strictEqual(createResult.config, config);
     });
 
     it('throws when used more than once, by default', () => {
       const singleton = new util.Singleton(MyClass);
-      singleton.create(logger, {});
-      assert.throws(() => singleton.create(logger, {}));
+      singleton.create({}, logger);
+      assert.throws(() => singleton.create({}, logger));
     });
 
     it('creates a new instance when [FORCE_NEW] is true in the config', () => {
       const singleton = new util.Singleton(MyClass);
-      const createResult1 = singleton.create(logger, {});
-      const createResult2 = singleton.create(logger, {[util.FORCE_NEW]: true});
+      const createResult1 = singleton.create({}, logger);
+      const createResult2 = singleton.create({[util.FORCE_NEW]: true}, logger);
       assert.notStrictEqual(createResult1, createResult2);
     });
   });
@@ -69,15 +69,15 @@ describe('Singleton', () => {
 
     it('returns the same value returned by create function', () => {
       const singleton = new util.Singleton(MyClass);
-      const createResult = singleton.create(logger, {});
+      const createResult = singleton.create({}, logger);
       const getResult = singleton.get();
       assert.strictEqual(getResult, createResult);
     });
 
     it('does not return a stale value', () => {
       const singleton = new util.Singleton(MyClass);
-      singleton.create(logger, {});
-      const createResult = singleton.create(logger, {[util.FORCE_NEW]: true});
+      singleton.create({}, logger);
+      const createResult = singleton.create({[util.FORCE_NEW]: true}, logger);
       const getResult = singleton.get();
       assert.strictEqual(getResult, createResult);
     });

--- a/test/trace.ts
+++ b/test/trace.ts
@@ -59,8 +59,8 @@ const traces: Trace[] = [];
 const spans: TraceSpan[] = [];
 
 export class TestCLS extends TraceCLS {
-  constructor(logger: common.Logger, config: {}) {
-    super(logger, {mechanism: TraceCLSMechanism.NONE});
+  constructor(config: {}, logger: common.Logger) {
+    super({mechanism: TraceCLSMechanism.NONE}, logger);
   }
 }
 


### PR DESCRIPTION
This PR just changes methods so that a logger, if any, is always the last argument. There should be no functional changes -- this is just a self-contained part of a larger change.