### PR TITLE
refactor: address TODOs related to spans

### DIFF
--- a/src/cls.ts
+++ b/src/cls.ts
@@ -23,8 +23,8 @@ import {AsyncListenerCLS} from './cls/async-listener';
 import {CLS, Func} from './cls/base';
 import {NullCLS} from './cls/null';
 import {SingularCLS} from './cls/singular';
-import {SpanDataType} from './constants';
-import {SpanData, SpanOptions} from './plugin-types';
+import {SpanType} from './constants';
+import {Span, SpanOptions} from './plugin-types';
 import {Trace, TraceSpan} from './trace';
 import {Singleton} from './util';
 
@@ -33,12 +33,12 @@ const asyncHooksAvailable = semver.satisfies(process.version, '>=8');
 export interface RealRootContext {
   readonly span: TraceSpan;
   readonly trace: Trace;
-  createChildSpan(options: SpanOptions): SpanData;
-  readonly type: SpanDataType.ROOT;
+  createChildSpan(options: SpanOptions): Span;
+  readonly type: SpanType.ROOT;
 }
 
 export interface PhantomRootContext {
-  readonly type: SpanDataType.UNCORRELATED|SpanDataType.UNTRACED;
+  readonly type: SpanType.UNCORRELATED|SpanType.UNTRACED;
 }
 
 /**
@@ -101,8 +101,8 @@ export class TraceCLS implements CLS<RootContext> {
   private CLSClass: CLSConstructor;
   private enabled = false;
 
-  private static UNCORRELATED: RootContext = {type: SpanDataType.UNCORRELATED};
-  private static UNTRACED: RootContext = {type: SpanDataType.UNTRACED};
+  private static UNCORRELATED: RootContext = {type: SpanType.UNCORRELATED};
+  private static UNTRACED: RootContext = {type: SpanType.UNTRACED};
 
   /**
    * Stack traces are captured when a root span is started. Because the stack

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -45,7 +45,7 @@ export const Constants = {
 /**
  * An enumeration of the possible "types" of spans.
  */
-export enum SpanDataType {
+export enum SpanType {
   /**
    * This span object was created in circumstances where it is impossible to
    * determine the associated request, and does not represent a real trace span.

--- a/src/plugin-types.ts
+++ b/src/plugin-types.ts
@@ -16,7 +16,7 @@
 
 // tslint:disable:no-any
 
-import {Constants, SpanDataType} from './constants';
+import {Constants, SpanType} from './constants';
 import {TraceLabels} from './trace-labels';
 
 export type Func<T> = (...args: any[]) => T;
@@ -26,9 +26,8 @@ export interface TraceAgentExtension { _google_trace_patched: boolean; }
 
 /**
  * Represents a trace span.
- * TODO(kjin): This should be called `Span`.
  */
-export interface SpanData {
+export interface Span {
   /**
    * Gets the current trace context serialized as a string, or an empty string
    * if it can't be generated.
@@ -46,9 +45,9 @@ export interface SpanData {
   addLabel(key: string, value: any): void;
 
   /**
-   * The current span type. See `SpanDataType` for more information.
+   * The current span type. See `SpanType` for more information.
    */
-  readonly type: SpanDataType;
+  readonly type: SpanType;
 
   /**
    * Ends the span. This method should only be called once.
@@ -61,7 +60,7 @@ export interface SpanData {
 /**
  * Represents the root span within a trace.
  */
-export interface RootSpanData extends SpanData {
+export interface RootSpan extends Span {
   /**
    * Creates and starts a child span under this root span.
    * If the root span is a real span (type = ROOT), the child span will be as
@@ -69,9 +68,9 @@ export interface RootSpanData extends SpanData {
    * Otherwise, if the root span's type is UNTRACED or UNCORRELATED, the child
    * span will be of the same type.
    * @param options Options for creating the child span.
-   * @returns A new SpanData object.
+   * @returns A new Span object.
    */
-  createChildSpan(options?: SpanOptions): SpanData;
+  createChildSpan(options?: SpanOptions): Span;
 }
 
 /**
@@ -119,12 +118,12 @@ export interface TraceAgent {
    * span is created and propagated.
    * @param fn A function that will be called exactly
    * once. If the incoming request should be traced, a root span will be
-   * created, and this function will be called with a SpanData object exposing
+   * created, and this function will be called with a Span object exposing
    * functions operating on the root span; otherwise, it will be called with
-   * a phantom SpanData object.
+   * a phantom Span object.
    * @returns The return value of calling fn.
    */
-  runInRootSpan<T>(options: RootSpanOptions, fn: (span: RootSpanData) => T): T;
+  runInRootSpan<T>(options: RootSpanOptions, fn: (span: RootSpan) => T): T;
 
   /**
    * Returns a unique identifier for the currently active context. This can be
@@ -144,19 +143,19 @@ export interface TraceAgent {
   getWriterProjectId(): string|null;
 
   /**
-   * Creates and returns a new SpanData object nested within the current root
+   * Creates and returns a new Span object nested within the current root
    * span, which is detected automatically.
    * If the root span is a phantom span or doesn't exist, the child span will
    * be a phantom span as well.
    * @param options Options for creating the child span.
-   * @returns A new SpanData object.
+   * @returns A new Span object.
    */
-  createChildSpan(options?: SpanOptions): SpanData;
+  createChildSpan(options?: SpanOptions): Span;
 
   /**
-   * Returns whether a given span is real or not by checking its SpanDataType.
+   * Returns whether a given span is real or not by checking its SpanType.
    */
-  isRealSpan(span: SpanData): boolean;
+  isRealSpan(span: Span): boolean;
 
   /**
    * Generates a stringified trace context that should be set as the trace
@@ -195,7 +194,7 @@ export interface TraceAgent {
 
   readonly constants: typeof Constants;
   readonly labels: typeof TraceLabels;
-  readonly spanTypes: typeof SpanDataType;
+  readonly spanTypes: typeof SpanType;
 }
 
 export interface Patch<T> {

--- a/src/plugins/plugin-grpc.ts
+++ b/src/plugins/plugin-grpc.ts
@@ -41,7 +41,7 @@ function patchClient(client, api) {
   /**
    * Wraps a callback so that the current span for this trace is also ended when
    * the callback is invoked.
-   * @param {SpanData} span - The span that should end after this callback.
+   * @param {Span} span - The span that should end after this callback.
    * @param {function(?Error, value=)} done - The callback to be wrapped.
    */
   function wrapCallback(span, done) {

--- a/src/plugins/plugin-pg.ts
+++ b/src/plugins/plugin-pg.ts
@@ -18,7 +18,7 @@ import {EventEmitter} from 'events';
 import * as shimmer from 'shimmer';
 import {Readable} from 'stream';
 
-import {Patch, Plugin, SpanData} from '../plugin-types';
+import {Patch, Plugin, Span} from '../plugin-types';
 
 import {pg_6, pg_7} from './types';
 
@@ -36,7 +36,7 @@ function isSubmittable(obj: any): obj is {submit: Function} {
 
 const noOp = () => {};
 
-function populateLabelsFromInputs(span: SpanData, args: ClientQueryArguments) {
+function populateLabelsFromInputs(span: Span, args: ClientQueryArguments) {
   const queryObj = args[0];
   if (typeof queryObj === 'object') {
     if (queryObj.text) {
@@ -54,7 +54,7 @@ function populateLabelsFromInputs(span: SpanData, args: ClientQueryArguments) {
 }
 
 function populateLabelsFromOutputs(
-    span: SpanData, err: Error|null, res?: pg_7.QueryResult) {
+    span: Span, err: Error|null, res?: pg_7.QueryResult) {
   if (err) {
     span.addLabel('error', err);
   }

--- a/test/plugins/common.ts
+++ b/test/plugins/common.ts
@@ -29,7 +29,7 @@ import { cls } from '../../src/cls';
 import { TraceAgent } from '../../src/trace-api';
 import { traceWriter } from '../../src/trace-writer';
 import * as TracingPolicy from '../../src/tracing-policy';
-import { SpanDataType } from '../../src/constants';
+import { SpanType } from '../../src/constants';
 
 var semver = require('semver');
 
@@ -159,7 +159,7 @@ function assertDurationCorrect(expectedDuration, predicate) {
 function runInTransaction(fn) {
   testTraceAgent.runInRootSpan({ name: 'outer' }, function(span) {
     return fn(function() {
-      assert.strictEqual(span.type, SpanDataType.ROOT);
+      assert.strictEqual(span.type, SpanType.ROOT);
       span.endSpan();
     });
   });
@@ -173,13 +173,13 @@ function createChildSpan(cb, duration) {
   var span = testTraceAgent.createChildSpan({ name: 'inner' });
   assert.ok(span);
   var t = setTimeout(function() {
-    assert.strictEqual(span.type, SpanDataType.CHILD);
+    assert.strictEqual(span.type, SpanType.CHILD);
     if (cb) {
       cb();
     }
   }, duration);
   return function() {
-    assert.strictEqual(span.type, SpanDataType.CHILD);
+    assert.strictEqual(span.type, SpanType.CHILD);
     span.endSpan();
     clearTimeout(t);
   };
@@ -194,7 +194,7 @@ function avoidTraceWriterAuth() {
 }
 
 function hasContext() {
-  return cls.get().getContext().type !== SpanDataType.UNCORRELATED;
+  return cls.get().getContext().type !== SpanType.UNCORRELATED;
 }
 
 module.exports = {

--- a/test/plugins/test-trace-grpc.ts
+++ b/test/plugins/test-trace-grpc.ts
@@ -16,13 +16,13 @@
 'use strict';
 
 import { cls } from '../../src/cls';
-import { Constants, SpanDataType } from '../../src/constants';
+import { Constants, SpanType } from '../../src/constants';
 import { TraceLabels } from '../../src/trace-labels';
 import * as TracingPolicy from '../../src/tracing-policy';
 import * as util from '../../src/util';
 import * as assert from 'assert';
 import { asRootSpanData } from '../utils';
-import { SpanData } from '../../src/plugin-types';
+import { Span } from '../../src/plugin-types';
 import { FORCE_NEW } from '../../src/util';
 
 var shimmer = require('shimmer');
@@ -55,7 +55,7 @@ function checkServerMetadata(metadata) {
     assert.ok(/[a-f0-9]{32}\/[0-9]+;o=1/.test(traceContext));
     var parsedContext = util.parseContextFromHeader(traceContext);
     assert.ok(parsedContext);
-    var root = asRootSpanData(cls.get().getContext() as SpanData);
+    var root = asRootSpanData(cls.get().getContext() as Span);
     assert.strictEqual(root.span.parentSpanId, parsedContext!.spanId);
   }
 }
@@ -296,8 +296,8 @@ Object.keys(versions).forEach(function(version) {
         var result = oldRegister.call(this, n, h, s, d, m);
         var oldFunc = this.handlers[n].func;
         this.handlers[n].func = function() {
-          if (cls.get().getContext().type === SpanDataType.ROOT) {
-            cls.get().setContext({ type: SpanDataType.UNCORRELATED });
+          if (cls.get().getContext().type === SpanType.ROOT) {
+            cls.get().setContext({ type: SpanType.UNCORRELATED });
           }
           return oldFunc.apply(this, arguments);
         };
@@ -454,7 +454,7 @@ Object.keys(versions).forEach(function(version) {
     it('should support distributed trace context', function(done) {
       function makeLink(fn, meta, next) {
         return function() {
-          cls.get().setContext({ type: SpanDataType.UNCORRELATED });
+          cls.get().setContext({ type: SpanType.UNCORRELATED });
           common.runInTransaction(function(terminate) {
             fn(client, grpc, meta, function() {
               terminate();
@@ -519,7 +519,7 @@ Object.keys(versions).forEach(function(version) {
                 // Clear root context so the next call to runInTransaction
                 // doesn't think we are still in one.
                 // TODO: Maybe we should do this automatically upon root.endSpan
-                cls.get().setContext({ type: SpanDataType.UNCORRELATED });
+                cls.get().setContext({ type: SpanType.UNCORRELATED });
                 setImmediate(prevNext);
               }
             };

--- a/test/test-cls.ts
+++ b/test/test-cls.ts
@@ -26,7 +26,7 @@ import {AsyncListenerCLS} from '../src/cls/async-listener';
 import {CLS} from '../src/cls/base';
 import {NullCLS} from '../src/cls/null';
 import {SingularCLS} from '../src/cls/singular';
-import {SpanDataType} from '../src/constants';
+import {SpanType} from '../src/constants';
 import {createStackTrace, FORCE_NEW} from '../src/util';
 
 import {TestLogger} from './logger';
@@ -255,24 +255,24 @@ describe('Continuation-Local Storage', () => {
 
   describe('TraceCLS', () => {
     const validTestCases:
-        Array<{config: TraceCLSConfig, expectedDefaultType: SpanDataType}> = [
+        Array<{config: TraceCLSConfig, expectedDefaultType: SpanType}> = [
           {
             config: {mechanism: TraceCLSMechanism.ASYNC_LISTENER},
-            expectedDefaultType: SpanDataType.UNCORRELATED
+            expectedDefaultType: SpanType.UNCORRELATED
           },
           {
             config: {mechanism: TraceCLSMechanism.SINGULAR},
-            expectedDefaultType: SpanDataType.UNCORRELATED
+            expectedDefaultType: SpanType.UNCORRELATED
           },
           {
             config: {mechanism: TraceCLSMechanism.NONE},
-            expectedDefaultType: SpanDataType.UNTRACED
+            expectedDefaultType: SpanType.UNTRACED
           }
         ];
     if (asyncAwaitSupported) {
       validTestCases.push({
         config: {mechanism: TraceCLSMechanism.ASYNC_HOOKS},
-        expectedDefaultType: SpanDataType.UNCORRELATED
+        expectedDefaultType: SpanType.UNCORRELATED
       });
     }
     for (const testCase of validTestCases) {
@@ -298,7 +298,7 @@ describe('Continuation-Local Storage', () => {
            () => {
              c.disable();
              assert.ok(!c.isEnabled());
-             assert.ok(c.getContext().type, SpanDataType.UNTRACED);
+             assert.ok(c.getContext().type, SpanType.UNTRACED);
              assert.ok(c.runWithNewContext(() => 'hi'), 'hi');
              const fn = () => {};
              assert.strictEqual(c.bindWithCurrentContext(fn), fn);

--- a/test/test-index.ts
+++ b/test/test-index.ts
@@ -18,7 +18,7 @@
 
 import './override-gcp-metadata';
 import { TraceAgent } from '../src/trace-api';
-import { SpanDataType } from '../src/constants';
+import { SpanType } from '../src/constants';
 import { FORCE_NEW } from '../src/util';
 
 var assert = require('assert');
@@ -33,14 +33,14 @@ describe('index.js', function() {
     assert.ok(!disabledAgent.isActive()); // ensure it's disabled first
     let ranInRootSpan = false;
     disabledAgent.runInRootSpan({ name: '' }, (span) => {
-      assert.strictEqual(span.type, SpanDataType.UNTRACED);
+      assert.strictEqual(span.type, SpanType.UNTRACED);
       ranInRootSpan = true;
     });
     assert.ok(ranInRootSpan);
     assert.strictEqual(disabledAgent.enhancedDatabaseReportingEnabled(), false);
     assert.strictEqual(disabledAgent.getCurrentContextId(), null);
     assert.strictEqual(disabledAgent.getWriterProjectId(), null);
-    assert.strictEqual(disabledAgent.createChildSpan({ name: '' }).type, SpanDataType.UNTRACED);
+    assert.strictEqual(disabledAgent.createChildSpan({ name: '' }).type, SpanType.UNTRACED);
     assert.strictEqual(disabledAgent.getResponseTraceContext('', false), '');
     const fn = () => {};
     assert.strictEqual(disabledAgent.wrap(fn), fn);

--- a/test/test-span-data.ts
+++ b/test/test-span-data.ts
@@ -16,7 +16,7 @@
 
 import * as assert from 'assert';
 
-import {Constants, SpanDataType} from '../src/constants';
+import {Constants, SpanType} from '../src/constants';
 import {BaseSpanData, ChildSpanData, RootSpanData} from '../src/span-data';
 import {Trace} from '../src/trace';
 import {TraceLabels} from '../src/trace-labels';

--- a/test/test-trace-api-none-cls.ts
+++ b/test/test-trace-api-none-cls.ts
@@ -16,7 +16,7 @@
 
 import * as assert from 'assert';
 
-import {SpanDataType} from '../src/constants';
+import {SpanType} from '../src/constants';
 import {TraceAgent} from '../src/plugin-types';
 
 import * as testTraceModule from './trace';
@@ -45,9 +45,9 @@ describe('Custom Trace API with CLS disabled', () => {
 
   it('should allow root spans to be created without constraints', () => {
     traceApi.runInRootSpan({name: 'root1'}, root1 => {
-      assert.strictEqual(root1.type, SpanDataType.ROOT);
+      assert.strictEqual(root1.type, SpanType.ROOT);
       traceApi.runInRootSpan({name: 'root2'}, root2 => {
-        assert.strictEqual(root2.type, SpanDataType.ROOT);
+        assert.strictEqual(root2.type, SpanType.ROOT);
         assert.notStrictEqual(
             asRootSpanData(root2).trace.traceId,
             asRootSpanData(root1).trace.traceId);
@@ -71,7 +71,7 @@ describe('Custom Trace API with CLS disabled', () => {
     const root =
         asRootSpanData(traceApi.runInRootSpan({name: 'root'}, identity));
     const child = traceApi.createChildSpan({name: 'child'});
-    assert.strictEqual(child.type, SpanDataType.UNTRACED);
+    assert.strictEqual(child.type, SpanType.UNTRACED);
     child.endSpan();
     root.endSpan();
   });

--- a/test/test-trace-api.ts
+++ b/test/test-trace-api.ts
@@ -24,7 +24,7 @@ import { traceWriter } from '../src/trace-writer';
 import * as TracingPolicy from '../src/tracing-policy';
 import { FORCE_NEW } from '../src/util';
 import { asRootSpanData, asChildSpanData } from './utils';
-import { SpanDataType } from '../src/constants';
+import { SpanType } from '../src/constants';
 
 var assert = require('assert');
 var common = require('./plugins/common'/*.js*/);
@@ -190,9 +190,9 @@ describe('Trace Interface', function() {
       traceAPI.runInRootSpan({name: 'root', url: 'root'}, function(rootSpan1_) {
         var rootSpan1 = asRootSpanData(rootSpan1_);
         traceAPI.runInRootSpan({name: 'root2', url: 'root2'}, function(rootSpan2) {
-          assert.strictEqual(rootSpan2.type, SpanDataType.UNCORRELATED);
+          assert.strictEqual(rootSpan2.type, SpanType.UNCORRELATED);
           const childSpan = rootSpan2.createChildSpan({ name: 'child' });
-          assert.strictEqual(childSpan.type, SpanDataType.UNCORRELATED);
+          assert.strictEqual(childSpan.type, SpanType.UNCORRELATED);
         });
         rootSpan1.endSpan();
         var span = common.getMatchingSpan(function() { return true; });
@@ -237,9 +237,9 @@ describe('Trace Interface', function() {
     it('should respect trace policy', function(done) {
       var traceAPI = createTraceAgent(new TracingPolicy.TraceNonePolicy());
       traceAPI.runInRootSpan({name: 'root', url: 'root'}, function(rootSpan) {
-        assert.strictEqual(rootSpan.type, SpanDataType.UNTRACED);
+        assert.strictEqual(rootSpan.type, SpanType.UNTRACED);
         const childSpan = rootSpan.createChildSpan({ name: 'child' });
-        assert.strictEqual(childSpan.type, SpanDataType.UNTRACED);
+        assert.strictEqual(childSpan.type, SpanType.UNTRACED);
         done();
       });
     });
@@ -250,7 +250,7 @@ describe('Trace Interface', function() {
         new TracingPolicy.TraceAllPolicy(),
         [url]));
       traceAPI.runInRootSpan({name: 'root1', url: url}, function(rootSpan) {
-        assert.strictEqual(rootSpan.type, SpanDataType.UNTRACED);
+        assert.strictEqual(rootSpan.type, SpanType.UNTRACED);
       });
       traceAPI.runInRootSpan({name: 'root2', url: 'alternativeUrl'}, function(rootSpan_) {
         var rootSpan = asRootSpanData(rootSpan_);

--- a/test/test-trace-api.ts
+++ b/test/test-trace-api.ts
@@ -49,23 +49,16 @@ function createTraceAgent(policy?, config?) {
 function assertAPISurface(traceAPI) {
   assert.strictEqual(typeof traceAPI.enhancedDatabaseReportingEnabled(), 'boolean');
   traceAPI.runInRootSpan({ name: 'root' }, function(root) {
-    // TODO: Once NullSpans are in the functional implementation,
-    // remove the conditional check
-    if (root) {
-      assert.strictEqual(typeof root.addLabel, 'function');
-      assert.strictEqual(typeof root.endSpan, 'function');
-      assert.strictEqual(typeof root.getTraceContext(), 'string');
-    }
-  });
-  assert.strictEqual(typeof traceAPI.getCurrentContextId, 'function');
-  assert.strictEqual(typeof traceAPI.getWriterProjectId, 'function');
-  var child = traceAPI.createChildSpan({ name: 'child' });
-  // TODO: Ditto but with child spans
-  if (child) {
+    assert.strictEqual(typeof root.addLabel, 'function');
+    assert.strictEqual(typeof root.endSpan, 'function');
+    assert.strictEqual(typeof root.getTraceContext(), 'string');
+    var child = traceAPI.createChildSpan({ name: 'child' });
     assert.strictEqual(typeof child.addLabel, 'function');
     assert.strictEqual(typeof child.endSpan, 'function');
     assert.strictEqual(typeof child.getTraceContext(), 'string');
-  }
+  });
+  assert.strictEqual(typeof traceAPI.getCurrentContextId, 'function');
+  assert.strictEqual(typeof traceAPI.getWriterProjectId, 'function');
   assert.strictEqual(typeof traceAPI.wrap(function() {}), 'function');
   assert.strictEqual(typeof traceAPI.wrapEmitter(new EventEmitter()), 'undefined');
   assert.strictEqual(typeof traceAPI.constants, 'object');

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -18,8 +18,8 @@
 
 import * as assert from 'assert';
 
-import {SpanDataType} from '../src/constants';
-import {SpanData} from '../src/plugin-types';
+import {SpanType} from '../src/constants';
+import {Span} from '../src/plugin-types';
 import {ChildSpanData, RootSpanData} from '../src/span-data';
 import {TraceSpan} from '../src/trace';
 
@@ -55,13 +55,13 @@ export function assertSpanDuration(span: TraceSpan, bounds: [number, number]) {
           bounds[0]}, ${bounds[1]}] ms`);
 }
 
-export function asRootSpanData(arg: SpanData): RootSpanData {
-  assert.strictEqual(arg.type, SpanDataType.ROOT);
+export function asRootSpanData(arg: Span): RootSpanData {
+  assert.strictEqual(arg.type, SpanType.ROOT);
   return arg as RootSpanData;
 }
 
-export function asChildSpanData(arg: SpanData): ChildSpanData {
-  assert.strictEqual(arg.type, SpanDataType.CHILD);
+export function asChildSpanData(arg: Span): ChildSpanData {
+  assert.strictEqual(arg.type, SpanType.CHILD);
   return arg as ChildSpanData;
 }
 


### PR DESCRIPTION
This PR addresses two TODOs:

- `SpanData` should be named `Span` for the public API (this is suggested by the OpenCensus specification, and avoids name collisions)
- An outstanding TODO was to be done when "null spans" were implemented (#680)