### PR TITLE
test: make it clear that some methods are test-only

### DIFF
--- a/test/plugins/test-trace-google-gax.ts
+++ b/test/plugins/test-trace-google-gax.ts
@@ -59,15 +59,15 @@ describe('Tracing with google-gax', () => {
   let googleGax: GaxModule;
 
   before(() => {
-    trace.setCLS();
-    trace.setPluginLoader();
+    trace.setCLSForTest();
+    trace.setPluginLoaderForTest();
     trace.start();
     googleGax = require('./fixtures/google-gax0.16');
   });
 
   after(() => {
-    trace.setCLS(trace.TestCLS);
-    trace.setPluginLoader(trace.TestPluginLoader);
+    trace.setCLSForTest(trace.TestCLS);
+    trace.setPluginLoaderForTest(trace.TestPluginLoader);
   });
 
   it(`doesn't break context`, (done) => {

--- a/test/plugins/test-trace-google-gax.ts
+++ b/test/plugins/test-trace-google-gax.ts
@@ -37,7 +37,7 @@
 
 import * as assert from 'assert';
 
-import * as trace from '../trace';
+import * as testTraceModule from '../trace';
 
 interface ApiCallSettings {
   merge: () => {
@@ -59,38 +59,38 @@ describe('Tracing with google-gax', () => {
   let googleGax: GaxModule;
 
   before(() => {
-    trace.setCLSForTest();
-    trace.setPluginLoaderForTest();
-    trace.start();
+    testTraceModule.setCLSForTest();
+    testTraceModule.setPluginLoaderForTest();
+    testTraceModule.start();
     googleGax = require('./fixtures/google-gax0.16');
   });
 
   after(() => {
-    trace.setCLSForTest(trace.TestCLS);
-    trace.setPluginLoaderForTest(trace.TestPluginLoader);
+    testTraceModule.setCLSForTest(testTraceModule.TestCLS);
+    testTraceModule.setPluginLoaderForTest(testTraceModule.TestPluginLoader);
   });
 
   it(`doesn't break context`, (done) => {
     const authPromise = Promise.resolve(
         ((args, metadata, opts, cb) => {
           // Simulate an RPC.
-          trace.get().createChildSpan({name: 'in-request'}).endSpan();
+          testTraceModule.get().createChildSpan({name: 'in-request'}).endSpan();
           setImmediate(() => cb(null, {}));
         }) as InnerApiCall<{}, {}>);
     const apiCall =
         googleGax.createApiCall(authPromise, {merge: () => ({otherArgs: {}})});
 
-    trace.get().runInRootSpan({name: 'root'}, (root) => {
+    testTraceModule.get().runInRootSpan({name: 'root'}, (root) => {
       apiCall({}, {timeout: 20}, (err) => {
         assert.ifError(err);
-        trace.get().createChildSpan({name: 'in-callback'}).endSpan();
+        testTraceModule.get().createChildSpan({name: 'in-callback'}).endSpan();
         root.endSpan();
 
         // Both children should be nested under the root span where the API call
         // was made, instead of inheriting the (non-existent) context where
         // createApiCall was called.
-        const correctTrace =
-            trace.getOneTrace(t => t.spans.some(span => span.name === 'root'));
+        const correctTrace = testTraceModule.getOneTrace(
+            t => t.spans.some(span => span.name === 'root'));
         assert.strictEqual(correctTrace.spans.length, 3);
         done();
       });

--- a/test/plugins/test-trace-http.ts
+++ b/test/plugins/test-trace-http.ts
@@ -117,8 +117,8 @@ for (const nodule of Object.keys(servers) as Array<keyof typeof servers>) {
   describe(`${nodule} client tracing`, () => {
     let http: {get: HttpRequest; request: HttpRequest;};
     before(() => {
-      trace.setCLS();
-      trace.setPluginLoader();
+      trace.setCLSForTest();
+      trace.setPluginLoaderForTest();
       trace.start({
         plugins: {
           express: ''  // we are not interested in tracing express.

--- a/test/plugins/test-trace-http.ts
+++ b/test/plugins/test-trace-http.ts
@@ -26,7 +26,7 @@ import * as stream from 'stream';
 import {URL} from 'url';
 
 import {TraceSpan} from '../../src/trace';
-import * as trace from '../trace';
+import * as testTraceModule from '../trace';
 import {ASSERT_SPAN_TIME_TOLERANCE_MS, assertSpanDuration, DEFAULT_SPAN_DURATION} from '../utils';
 import {Express4} from '../web-frameworks/express';
 
@@ -117,9 +117,9 @@ for (const nodule of Object.keys(servers) as Array<keyof typeof servers>) {
   describe(`${nodule} client tracing`, () => {
     let http: {get: HttpRequest; request: HttpRequest;};
     before(() => {
-      trace.setCLSForTest();
-      trace.setPluginLoaderForTest();
-      trace.start({
+      testTraceModule.setCLSForTest();
+      testTraceModule.setPluginLoaderForTest();
+      testTraceModule.start({
         plugins: {
           express: ''  // we are not interested in tracing express.
         }
@@ -128,7 +128,7 @@ for (const nodule of Object.keys(servers) as Array<keyof typeof servers>) {
     });
 
     afterEach(() => {
-      trace.clearTraceData();
+      testTraceModule.clearTraceData();
     });
 
     describe('in various usage scenarios', () => {
@@ -225,16 +225,16 @@ for (const nodule of Object.keys(servers) as Array<keyof typeof servers>) {
         it(`creates spans with accurate timespans when ${testCase.description}`,
            async () => {
              let recordedTime = 0;
-             await trace.get().runInRootSpan(
+             await testTraceModule.get().runInRootSpan(
                  {name: 'outer'}, async (rootSpan) => {
-                   assert.ok(trace.get().isRealSpan(rootSpan));
+                   assert.ok(testTraceModule.get().isRealSpan(rootSpan));
                    recordedTime = Date.now();
                    await testCase.fn();
                    recordedTime = Date.now() - recordedTime;
                    rootSpan.endSpan();
                  });
              const clientSpan =
-                 trace.getOneSpan(span => span.kind === 'RPC_CLIENT');
+                 testTraceModule.getOneSpan(span => span.kind === 'RPC_CLIENT');
              assertSpanDuration(
                  clientSpan,
                  [recordedTime - ASSERT_SPAN_TIME_TOLERANCE_MS, recordedTime]);
@@ -256,15 +256,18 @@ for (const nodule of Object.keys(servers) as Array<keyof typeof servers>) {
       });
       const port = server.listen(0);
       try {
-        await trace.get().runInRootSpan({name: 'outer'}, async (rootSpan) => {
-          assert.ok(trace.get().isRealSpan(rootSpan));
-          const waitForResponse = new WaitForResponse();
-          http.get(`http://localhost:${port}`, waitForResponse.handleResponse);
-          await waitForResponse.done;
-          rootSpan.endSpan();
-        });
+        await testTraceModule.get().runInRootSpan(
+            {name: 'outer'}, async (rootSpan) => {
+              assert.ok(testTraceModule.get().isRealSpan(rootSpan));
+              const waitForResponse = new WaitForResponse();
+              http.get(
+                  `http://localhost:${port}`, waitForResponse.handleResponse);
+              await waitForResponse.done;
+              rootSpan.endSpan();
+            });
         assert.doesNotThrow(
-            () => trace.getOneSpan(span => span.kind === 'RPC_CLIENT'));
+            () =>
+                testTraceModule.getOneSpan(span => span.kind === 'RPC_CLIENT'));
       } finally {
         server.shutdown();
       }
@@ -281,19 +284,20 @@ for (const nodule of Object.keys(servers) as Array<keyof typeof servers>) {
       });
       const port = server.listen(0);
       try {
-        await trace.get().runInRootSpan({name: 'outer'}, async (rootSpan) => {
-          assert.ok(trace.get().isRealSpan(rootSpan));
-          const waitForResponse = new WaitForResponse();
-          http.get(
-              {port, rejectUnauthorized: false},
-              waitForResponse.handleResponse);
-          await waitForResponse.done;
-          const afterHttpSpan =
-              trace.get().createChildSpan({name: 'after-http'});
-          assert.ok(trace.get().isRealSpan(afterHttpSpan));
-          afterHttpSpan.endSpan();
-          rootSpan.endSpan();
-        });
+        await testTraceModule.get().runInRootSpan(
+            {name: 'outer'}, async (rootSpan) => {
+              assert.ok(testTraceModule.get().isRealSpan(rootSpan));
+              const waitForResponse = new WaitForResponse();
+              http.get(
+                  {port, rejectUnauthorized: false},
+                  waitForResponse.handleResponse);
+              await waitForResponse.done;
+              const afterHttpSpan =
+                  testTraceModule.get().createChildSpan({name: 'after-http'});
+              assert.ok(testTraceModule.get().isRealSpan(afterHttpSpan));
+              afterHttpSpan.endSpan();
+              rootSpan.endSpan();
+            });
       } finally {
         server.shutdown();
       }
@@ -310,19 +314,22 @@ for (const nodule of Object.keys(servers) as Array<keyof typeof servers>) {
       });
       const port = server.listen(0);
       try {
-        await trace.get().runInRootSpan({name: 'outer'}, async (rootSpan) => {
-          assert.ok(trace.get().isRealSpan(rootSpan));
-          const waitForResponse = new WaitForResponse();
-          const headers: httpModule.OutgoingHttpHeaders = {};
-          headers[trace.get().constants.TRACE_AGENT_REQUEST_HEADER] = 'yay';
-          http.get(
-              {port, rejectUnauthorized: false, headers},
-              waitForResponse.handleResponse);
-          await waitForResponse.done;
-          rootSpan.endSpan();
-        });
+        await testTraceModule.get().runInRootSpan(
+            {name: 'outer'}, async (rootSpan) => {
+              assert.ok(testTraceModule.get().isRealSpan(rootSpan));
+              const waitForResponse = new WaitForResponse();
+              const headers: httpModule.OutgoingHttpHeaders = {};
+              headers[testTraceModule.get()
+                          .constants.TRACE_AGENT_REQUEST_HEADER] = 'yay';
+              http.get(
+                  {port, rejectUnauthorized: false, headers},
+                  waitForResponse.handleResponse);
+              await waitForResponse.done;
+              rootSpan.endSpan();
+            });
         assert.strictEqual(
-            trace.getSpans(span => span.kind === 'RPC_CLIENT').length, 0);
+            testTraceModule.getSpans(span => span.kind === 'RPC_CLIENT').length,
+            0);
       } finally {
         server.shutdown();
       }
@@ -330,13 +337,15 @@ for (const nodule of Object.keys(servers) as Array<keyof typeof servers>) {
 
     it('should not break with no target', () => {
       return new Promise(
-          resolve => trace.get().runInRootSpan({name: 'outer'}, (rootSpan) => {
-            assert.ok(trace.get().isRealSpan(rootSpan));
-            (http.get as (arg?: {}) => EventEmitter)().on('error', (err) => {
-              resolve();
-            });
-            rootSpan.endSpan();
-          }));
+          resolve => testTraceModule.get().runInRootSpan(
+              {name: 'outer'}, (rootSpan) => {
+                assert.ok(testTraceModule.get().isRealSpan(rootSpan));
+                (http.get as (arg?: {}) => EventEmitter)().on(
+                    'error', (err) => {
+                      resolve();
+                    });
+                rootSpan.endSpan();
+              }));
     });
 
     it('should handle concurrent requests', async () => {
@@ -352,22 +361,23 @@ for (const nodule of Object.keys(servers) as Array<keyof typeof servers>) {
       });
       const port = server.listen(0);
       try {
-        await trace.get().runInRootSpan({name: 'outer'}, async (rootSpan) => {
-          await Promise.all([0, 1, 2, 3, 4].map(async i => {
-            assert.ok(trace.get().isRealSpan(rootSpan));
-            const waitForResponse = new WaitForResponse();
-            http.get(
-                {port, rejectUnauthorized: false},
-                waitForResponse.handleResponse);
-            await waitForResponse.done;
-          }));
-          rootSpan.endSpan();
-        });
+        await testTraceModule.get().runInRootSpan(
+            {name: 'outer'}, async (rootSpan) => {
+              await Promise.all([0, 1, 2, 3, 4].map(async i => {
+                assert.ok(testTraceModule.get().isRealSpan(rootSpan));
+                const waitForResponse = new WaitForResponse();
+                http.get(
+                    {port, rejectUnauthorized: false},
+                    waitForResponse.handleResponse);
+                await waitForResponse.done;
+              }));
+              rootSpan.endSpan();
+            });
         assert.strictEqual(
-            trace.getSpans(span => span.kind === 'RPC_CLIENT')
+            testTraceModule.getSpans(span => span.kind === 'RPC_CLIENT')
                 .map(
                     span => Number(
-                        span.labels[trace.get()
+                        span.labels[testTraceModule.get()
                                         .labels.HTTP_RESPONSE_CODE_LABEL_KEY]))
                 .reduce((a, b) => a + b, 0),
             1010);
@@ -377,8 +387,10 @@ for (const nodule of Object.keys(servers) as Array<keyof typeof servers>) {
     });
 
     describe('trace spans', () => {
-      const ERROR_DETAILS_NAME = trace.get().labels.ERROR_DETAILS_NAME;
-      const ERROR_DETAILS_MESSAGE = trace.get().labels.ERROR_DETAILS_MESSAGE;
+      const ERROR_DETAILS_NAME =
+          testTraceModule.get().labels.ERROR_DETAILS_NAME;
+      const ERROR_DETAILS_MESSAGE =
+          testTraceModule.get().labels.ERROR_DETAILS_MESSAGE;
       let port: number;
       let successSpan: TraceSpan;
       let errorSpan: TraceSpan;
@@ -394,25 +406,26 @@ for (const nodule of Object.keys(servers) as Array<keyof typeof servers>) {
           }
         });
         port = server.listen(0);
-        await trace.get().runInRootSpan({name: 'outer'}, async (rootSpan) => {
-          assert.ok(trace.get().isRealSpan(rootSpan));
-          let waitForResponse = new WaitForResponse();
-          http.get(
-              {port, rejectUnauthorized: false, path: '/?foo=bar'},
-              waitForResponse.handleResponse);
-          await waitForResponse.done;
-          server.server!.timeout = DEFAULT_SPAN_DURATION / 2;
-          waitForResponse = new WaitForResponse();
-          http.get({port, rejectUnauthorized: false}).on('error', () => {
-            waitForResponse.handleDone();
-          });
-          await waitForResponse.done;
-          rootSpan.endSpan();
-        });
-        successSpan = trace.getOneSpan(
+        await testTraceModule.get().runInRootSpan(
+            {name: 'outer'}, async (rootSpan) => {
+              assert.ok(testTraceModule.get().isRealSpan(rootSpan));
+              let waitForResponse = new WaitForResponse();
+              http.get(
+                  {port, rejectUnauthorized: false, path: '/?foo=bar'},
+                  waitForResponse.handleResponse);
+              await waitForResponse.done;
+              server.server!.timeout = DEFAULT_SPAN_DURATION / 2;
+              waitForResponse = new WaitForResponse();
+              http.get({port, rejectUnauthorized: false}).on('error', () => {
+                waitForResponse.handleDone();
+              });
+              await waitForResponse.done;
+              rootSpan.endSpan();
+            });
+        successSpan = testTraceModule.getOneSpan(
             span =>
                 span.kind === 'RPC_CLIENT' && !span.labels[ERROR_DETAILS_NAME]);
-        errorSpan = trace.getOneSpan(
+        errorSpan = testTraceModule.getOneSpan(
             span => span.kind === 'RPC_CLIENT' &&
                 !!span.labels[ERROR_DETAILS_NAME]);
         server.shutdown();
@@ -424,7 +437,7 @@ for (const nodule of Object.keys(servers) as Array<keyof typeof servers>) {
 
       it('should include custom port number in the url label', () => {
         assert.strictEqual(
-            successSpan.labels[trace.get().labels.HTTP_URL_LABEL_KEY],
+            successSpan.labels[testTraceModule.get().labels.HTTP_URL_LABEL_KEY],
             `${nodule}://localhost:${port}/?foo=bar`);
       });
 

--- a/test/test-config-cls.ts
+++ b/test/test-config-cls.ts
@@ -43,11 +43,11 @@ describe('Behavior set by config for context propagation mechanism', () => {
   });
 
   before(() => {
-    trace.setCLS(CaptureConfigTestCLS);
+    trace.setCLSForTest(CaptureConfigTestCLS);
   });
 
   after(() => {
-    trace.setCLS(trace.TestCLS);
+    trace.setCLSForTest(trace.TestCLS);
   });
 
   const testCases: Array<

--- a/test/test-config-cls.ts
+++ b/test/test-config-cls.ts
@@ -21,7 +21,7 @@ import * as util from 'util';
 
 import {TraceCLSConfig, TraceCLSMechanism} from '../src/cls';
 
-import * as trace from './trace';
+import * as testTraceModule from './trace';
 
 describe('Behavior set by config for context propagation mechanism', () => {
   const useAH = semver.satisfies(process.version, '>=8') &&
@@ -30,7 +30,7 @@ describe('Behavior set by config for context propagation mechanism', () => {
       useAH ? TraceCLSMechanism.ASYNC_HOOKS : TraceCLSMechanism.ASYNC_LISTENER;
   let capturedConfig: TraceCLSConfig|null;
 
-  class CaptureConfigTestCLS extends trace.TestCLS {
+  class CaptureConfigTestCLS extends testTraceModule.TestCLS {
     constructor(config: TraceCLSConfig, logger: Logger) {
       super(config, logger);
       // Capture the config object passed into this constructor.
@@ -43,15 +43,17 @@ describe('Behavior set by config for context propagation mechanism', () => {
   });
 
   before(() => {
-    trace.setCLSForTest(CaptureConfigTestCLS);
+    testTraceModule.setCLSForTest(CaptureConfigTestCLS);
   });
 
   after(() => {
-    trace.setCLSForTest(trace.TestCLS);
+    testTraceModule.setCLSForTest(testTraceModule.TestCLS);
   });
 
-  const testCases: Array<
-      {tracingConfig: trace.Config, contextPropagationConfig: TraceCLSConfig}> =
+  const testCases: Array<{
+    tracingConfig: testTraceModule.Config,
+    contextPropagationConfig: TraceCLSConfig
+  }> =
       [
         {
           tracingConfig: {clsMechanism: 'none'},
@@ -77,7 +79,7 @@ describe('Behavior set by config for context propagation mechanism', () => {
     it(`should be as expected for config: ${
            util.inspect(testCase.tracingConfig)}`,
        () => {
-         trace.start(testCase.tracingConfig);
+         testTraceModule.start(testCase.tracingConfig);
          assert.ok(capturedConfig);
          assert.strictEqual(
              capturedConfig!.mechanism,

--- a/test/test-config-credentials.ts
+++ b/test/test-config-credentials.ts
@@ -21,7 +21,7 @@ import * as path from 'path';
 
 import {FORCE_NEW} from '../src/util';
 import {oauth2, patchTraces} from './nocks';
-import * as trace from './trace';
+import * as testTraceModule from './trace';
 import {plan} from './utils';
 
 interface TestCredentials {
@@ -33,7 +33,7 @@ interface TestCredentials {
 }
 
 function queueSpans(n: number) {
-  const traceApi = trace.get();
+  const traceApi = testTraceModule.get();
   for (let i = 0; i < n; i++) {
     traceApi.runInRootSpan({name: `trace-${i}`}, (rootSpan) => {
       assert.ok(rootSpan);
@@ -48,13 +48,13 @@ describe('Credentials Configuration', () => {
   before(() => {
     savedProject = process.env.GCLOUD_PROJECT;
     process.env.GCLOUD_PROJECT = '0';
-    trace.setTraceWriterForTest();
+    testTraceModule.setTraceWriterForTest();
     disableNetConnect();
   });
 
   after(() => {
     process.env.GCLOUD_PROJECT = savedProject;
-    trace.setTraceWriterForTest(trace.TestTraceWriter);
+    testTraceModule.setTraceWriterForTest(testTraceModule.TestTraceWriter);
     enableNetConnect();
   });
 
@@ -67,7 +67,7 @@ describe('Credentials Configuration', () => {
       keyFilename: path.join('test', 'fixtures', 'gcloud-credentials.json'),
       [FORCE_NEW]: true
     };
-    const agent = trace.start(config);
+    const agent = testTraceModule.start(config);
     const scope = oauth2<TestCredentials>((body) => {
       assert.strictEqual(body.client_id, credentials.client_id);
       assert.strictEqual(body.client_secret, credentials.client_secret);
@@ -89,7 +89,7 @@ describe('Credentials Configuration', () => {
     const credentials: TestCredentials =
         require('./fixtures/gcloud-credentials.json');
     const config = {bufferSize: 2, credentials, [FORCE_NEW]: true};
-    const agent = trace.start(config);
+    const agent = testTraceModule.start(config);
     const scope = oauth2<TestCredentials>((body) => {
       assert.strictEqual(body.client_id, credentials.client_id);
       assert.strictEqual(body.client_secret, credentials.client_secret);
@@ -120,7 +120,7 @@ describe('Credentials Configuration', () => {
       keyFilename: path.join('test', 'fixtures', 'gcloud-credentials.json'),
       [FORCE_NEW]: true
     };
-    const agent = trace.start(config);
+    const agent = testTraceModule.start(config);
     const scope = oauth2<TestCredentials>((body) => {
       assert.strictEqual(body.client_id, correctCredentials.client_id);
       assert.strictEqual(body.client_secret, correctCredentials.client_secret);

--- a/test/test-config-credentials.ts
+++ b/test/test-config-credentials.ts
@@ -48,13 +48,13 @@ describe('Credentials Configuration', () => {
   before(() => {
     savedProject = process.env.GCLOUD_PROJECT;
     process.env.GCLOUD_PROJECT = '0';
-    trace.setTraceWriter();
+    trace.setTraceWriterForTest();
     disableNetConnect();
   });
 
   after(() => {
     process.env.GCLOUD_PROJECT = savedProject;
-    trace.setTraceWriter(trace.TestTraceWriter);
+    trace.setTraceWriterForTest(trace.TestTraceWriter);
     enableNetConnect();
   });
 

--- a/test/test-config-plugins.ts
+++ b/test/test-config-plugins.ts
@@ -34,11 +34,11 @@ describe('Configuration: Plugins', () => {
   }
 
   before(() => {
-    trace.setPluginLoader(ConfigTestPluginLoader);
+    trace.setPluginLoaderForTest(ConfigTestPluginLoader);
   });
 
   after(() => {
-    trace.setPluginLoader(trace.TestPluginLoader);
+    trace.setPluginLoaderForTest(trace.TestPluginLoader);
   });
 
   afterEach(() => {

--- a/test/test-config-plugins.ts
+++ b/test/test-config-plugins.ts
@@ -20,7 +20,7 @@ import * as assert from 'assert';
 import {defaultConfig} from '../src/config';
 import {PluginLoader, PluginLoaderConfig} from '../src/trace-plugin-loader';
 
-import * as trace from './trace';
+import * as testTraceModule from './trace';
 
 describe('Configuration: Plugins', () => {
   const instrumentedModules = Object.keys(defaultConfig.plugins);
@@ -34,11 +34,11 @@ describe('Configuration: Plugins', () => {
   }
 
   before(() => {
-    trace.setPluginLoaderForTest(ConfigTestPluginLoader);
+    testTraceModule.setPluginLoaderForTest(ConfigTestPluginLoader);
   });
 
   after(() => {
-    trace.setPluginLoaderForTest(trace.TestPluginLoader);
+    testTraceModule.setPluginLoaderForTest(testTraceModule.TestPluginLoader);
   });
 
   afterEach(() => {
@@ -46,7 +46,7 @@ describe('Configuration: Plugins', () => {
   });
 
   it('should have correct defaults', () => {
-    trace.start();
+    testTraceModule.start();
     assert.ok(plugins);
     assert.strictEqual(
         JSON.stringify(Object.keys(plugins!)),
@@ -56,7 +56,7 @@ describe('Configuration: Plugins', () => {
   });
 
   it('should handle empty object', () => {
-    trace.start({plugins: {}});
+    testTraceModule.start({plugins: {}});
     assert.ok(plugins);
     assert.strictEqual(
         JSON.stringify(Object.keys(plugins!)),
@@ -66,12 +66,12 @@ describe('Configuration: Plugins', () => {
   });
 
   it('should handle non-object', () => {
-    trace.start({plugins: false as {}});
+    testTraceModule.start({plugins: false as {}});
     assert.deepStrictEqual(plugins, {});
   });
 
   it('should overwrite builtin plugins correctly', () => {
-    trace.start({plugins: {express: 'foo'}});
+    testTraceModule.start({plugins: {express: 'foo'}});
     assert.ok(plugins);
     assert.strictEqual(
         JSON.stringify(Object.keys(plugins!)),

--- a/test/test-modules-loaded-before-agent.ts
+++ b/test/test-modules-loaded-before-agent.ts
@@ -19,7 +19,7 @@ import * as assert from 'assert';
 import * as shimmer from 'shimmer';
 
 import {TestLogger} from './logger';
-import * as trace from './trace';
+import * as testTraceModule from './trace';
 
 describe('modules loaded before agent', () => {
   const logger = new TestLogger();
@@ -36,7 +36,7 @@ describe('modules loaded before agent', () => {
   });
 
   it('should log if modules were loaded before agent', () => {
-    trace.start();
+    testTraceModule.start();
     assert.strictEqual(
         logger.getNumLogsWith(
             'error', /modules.*loaded.*before.*trace agent.*: .*shimmer/),

--- a/test/test-span-data.ts
+++ b/test/test-span-data.ts
@@ -37,7 +37,7 @@ describe('SpanData', () => {
   let trace: Trace;
 
   before(() => {
-    traceAgentModule.setTraceWriter(CaptureSpanTraceWriter);
+    traceAgentModule.setTraceWriterForTest(CaptureSpanTraceWriter);
     traceWriter.create(
         {
           onUncaughtException: 'ignore',
@@ -48,7 +48,7 @@ describe('SpanData', () => {
   });
 
   after(() => {
-    traceAgentModule.setTraceWriter(traceAgentModule.TestTraceWriter);
+    traceAgentModule.setTraceWriterForTest(traceAgentModule.TestTraceWriter);
   });
 
   beforeEach(() => {

--- a/test/test-trace-api-none-cls.ts
+++ b/test/test-trace-api-none-cls.ts
@@ -19,7 +19,7 @@ import * as assert from 'assert';
 import {SpanDataType} from '../src/constants';
 import {TraceAgent} from '../src/plugin-types';
 
-import * as trace from './trace';
+import * as testTraceModule from './trace';
 import {asChildSpanData, asRootSpanData} from './utils';
 
 const identity = <T>(x: T) => x;
@@ -28,19 +28,19 @@ describe('Custom Trace API with CLS disabled', () => {
   let traceApi: TraceAgent;
 
   before(() => {
-    trace.setCLSForTest();
+    testTraceModule.setCLSForTest();
   });
 
   after(() => {
-    trace.setCLSForTest(trace.TestCLS);
+    testTraceModule.setCLSForTest(testTraceModule.TestCLS);
   });
 
   beforeEach(() => {
-    traceApi = trace.start({clsMechanism: 'none'});
+    traceApi = testTraceModule.start({clsMechanism: 'none'});
   });
 
   afterEach(() => {
-    trace.clearTraceData();
+    testTraceModule.clearTraceData();
   });
 
   it('should allow root spans to be created without constraints', () => {

--- a/test/test-trace-api-none-cls.ts
+++ b/test/test-trace-api-none-cls.ts
@@ -28,11 +28,11 @@ describe('Custom Trace API with CLS disabled', () => {
   let traceApi: TraceAgent;
 
   before(() => {
-    trace.setCLS();
+    trace.setCLSForTest();
   });
 
   after(() => {
-    trace.setCLS(trace.TestCLS);
+    trace.setCLSForTest(trace.TestCLS);
   });
 
   beforeEach(() => {

--- a/test/test-trace-cluster.ts
+++ b/test/test-trace-cluster.ts
@@ -30,16 +30,16 @@ describe('test-trace-cluster', () => {
   let axios: typeof axiosModule;
   let express: typeof expressModule;
   before(() => {
-    trace.setCLS();
-    trace.setPluginLoader();
+    trace.setCLSForTest();
+    trace.setPluginLoaderForTest();
     trace.start();
     express = require('express');
     axios = require('axios');
   });
 
   after(() => {
-    trace.setCLS(trace.TestCLS);
-    trace.setPluginLoader(trace.TestPluginLoader);
+    trace.setCLSForTest(trace.TestCLS);
+    trace.setPluginLoaderForTest(trace.TestPluginLoader);
   });
 
   it('should not interfere with express span', async () => {

--- a/test/test-trace-cluster.ts
+++ b/test/test-trace-cluster.ts
@@ -23,23 +23,23 @@ import {AddressInfo} from 'net';
 import * as cls from '../src/cls';
 import {express_4 as expressModule} from '../src/plugins/types';
 
-import * as trace from './trace';
+import * as testTraceModule from './trace';
 import {assertSpanDuration, DEFAULT_SPAN_DURATION, isServerSpan, wait} from './utils';
 
 describe('test-trace-cluster', () => {
   let axios: typeof axiosModule;
   let express: typeof expressModule;
   before(() => {
-    trace.setCLSForTest();
-    trace.setPluginLoaderForTest();
-    trace.start();
+    testTraceModule.setCLSForTest();
+    testTraceModule.setPluginLoaderForTest();
+    testTraceModule.start();
     express = require('express');
     axios = require('axios');
   });
 
   after(() => {
-    trace.setCLSForTest(trace.TestCLS);
-    trace.setPluginLoaderForTest(trace.TestPluginLoader);
+    testTraceModule.setCLSForTest(testTraceModule.TestCLS);
+    testTraceModule.setPluginLoaderForTest(testTraceModule.TestPluginLoader);
   });
 
   it('should not interfere with express span', async () => {
@@ -74,7 +74,7 @@ describe('test-trace-cluster', () => {
       let recordedTime = Date.now();
       await axios.get(`http://localhost:${port}`);
       recordedTime = Date.now() - recordedTime;
-      const serverSpan = trace.getOneSpan(isServerSpan);
+      const serverSpan = testTraceModule.getOneSpan(isServerSpan);
       assertSpanDuration(serverSpan, [DEFAULT_SPAN_DURATION, recordedTime]);
       cluster.worker.disconnect();
       server.close();

--- a/test/test-trace-web-frameworks.ts
+++ b/test/test-trace-web-frameworks.ts
@@ -56,15 +56,15 @@ const FRAMEWORKS: WebFrameworkConstructor[] = [
 describe('Web framework tracing', () => {
   let axios: typeof axiosModule;
   before(() => {
-    trace.setCLS();
-    trace.setPluginLoader();
+    trace.setCLSForTest();
+    trace.setPluginLoaderForTest();
     trace.start({ignoreUrls: [/ignore-me/]});
     axios = require('axios');
   });
 
   after(() => {
-    trace.setCLS(trace.TestCLS);
-    trace.setPluginLoader(trace.TestPluginLoader);
+    trace.setCLSForTest(trace.TestCLS);
+    trace.setPluginLoaderForTest(trace.TestPluginLoader);
   });
 
   FRAMEWORKS.forEach((webFrameworkConstructor) => {

--- a/test/trace.ts
+++ b/test/trace.ts
@@ -86,10 +86,10 @@ export class TestPluginLoader extends PluginLoader {
   }
 }
 
-setCLS(TestCLS);
-setLogger(TestLogger);
-setTraceWriter(TestTraceWriter);
-setPluginLoader(TestPluginLoader);
+setCLSForTest(TestCLS);
+setLoggerForTest(TestLogger);
+setTraceWriterForTest(TestTraceWriter);
+setPluginLoaderForTest(TestPluginLoader);
 
 export type Predicate<T> = (value: T) => boolean;
 
@@ -105,7 +105,7 @@ export function get(): PluginTypes.TraceAgent {
 
 export type LoggerConstructor = new (logLevel?: keyof common.Logger) =>
     common.Logger;
-export function setLogger(impl?: LoggerConstructor) {
+export function setLoggerForTest(impl?: LoggerConstructor) {
   if (common.logger.__wrapped) {
     shimmer.unwrap(common, 'logger');
   }
@@ -131,15 +131,15 @@ export function setLogger(impl?: LoggerConstructor) {
   }
 }
 
-export function setCLS(impl?: typeof TraceCLS) {
+export function setCLSForTest(impl?: typeof TraceCLS) {
   cls['implementation'] = impl || TraceCLS;
 }
 
-export function setTraceWriter(impl?: typeof TraceWriter) {
+export function setTraceWriterForTest(impl?: typeof TraceWriter) {
   traceWriter['implementation'] = impl || TraceWriter;
 }
 
-export function setPluginLoader(impl?: typeof PluginLoader) {
+export function setPluginLoaderForTest(impl?: typeof PluginLoader) {
   pluginLoader['implementation'] = impl || PluginLoader;
 }
 

--- a/test/web-frameworks/koa1.ts
+++ b/test/web-frameworks/koa1.ts
@@ -18,7 +18,7 @@ import * as http from 'http';
 import {AddressInfo} from 'net';
 
 import {koa_1} from '../../src/plugins/types';
-import * as trace from '../trace';
+import * as testTraceModule from '../trace';
 
 import {WebFramework, WebFrameworkAddHandlerOptions, WebFrameworkResponse} from './base';
 
@@ -39,7 +39,7 @@ export class Koa1 implements WebFramework {
     this.app.use(function*(next) {
       if (this.request.path === options.path) {
         // Context doesn't automatically get propagated to yielded functions.
-        yield trace.get().wrap(async (cb: Function) => {
+        yield testTraceModule.get().wrap(async (cb: Function) => {
           let response: WebFrameworkResponse|void;
           try {
             response = await options.fn();


### PR DESCRIPTION
This test:

- Changes methods called `set*` (like `setTraceWriter`) to `set*ForTest`
- Changes references to `trace` to `testTraceModule` in tests (when it's appropriate)

Most of the diff is as a result of fixing format after these changes. I recommend `?w=1` in the URL to ignore whitespace changes.