### PR TITLE
chore: drop support for node 4 and 9

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,29 +91,21 @@ workflows:
               only:
                 - master
     jobs:
-      - node4
       - node6
       - node8
-      - node9
       - node10
   tests:
     jobs:
-      - node4:
-          filters: *release_tags
       - node6:
           filters: *release_tags
       - node8:
-          filters: *release_tags
-      - node9:
           filters: *release_tags
       - node10:
           filters: *release_tags
       - publish_npm:
           requires:
-            - node4
             - node6
             - node8
-            - node9
             - node10
           filters:
             branches:
@@ -121,14 +113,6 @@ workflows:
             <<: *release_tags
 
 jobs:
-  node4:
-    docker:
-      - image: node:4
-      - *mongo_service
-      - *redis_service
-      - *postgres_service
-      - *mysql_service
-    <<: *unit_tests
   node6:
     docker:
       - image: node:6
@@ -140,14 +124,6 @@ jobs:
   node8:
     docker:
       - image: node:8
-      - *mongo_service
-      - *redis_service
-      - *postgres_service
-      - *mysql_service
-    <<: *unit_tests
-  node9:
-    docker:
-      - image: node:9
       - *mongo_service
       - *redis_service
       - *postgres_service

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This module provides automatic tracing for Node.js applications with Stackdriver
 
 ## Usage
 
-The Trace Agent supports Node 4+.
+The Trace Agent supports Node 6+.
 
 > **Note**: Using the Trace Agent requires a Google Cloud Project with the [Stackdriver Trace API enabled](https://console.cloud.google.com/flows/enableapi?apiid=cloudtrace) and associated credentials. These values are auto-detected if the application is running on Google Cloud Platform. If your application is not running on GCP, you will need to specify the project ID and credentials either through the configuration object, or with environment variables. See [Setting Up Stackdriver Trace for Node.js][setting-up-stackdriver-trace] for more details.
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,10 +2,9 @@
 environment:
   matrix:
   # node.js
-  - nodejs_version: "4"
   - nodejs_version: "6"
   - nodejs_version: "8"
-  # - nodejs_version: "10"
+  - nodejs_version: "10"
 
 cache:
   - src/plugins/types -> src/plugins/types/index.d.ts

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   "author": "Google Inc.",
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=4"
+    "node": ">=6"
   },
   "devDependencies": {
     "@types/builtin-modules": "^2.0.0",


### PR DESCRIPTION
BREAKING CHANGE: This change drops support for Node 4 and 9.

r-i-t-m needs to be fixed at 2.2.1. Tracking this at #779.

Actually, I do not want this to land yet.