### PR TITLE
feat: allow timestamps to be passed to endSpan

### DIFF
--- a/src/plugin-types.ts
+++ b/src/plugin-types.ts
@@ -52,8 +52,10 @@ export interface SpanData {
 
   /**
    * Ends the span. This method should only be called once.
+   * @param timestamp A custom span end time; defaults to the time when endSpan
+   * was called if not provided.
    */
-  endSpan(): void;
+  endSpan(timestamp?: Date): void;
 }
 
 /**

--- a/src/span-data.ts
+++ b/src/span-data.ts
@@ -103,8 +103,9 @@ export abstract class BaseSpanData implements SpanData {
     this.span.labels[k] = v;
   }
 
-  endSpan() {
-    this.span.endTime = (new Date()).toISOString();
+  endSpan(timestamp?: Date) {
+    timestamp = timestamp || new Date();
+    this.span.endTime = timestamp.toISOString();
   }
 }
 
@@ -131,8 +132,8 @@ export class RootSpanData extends BaseSpanData implements types.RootSpanData {
         skipFrames);      /* # of frames to skip in stack trace */
   }
 
-  endSpan() {
-    super.endSpan();
+  endSpan(timestamp?: Date) {
+    super.endSpan(timestamp);
     traceWriter.get().writeSpan(this.trace);
   }
 }

--- a/test/test-span-data.ts
+++ b/test/test-span-data.ts
@@ -109,7 +109,7 @@ describe('SpanData', () => {
       const spanData = new CommonSpanData(trace, 'name', '0', 0);
       const startTime = new Date(spanData.span.startTime).getTime();
       // This input Date is far enough in the future that it's unlikely that the
-      // timethis function was called could be close to it.
+      // time this function was called could be close to it.
       spanData.endSpan(new Date(startTime + 1000000));
       const endTime = new Date(spanData.span.endTime).getTime();
       assert.strictEqual(endTime - startTime, 1000000);

--- a/test/test-span-data.ts
+++ b/test/test-span-data.ts
@@ -85,7 +85,6 @@ describe('SpanData', () => {
     });
 
     it('accurately records timestamps', async () => {
-      // Create another span, to determine start time correctness
       const startLowerBound = Date.now();
       const spanData = new CommonSpanData(trace, 'name', '0', 0);
       const startUpperBound = Date.now();
@@ -104,6 +103,16 @@ describe('SpanData', () => {
       const ascending = (a: number, b: number) => a - b;
       assert.deepStrictEqual(
           expectedTimes.slice().sort(ascending), expectedTimes);
+    });
+
+    it('accepts a custom span end time', () => {
+      const spanData = new CommonSpanData(trace, 'name', '0', 0);
+      const startTime = new Date(spanData.span.startTime).getTime();
+      // This input Date is far enough in the future that it's unlikely that the
+      // timethis function was called could be close to it.
+      spanData.endSpan(new Date(startTime + 1000000));
+      const endTime = new Date(spanData.span.endTime).getTime();
+      assert.strictEqual(endTime - startTime, 1000000);
     });
 
     it('truncates large span names to limit', () => {


### PR DESCRIPTION
Fixes #456

This PR adds an option to specify a time when a given span should be ended.