### PR TITLE
 feat: add options to set the cls mechanism to async-hooks or async-listener

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -19,16 +19,22 @@ import * as path from 'path';
 const pluginDirectory =
     path.join(path.resolve(__dirname, '..'), 'src', 'plugins');
 
-export type CLSMechanism = 'auto'|'none'|'singular';
+export type CLSMechanism =
+    'async-hooks'|'async-listener'|'auto'|'none'|'singular';
 
 /** Available configuration options. */
 export interface Config {
   /**
    * The trace context propagation mechanism to use. The following options are
    * available:
-   * - 'auto' uses continuation-local-storage, unless async_hooks is available
-   *   _and_ the environment variable GCLOUD_TRACE_NEW_CONTEXT is set, in which
-   *   case async_hooks will be used instead.
+   * - 'async-hooks' uses an implementation of CLS on top of the Node core
+   *   `async_hooks` module in Node 8+. This option should not be used if the
+   *   Node binary version requirements are not met.
+   * - 'async-listener' uses an implementation of CLS on top of the
+   *   `continuation-local-storage` module.
+   * - 'auto' behaves like 'async-hooks' on Node 8+ when the
+   *   GCLOUD_TRACE_NEW_CONTEXT env variable is set, and 'async-listener'
+   *   otherwise.
    * - 'none' disables CLS completely.
    * - 'singular' allows one root span to exist at a time. This option is meant
    *   to be used internally by Google Cloud Functions, or in any other

--- a/src/trace-plugin-loader.ts
+++ b/src/trace-plugin-loader.ts
@@ -420,8 +420,6 @@ export class PluginLoader {
       }
       this.internalState = PluginLoaderState.DEACTIVATED;
       this.logger.info(`PluginLoader#deactivate: Deactivated.`);
-    } else {
-      throw new Error('Plugin loader is not activated.');
     }
     return this;
   }

--- a/src/tracing.ts
+++ b/src/tracing.ts
@@ -1,0 +1,220 @@
+/**
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as common from '@google-cloud/common';
+import * as extend from 'extend';
+import * as path from 'path';
+import * as semver from 'semver';
+
+import {cls, TraceCLSConfig, TraceCLSMechanism} from './cls';
+import {CLSMechanism, Config, defaultConfig} from './config';
+import {Constants} from './constants';
+import * as PluginTypes from './plugin-types';
+import {TraceAgent} from './trace-api';
+import {pluginLoader, PluginLoaderConfig} from './trace-plugin-loader';
+import {traceWriter, TraceWriterConfig} from './trace-writer';
+import {Component, FORCE_NEW, Forceable, packageNameFromPath, Singleton} from './util';
+
+interface TopLevelConfig {
+  enabled: boolean;
+  logLevel: number;
+  clsMechanism: CLSMechanism;
+}
+
+// PluginLoaderConfig extends TraceAgentConfig
+type NormalizedConfig = TraceWriterConfig&PluginLoaderConfig&TopLevelConfig;
+
+/**
+ * A class that represents automatic tracing.
+ */
+export class Tracing implements Component {
+  /** An object representing the custom span API. */
+  readonly traceAgent: TraceAgent = new TraceAgent('Custom Trace API');
+  private logger: common.Logger;
+  private config: Forceable<NormalizedConfig>;
+
+  /**
+   * Constructs a new Tracing instance.
+   * @param config The configuration for this instance.
+   */
+  constructor(config: Config) {
+    this.config = Tracing.initConfig(config);
+    this.logger = common.logger({
+      level: common.logger.LEVELS[this.config.logLevel],
+      tag: '@google-cloud/trace-agent'
+    });
+  }
+
+  /**
+   * Normalizes the user-provided configuration object by adding default values
+   * and overriding with env variables when they are provided.
+   * @param projectConfig The user-provided configuration object. It will not
+   * be modified.
+   * @return A normalized configuration object.
+   */
+  private static initConfig(projectConfig: Forceable<Config>):
+      Forceable<NormalizedConfig> {
+    // `|| undefined` prevents environmental variables that are empty strings
+    // from overriding values provided in the config object passed to start().
+    const envConfig = {
+      logLevel: Number(process.env.GCLOUD_TRACE_LOGLEVEL) || undefined,
+      projectId: process.env.GCLOUD_PROJECT || undefined,
+      serviceContext: {
+        service:
+            process.env.GAE_SERVICE || process.env.GAE_MODULE_NAME || undefined,
+        version: process.env.GAE_VERSION || process.env.GAE_MODULE_VERSION ||
+            undefined,
+        minorVersion: process.env.GAE_MINOR_VERSION || undefined
+      }
+    };
+
+    let envSetConfig: Config = {};
+    if (!!process.env.GCLOUD_TRACE_CONFIG) {
+      envSetConfig =
+          require(path.resolve(process.env.GCLOUD_TRACE_CONFIG!)) as Config;
+    }
+    // Configuration order of precedence:
+    // 1. Environment Variables
+    // 2. Project Config
+    // 3. Environment Variable Set Configuration File (from GCLOUD_TRACE_CONFIG)
+    // 4. Default Config (as specified in './config')
+    const config = extend(
+        true, {[FORCE_NEW]: projectConfig[FORCE_NEW]}, defaultConfig,
+        envSetConfig, projectConfig, envConfig, {plugins: {}});
+    // The empty plugins object guarantees that plugins is a plain object,
+    // even if it's explicitly specified in the config to be a non-object.
+
+    // Enforce the upper limit for the label value size.
+    if (config.maximumLabelValueSize >
+        Constants.TRACE_SERVICE_LABEL_VALUE_LIMIT) {
+      config.maximumLabelValueSize = Constants.TRACE_SERVICE_LABEL_VALUE_LIMIT;
+    }
+    // Clamp the logger level.
+    if (config.logLevel < 0) {
+      config.logLevel = 0;
+    } else if (config.logLevel >= common.logger.LEVELS.length) {
+      config.logLevel = common.logger.LEVELS.length - 1;
+    }
+    return config;
+  }
+
+  /**
+   * Logs an error message detailing the list of modules that were loaded before
+   * the Trace Agent. Loading these modules before the Trace Agent may prevent
+   * us from monkeypatching those modules for automatic tracing.
+   * @param filesLoadedBeforeTrace The list of files that were loaded using
+   * require() before the Stackdriver Trace Agent was required.
+   */
+  logModulesLoadedBeforeTrace(filesLoadedBeforeTrace: string[]) {
+    const modulesLoadedBeforeTrace: string[] = [];
+    const traceModuleName = path.join('@google-cloud', 'trace-agent');
+    for (let i = 0; i < filesLoadedBeforeTrace.length; i++) {
+      const moduleName = packageNameFromPath(filesLoadedBeforeTrace[i]);
+      if (moduleName && moduleName !== traceModuleName &&
+          modulesLoadedBeforeTrace.indexOf(moduleName) === -1) {
+        modulesLoadedBeforeTrace.push(moduleName);
+      }
+    }
+    if (modulesLoadedBeforeTrace.length > 0) {
+      this.logger.error(
+          'TraceAgent#start: Tracing might not work as the following modules',
+          'were loaded before the trace agent was initialized:',
+          `[${modulesLoadedBeforeTrace.sort().join(', ')}]`);
+    }
+  }
+
+  /**
+   * Enables automatic tracing support and the custom span API.
+   */
+  enable(): void {
+    if (this.traceAgent.isActive()) {
+      // For unit tests only.
+      // Undoes initialization that occurred last time this function was called.
+      this.disable();
+    }
+
+    if (!this.config.enabled) {
+      return;
+    }
+
+    try {
+      // Initialize context propagation mechanism.
+      const m = this.config.clsMechanism;
+      const ahAvailable = semver.satisfies(process.version, '>=8') &&
+          process.env.GCLOUD_TRACE_NEW_CONTEXT;
+      const clsConfig: Forceable<TraceCLSConfig> = {
+        mechanism: m === 'auto' ?
+            (ahAvailable ? TraceCLSMechanism.ASYNC_HOOKS :
+                           TraceCLSMechanism.ASYNC_LISTENER) :
+            m as TraceCLSMechanism,
+        [FORCE_NEW]: this.config[FORCE_NEW]
+      };
+      cls.create(clsConfig, this.logger).enable();
+
+      traceWriter.create(this.config, this.logger).initialize((err) => {
+        if (err) {
+          this.disable();
+        }
+      });
+
+      this.traceAgent.enable(this.config, this.logger);
+
+      pluginLoader.create(this.config, this.logger).activate();
+    } catch (e) {
+      this.logger.error(
+          'TraceAgent#start: Disabling the Trace Agent for the',
+          `following reason: ${e.message}`);
+      this.disable();
+      return;
+    }
+
+    if (typeof this.config.projectId !== 'string' &&
+        typeof this.config.projectId !== 'undefined') {
+      this.logger.error(
+          'TraceAgent#start: config.projectId, if provided, must be a string.',
+          'Disabling trace agent.');
+      this.disable();
+      return;
+    }
+
+    // Make trace agent available globally without requiring package
+    global._google_trace_agent = this.traceAgent;
+
+    this.logger.info('TraceAgent#start: Trace Agent activated.');
+  }
+
+  /**
+   * Disables automatic tracing support. This disables the publicly exposed
+   * custom span API, as well as any instances passed to plugins. This also
+   * prevents the Trace Writer from publishing additional traces.
+   */
+  disable() {
+    if (pluginLoader.exists()) {
+      pluginLoader.get().deactivate();
+    }
+    if (this.traceAgent.isActive()) {
+      this.traceAgent.disable();
+    }
+    if (cls.exists()) {
+      cls.get().disable();
+    }
+    if (traceWriter.exists()) {
+      traceWriter.get().stop();
+    }
+  }
+}
+
+export const tracing = new Singleton(Tracing);

--- a/src/tracing.ts
+++ b/src/tracing.ts
@@ -42,16 +42,19 @@ export type NormalizedConfig =
  */
 export class Tracing implements Component {
   /** An object representing the custom span API. */
-  readonly traceAgent: TraceAgent = new TraceAgent('Custom Trace API');
-  private logger: common.Logger;
-  private config: Forceable<NormalizedConfig>;
+  private readonly traceAgent: TraceAgent;
+  /** A logger. */
+  private readonly logger: common.Logger;
+  /** The configuration object for this instance. */
+  private readonly config: Forceable<NormalizedConfig>;
 
   /**
    * Constructs a new Tracing instance.
    * @param config The configuration for this instance.
    */
-  constructor(config: NormalizedConfig) {
+  constructor(config: NormalizedConfig, traceAgent: TraceAgent) {
     this.config = config;
+    this.traceAgent = traceAgent;
     let logLevel = config.enabled ? config.logLevel : 0;
     // Clamp the logger level.
     if (logLevel < 0) {

--- a/src/util.ts
+++ b/src/util.ts
@@ -54,6 +54,10 @@ export const FORCE_NEW = Symbol('force-new');
 
 export type Forceable<T> = T&{[FORCE_NEW]?: boolean};
 
+export type Component = {
+  enable(): void; disable(): void;
+};
+
 /**
  * A class that provides access to a singleton.
  * We assume that any such singleton is always constructed with two arguments:
@@ -68,6 +72,10 @@ export class Singleton<T, ConfigType, LoggerType> {
 
   create(config: Forceable<ConfigType>, logger: LoggerType): T {
     if (!this[kSingleton] || config[FORCE_NEW]) {
+      const s = this[kSingleton] as Partial<Component>;
+      if (s && s.disable) {
+        s.disable();
+      }
       this[kSingleton] = new this.implementation(config, logger);
       return this[kSingleton]!;
     } else {

--- a/test/test-plugin-loader.ts
+++ b/test/test-plugin-loader.ts
@@ -136,24 +136,6 @@ describe('Trace Plugin Loader', () => {
                pluginLoader.state, PluginLoaderState.DEACTIVATED);
            assert.ok(plugin.unapplyCalled);
          });
-
-      it('throws when internal state is not ACTIVATED', () => {
-        const pluginLoader = makePluginLoader({plugins: {}});
-        assert.strictEqual(pluginLoader.state, PluginLoaderState.NO_HOOK);
-        const plugin = new TestPluginWrapper();
-        // TODO(kjin): Stop using index properties.
-        pluginLoader['pluginMap'].set('foo', plugin);
-
-        assert.throws(() => pluginLoader.deactivate());
-        assert.ok(!plugin.unapplyCalled);
-
-        pluginLoader.activate().deactivate();
-        assert.strictEqual(pluginLoader.state, PluginLoaderState.DEACTIVATED);
-
-        plugin.unapplyCalled = false;
-        assert.throws(() => pluginLoader.deactivate());
-        assert.ok(!plugin.unapplyCalled);
-      });
     });
   });
 


### PR DESCRIPTION
~~This PR makes `async_hooks`-based Tracing the default option for tracing using Node 8+. To go back to using `async-listener` (via `continuation-local-storage`), new `config.clsMechanism` options are accepted: `async-listener` (and `async-hooks`).~~

This PR provides two new possible values for `config.clsMechanism`: `async-listener` and `async-hooks`.

Because context tracking is now specified as a config option rather than strictly as an environmental variable, a fair bit of refactoring is needed to support conditionally loading `continuation-local-storage` as late as possible. The constraints to satisfy are as following:

- `continuation-local-storage` needs to be loaded as early as possible, and definitely before any modules that do I/O.
- `continuation-local-storage` must be loaded after `start()` is called, so we know whether to load it (via the config option passed to `start`).

To accomplish this, most of the logic in `index.ts` has been moved to a new file, `tracing.ts`, where it is now encapsulated in a class `Tracing`. Barring the `feat:` change, there should be no behavioral changes; however there are some caveats that hopefully are captured in the added comments.

There is also a small change to prevent `PluginLoader#deactivate` from throwing when being called on an already deactivated plugin loader. This is only required to prevent large-scale changes to tests, as the case when it might be called when the plugin loader is de-activated is from test code that sets the `[FORCE_NEW]` flag in configuration objects.