### PR TITLE
fix: inject context http headers early if expect header exists

### DIFF
--- a/src/plugins/plugin-http.ts
+++ b/src/plugins/plugin-http.ts
@@ -46,8 +46,7 @@ function getSpanName(options: ClientRequestArgs|url.URL) {
  * Returns whether the Expect header is on the given options object.
  * @param options Options for http.request.
  */
-function hasExpectHeader(options: ClientRequestArgs|
-                         url.URL): options is ClientRequestArgs {
+function hasExpectHeader(options: ClientRequestArgs|url.URL): boolean {
   return !!(
       (options as ClientRequestArgs).headers &&
       (options as ClientRequestArgs).headers!.Expect);
@@ -133,7 +132,7 @@ function makeRequestTrace(
       traceHeaderPreinjected = true;
       // "Clone" the options object -- but don't deep-clone anything except for
       // headers.
-      options = Object.assign({}, options);
+      options = Object.assign({}, options) as ClientRequestArgs;
       options.headers = Object.assign({}, options.headers);
       // Inject the trace context header.
       options.headers[api.constants.TRACE_CONTEXT_HEADER_NAME] =

--- a/src/plugins/plugin-http.ts
+++ b/src/plugins/plugin-http.ts
@@ -48,8 +48,9 @@ function getSpanName(options: ClientRequestArgs|url.URL) {
  */
 function hasExpectHeader(options: ClientRequestArgs|
                          url.URL): options is ClientRequestArgs {
-  // tslint:disable-next-line:no-any
-  return !!((options as any).headers && (options as any).headers.Expect);
+  return !!(
+      (options as ClientRequestArgs).headers &&
+      (options as ClientRequestArgs).headers!.Expect);
 }
 
 function extractUrl(

--- a/test/plugins/test-trace-http.ts
+++ b/test/plugins/test-trace-http.ts
@@ -183,8 +183,21 @@ for (const nodule of Object.keys(servers) as Array<keyof typeof servers>) {
             const req = http.request(
                 {port, rejectUnauthorized: false},
                 waitForResponse.handleResponse);
-            await wait(DEFAULT_SPAN_DURATION / 2);
             req.end();
+            await waitForResponse.done;
+          }
+        },
+        {
+          description: 'calling http.get with Expect header',
+          fn: async () => {
+            const waitForResponse = new WaitForResponse();
+            const req = http.get(
+                {
+                  port,
+                  rejectUnauthorized: false,
+                  headers: {Expect: '100-continue'}
+                },
+                waitForResponse.handleResponse);
             await waitForResponse.done;
           }
         },


### PR DESCRIPTION
Fixes #763

This PR fixes a bug where our HTTP instrumentation fails if `Expect` is added as an outgoing header. This is because we normally inject a trace context header for a request as part of our HTTP instrumentation, but Node has a special case where it prohibits additional headers if the `Expect` header is detected. See: https://github.com/nodejs/node/blob/v7.10.1/lib/_http_outgoing.js#L323

To fix this, I brought back the old "slower" way of injecting trace context headers that was removed in #643, but only if the `Expect` header is detected.

I also added a test that fails without the source change.