### PR TITLE
chore: re-enable node 10 ci and modify init-test-fixtures

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -108,16 +108,15 @@ workflows:
           filters: *release_tags
       - node9:
           filters: *release_tags
-      # Node 10 + async_hooks-based tracing is not supported.
-      # - node10:
-      #     filters: *release_tags
+      - node10:
+          filters: *release_tags
       - publish_npm:
           requires:
             - node4
             - node6
             - node8
             - node9
-            # - node10
+            - node10
           filters:
             branches:
               ignore: /.*/

--- a/scripts/init-test-fixtures.ts
+++ b/scripts/init-test-fixtures.ts
@@ -1,5 +1,10 @@
 import * as path from 'path';
 import { BUILD_DIRECTORY, globP, statP, ncpP, spawnP, readFileP, writeFileP, mkdirP } from './utils';
+import { readdir } from 'fs';
+import * as pify from 'pify';
+import * as semver from 'semver';
+
+const readdirP: (path: string) => Promise<string[]> = pify(readdir);
 
 export async function initTestFixtures(installPlugins: boolean) {
   // Copy fixtures to build directory
@@ -20,25 +25,64 @@ export async function initTestFixtures(installPlugins: boolean) {
     let fixtureExists = true;
     try {
       await statP(packageDirectory);
-    } catch (e) {
+    } catch {
       fixtureExists = false;
     }
 
-    if (!fixtureExists) {
-      await mkdirP(packageDirectory);
-      await writeFileP(`${packageDirectory}/package.json`, JSON.stringify(Object.assign({
-        name: packageName,
-        version: '1.0.0',
-        main: 'index.js'
-      }, packageFixtures[packageName]), null, 2));
-      const mainModule = packageFixtures[packageName]._mainModule || Object.keys(packageFixtures[packageName].dependencies)[0];
-      await writeFileP(`${packageDirectory}/index.js`, `module.exports = require('${mainModule}');\n`);
-      console.log(`npm install in ${packageDirectory}`);
-      await spawnP('npm', ['install', '--silent'], {
-        cwd: packageDirectory
-      });
+    /**
+     * This is the general approach:
+     * 
+     *  if package supports this Node version:
+     *    if fixtures don't already exist for this package:
+     *      create fixtures
+     *    else
+     *      if gRPC module binary exists but for a different Node version:
+     *        reinstall gRPC
+     *      else
+     *        skip install
+     *  else
+     *    skip install
+     */
+    const packageFixture = packageFixtures[packageName];
+    const supportedNodeVersions = (packageFixture.engines && packageFixture.engines.node) || '*';
+    if (semver.satisfies(process.version, supportedNodeVersions)) {
+      if (!fixtureExists) {
+        await mkdirP(packageDirectory);
+        await writeFileP(`${packageDirectory}/package.json`, JSON.stringify(Object.assign({
+          name: packageName,
+          version: '1.0.0',
+          main: 'index.js'
+        }, packageFixture), null, 2));
+        const mainModule = packageFixture._mainModule || Object.keys(packageFixture.dependencies)[0];
+        await writeFileP(`${packageDirectory}/index.js`, `module.exports = require('${mainModule}');\n`);
+        console.log(`npm install in ${packageDirectory}`);
+        await spawnP('npm', ['install', '--reinstall'], {
+          cwd: packageDirectory
+        });
+      } else {
+        // Conditionally re-install if gRPC module binary exists but for a different Node version
+        let reinstallGrpc = !fixtureExists;
+        const extBinDirectory = `${packageDirectory}/node_modules/grpc/src/node/extension_binary`;
+        try {
+          await statP(extBinDirectory);
+          const files = await readdirP(extBinDirectory);
+          const modulesVersions = files.map(file => file.match(/^node-v([0-9]+)-/)).filter(x => x).map(matches => matches![1]);
+          if (!modulesVersions.some(version => version === process.versions.modules)) {
+            reinstallGrpc = true;
+          }
+        } catch {}
+        if (reinstallGrpc) {
+          console.log(`Re-installing gRPC in ${packageDirectory} because of stale gRPC binary`);
+          const grpcPackageJson = JSON.parse(await readFileP(`${packageDirectory}/node_modules/grpc/package.json`, 'utf8') as string);
+          await spawnP('npm', ['install', `grpc@${grpcPackageJson.version}`], {
+            cwd: packageDirectory
+          });
+        } else {
+          console.log(`Skipping npm install in ${packageDirectory} since node_modules already exists`);
+        }
+      }
     } else {
-      console.log(`Skipping npm install in ${packageDirectory} since node_modules already exists`);
+      console.log(`Skipping npm install in ${packageDirectory} since package not supported in Node ${process.version}`);
     }
   };
 }

--- a/test/fixtures/plugin-fixtures.json
+++ b/test/fixtures/plugin-fixtures.json
@@ -27,6 +27,9 @@
   "grpc1.6": {
     "dependencies": {
       "grpc": "~1.6.0"
+    },
+    "engines": {
+      "node": "<10"
     }
   },
   "grpc1.7": {

--- a/test/plugins/test-trace-grpc.ts
+++ b/test/plugins/test-trace-grpc.ts
@@ -24,14 +24,17 @@ import * as assert from 'assert';
 import { asRootSpanData } from '../utils';
 import { Span } from '../../src/plugin-types';
 import { FORCE_NEW } from '../../src/util';
+import * as semver from 'semver';
 
 var shimmer = require('shimmer');
 var common = require('./common'/*.js*/);
 
-var versions = {
-  grpc1_6: './fixtures/grpc1.6',
+var versions: { [key: string]: string } = {
   grpc1_7: './fixtures/grpc1.7'
 };
+if (semver.satisfies(process.version, '<10')) {
+  versions.grpc1_6 = './fixtures/grpc1.6';
+}
 
 var protoFile = __dirname + '/../fixtures/test-grpc.proto';
 var grpcPort = 50051;

--- a/test/test-grpc-context.ts
+++ b/test/test-grpc-context.ts
@@ -15,6 +15,8 @@
  */
 'use strict';
 
+import * as semver from 'semver';
+
 // Trace agent must be started out of the loop over gRPC versions,
 // because express can't be re-patched.
 var agent = require('../..').start({
@@ -28,10 +30,12 @@ var assert = require('assert');
 var express = require('./plugins/fixtures/express4');
 var http = require('http');
 
-var versions = {
-  grpc1_6: './plugins/fixtures/grpc1.6',
+var versions: { [key: string]: string } = {
   grpc1_7: './plugins/fixtures/grpc1.7'
 };
+if (semver.satisfies(process.version, '<10')) {
+  versions.grpc1_6 = './plugins/fixtures/grpc1.6';
+}
 
 var grpcPort = 50051;
 var protoFile = __dirname + '/fixtures/test-grpc.proto';


### PR DESCRIPTION
This change enables Node 10 CI. It also modifies `init-test-fixtures` to re-install gRPC binaries if there is a module version mismatch, and allows `engines.node` in `plugin-fixtures.json` to dictate whether the fixture is actually installed (at this time, there is only gRPC 1.6). The former doesn't affect CI, it is purely for developer convenience when switching between Node versions locally.