### PR TITLE
feat: support tracing for untranspiled async/await in Node 8+

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,8 +4,6 @@
 node_modules_cache_key: &node_modules_cache_key node-modules-cache-{{ .Environment.CIRCLE_JOB }}-{{ arch }}-{{ checksum "package.json" }}-{{ checksum "package-lock.json" }}
 test_fixtures_cache_key: &test_fixtures_cache_key test-fixtures-cache-{{ .Environment.CIRCLE_JOB }}-{{ arch }}-{{ checksum "test/fixtures/plugin-fixtures.json" }}
 plugin_types_cache_key: &plugin_types_cache_key plugin-types-cache-{{ .Environment.CIRCLE_JOB }}-{{ arch }}-{{ checksum "src/plugins/types/index.d.ts" }}
-test_env: &test_env
-  GCLOUD_TRACE_NEW_CONTEXT: 1
 release_tags: &release_tags
   tags:
     only: /^v\d+(\.\d+){2}(-.*)?$/
@@ -126,7 +124,6 @@ jobs:
   node4:
     docker:
       - image: node:4
-        environment: *test_env
       - *mongo_service
       - *redis_service
       - *postgres_service
@@ -135,7 +132,6 @@ jobs:
   node6:
     docker:
       - image: node:6
-        environment: *test_env
       - *mongo_service
       - *redis_service
       - *postgres_service
@@ -144,7 +140,6 @@ jobs:
   node8:
     docker:
       - image: node:8
-        environment: *test_env
       - *mongo_service
       - *redis_service
       - *postgres_service
@@ -153,7 +148,6 @@ jobs:
   node9:
     docker:
       - image: node:9
-        environment: *test_env
       - *mongo_service
       - *redis_service
       - *postgres_service
@@ -162,7 +156,6 @@ jobs:
   node10:
     docker:
       - image: node:10
-        environment: *test_env
       - *mongo_service
       - *redis_service
       - *postgres_service

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,6 @@ The command `npm test` tests code the same way that our CI will test it. This is
 
 There are a couple of environmental variables to note:
 
-- Setting `GCLOUD_TRACE_NEW_CONTEXT` (to any string) activates `async_hooks`-based tracing on Node 8+. On versions of Node where `async_hooks` is available, tests should pass whether this variable is set or not.
 - Setting `TRACE_TEST_EXCLUDE_INTEGRATION` (to any string) disables plugin tests when the command `npm run unit-test` is run. This is recommended for changes that do not affect plugins.
   - Some integration tests depend on locally running database services. On Unix, you can use `./bin/docker-trace.sh start` to start these services.
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,7 +16,6 @@ install:
   # Get the latest stable version of Node.js or io.js
   - ps: Install-Product node $env:nodejs_version
   - SET GCLOUD_PROJECT=0
-  - SET GCLOUD_TRACE_NEW_CONTEXT=1
   - SET TRACE_TEST_EXCLUDE_INTEGRATION=1
 
 # Post-install test scripts.

--- a/src/config.ts
+++ b/src/config.ts
@@ -32,8 +32,7 @@ export interface Config {
    *   Node binary version requirements are not met.
    * - 'async-listener' uses an implementation of CLS on top of the
    *   `continuation-local-storage` module.
-   * - 'auto' behaves like 'async-hooks' on Node 8+ when the
-   *   GCLOUD_TRACE_NEW_CONTEXT env variable is set, and 'async-listener'
+   * - 'auto' behaves like 'async-hooks' on Node 8+, and 'async-listener'
    *   otherwise.
    * - 'none' disables CLS completely.
    * - 'singular' allows one root span to exist at a time. This option is meant

--- a/src/index.ts
+++ b/src/index.ts
@@ -79,8 +79,7 @@ function initConfig(projectConfig: Forceable<Config>):
 
   // If the CLS mechanism is set to auto-determined, decide now what it should
   // be.
-  const ahAvailable = semver.satisfies(process.version, '>=8') &&
-      process.env.GCLOUD_TRACE_NEW_CONTEXT;
+  const ahAvailable = semver.satisfies(process.version, '>=8');
   if (config.clsMechanism === 'auto') {
     config.clsMechanism = ahAvailable ? 'async-hooks' : 'async-listener';
   }

--- a/system-test/trace-express.js
+++ b/system-test/trace-express.js
@@ -42,8 +42,7 @@ const queryString = require('querystring');
 const uuid = require('uuid');
 const semver = require('semver');
 
-const usingAsyncHooks = semver.satisfies(process.version, '>=8') &&
-                        !!process.env.GCLOUD_TRACE_NEW_CONTEXT;
+const usingAsyncHooks = semver.satisfies(process.version, '>=8');
 console.log(`Running system test with usingAsyncHooks=${usingAsyncHooks}`);
 
 // TODO(ofrobots): this code should be moved to a better location. Perhaps

--- a/test/plugins/common.ts
+++ b/test/plugins/common.ts
@@ -35,7 +35,7 @@ var semver = require('semver');
 
 var logger = require('@google-cloud/common').logger;
 var trace = require('../../..');
-if (semver.satisfies(process.version, '>=8') && process.env.GCLOUD_TRACE_NEW_CONTEXT) {
+if (semver.satisfies(process.version, '>=8')) {
   // Monkeypatch Mocha's it() to create a fresh context with each test case.
   var oldIt = global.it;
   global.it = Object.assign(function it(title, fn) {

--- a/test/test-config-cls.ts
+++ b/test/test-config-cls.ts
@@ -24,8 +24,7 @@ import {TraceCLSConfig, TraceCLSMechanism} from '../src/cls';
 import * as testTraceModule from './trace';
 
 describe('Behavior set by config for context propagation mechanism', () => {
-  const useAH = semver.satisfies(process.version, '>=8') &&
-      !!process.env.GCLOUD_TRACE_NEW_CONTEXT;
+  const useAH = semver.satisfies(process.version, '>=8');
   const autoMechanism =
       useAH ? TraceCLSMechanism.ASYNC_HOOKS : TraceCLSMechanism.ASYNC_LISTENER;
   let capturedConfig: TraceCLSConfig|null;


### PR DESCRIPTION
Fixes #566

This PR removes references to `GCLOUD_TRACE_NEW_CONTEXT`. Code that depend on its value now behave as if it were always `true`.

This change makes `async_hooks`-based tracing the default behavior in Node 8+.