### PR TITLE
chore: 2.9.0 release proposal

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@google-cloud/trace-agent",
-  "version": "2.8.1",
+  "version": "2.9.0",
   "description": "Node.js Support for StackDriver Trace",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",


### PR DESCRIPTION
[Release Notes](https://github.com/GoogleCloudPlatform/cloud-trace-nodejs/releases/tag/untagged-64026924b81c2bbbf765)