### PR TITLE
feat: add getProjectId and getCurrentRootSpan

### DIFF
--- a/src/cls.ts
+++ b/src/cls.ts
@@ -24,7 +24,8 @@ import {CLS, Func} from './cls/base';
 import {NullCLS} from './cls/null';
 import {SingularCLS} from './cls/singular';
 import {SpanType} from './constants';
-import {Span, SpanOptions} from './plugin-types';
+import {RootSpan} from './plugin-types';
+import {UNCORRELATED_ROOT_SPAN, UNTRACED_ROOT_SPAN} from './span-data';
 import {Trace, TraceSpan} from './trace';
 import {Singleton} from './util';
 
@@ -33,7 +34,6 @@ const asyncHooksAvailable = semver.satisfies(process.version, '>=8');
 export interface RealRootContext {
   readonly span: TraceSpan;
   readonly trace: Trace;
-  createChildSpan(options: SpanOptions): Span;
   readonly type: SpanType.ROOT;
 }
 
@@ -51,7 +51,7 @@ export interface PhantomRootContext {
  * When we store an actual root span, the only information we need is its
  * current trace/span fields.
  */
-export type RootContext = RealRootContext|PhantomRootContext;
+export type RootContext = RootSpan&(RealRootContext|PhantomRootContext);
 
 /**
  * An enumeration of the possible mechanisms for supporting context propagation
@@ -101,8 +101,8 @@ export class TraceCLS implements CLS<RootContext> {
   private CLSClass: CLSConstructor;
   private enabled = false;
 
-  static UNCORRELATED: RootContext = {type: SpanType.UNCORRELATED};
-  static UNTRACED: RootContext = {type: SpanType.UNTRACED};
+  static UNCORRELATED: RootContext = UNCORRELATED_ROOT_SPAN;
+  static UNTRACED: RootContext = UNTRACED_ROOT_SPAN;
 
   /**
    * Stack traces are captured when a root span is started. Because the stack

--- a/src/plugin-types.ts
+++ b/src/plugin-types.ts
@@ -126,6 +126,16 @@ export interface TraceAgent {
   runInRootSpan<T>(options: RootSpanOptions, fn: (span: RootSpan) => T): T;
 
   /**
+   * Gets the active root span for the current context. This method is
+   * guaranteed to return an object with the surface of a RootSpan object, but
+   * it may not represent a real root span if we are not in one. Use isRealSpan
+   * or check the `type` field to determine whether this is a real or phantom
+   * span.
+   * @returns An object that represents either a real or phantom root span.
+   */
+  getCurrentRootSpan(): RootSpan;
+
+  /**
    * Returns a unique identifier for the currently active context. This can be
    * used to uniquely identify the current root span. If there is no current,
    * context, or if we have lost context, this will return null. The structure
@@ -134,6 +144,12 @@ export interface TraceAgent {
    * @returns an id for the current context, or null if there is none
    */
   getCurrentContextId(): string|null;
+
+  /**
+   * Returns the projectId that was either configured or auto-discovered by the
+   * TraceWriter.
+   */
+  getProjectId(): Promise<string>;
 
   /**
    * Returns the projectId that was either configured or auto-discovered by the

--- a/test/test-index.ts
+++ b/test/test-index.ts
@@ -22,14 +22,12 @@ import { SpanType } from '../src/constants';
 import { FORCE_NEW } from '../src/util';
 
 var assert = require('assert');
-var nock = require('nock');
-var nocks = require('./nocks'/*.js*/);
 var trace = require('../..');
 
 var disabledAgent: TraceAgent = trace.get();
 
 describe('index.js', function() {
-  it('should get a disabled agent with `Trace.get`', function() {
+  it('should get a disabled agent with `Trace.get`', async function() {
     assert.ok(!disabledAgent.isActive()); // ensure it's disabled first
     let ranInRootSpan = false;
     disabledAgent.runInRootSpan({ name: '' }, (span) => {
@@ -40,6 +38,10 @@ describe('index.js', function() {
     assert.strictEqual(disabledAgent.enhancedDatabaseReportingEnabled(), false);
     assert.strictEqual(disabledAgent.getCurrentContextId(), null);
     assert.strictEqual(disabledAgent.getWriterProjectId(), null);
+    assert.strictEqual(disabledAgent.getCurrentRootSpan().type, SpanType.UNTRACED);
+    // getting project ID should reject.
+    await disabledAgent.getProjectId().then(
+        () => Promise.reject(new Error()), () => Promise.resolve());
     assert.strictEqual(disabledAgent.createChildSpan({ name: '' }).type, SpanType.UNTRACED);
     assert.strictEqual(disabledAgent.getResponseTraceContext('', false), '');
     const fn = () => {};

--- a/test/test-trace-uncaught-exception.ts
+++ b/test/test-trace-uncaught-exception.ts
@@ -74,7 +74,7 @@ describe('Trace Writer', () => {
      (done) => {
        const restoreOriginalUncaughtExceptionListeners =
            removeAllUncaughtExceptionListeners();
-       const traceApi = trace.start({onUncaughtException: 'flush'});
+       trace.start({onUncaughtException: 'flush', projectId: '0'});
        setImmediate(() => {
          setImmediate(() => {
            removeAllUncaughtExceptionListeners();


### PR DESCRIPTION
This PR adds two methods on the TraceAgent class, `getProjectId` and `getCurrentRootSpan`, which should supercede `getWriterProjectId` and `getCurrentContextId` respectively. It also uses `TraceWriter#projectId` instead of `TraceWriter#config.projectId` to store the retrieved project ID, because this is already the behavior of `Service`. In practice, this fixes a regression with `getProjectId`.