### PR TITLE
chore: 2.10.0 release proposal

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@google-cloud/trace-agent",
-  "version": "2.9.0",
+  "version": "2.10.0",
   "description": "Node.js Support for StackDriver Trace",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",


### PR DESCRIPTION
[Release Notes](https://github.com/GoogleCloudPlatform/cloud-trace-nodejs/releases/tag/untagged-1cbd299a868fd04b94f9)