### PR TITLE
feat: use well-known format for propagating trace context thru grpc

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -19,6 +19,9 @@
 /** Constant values. */
 // tslint:disable-next-line:variable-name
 export const Constants = {
+  /** The metadata key under which trace context  */
+  TRACE_CONTEXT_GRPC_METADATA_NAME: 'grpc-trace-bin',
+
   /** Header that carries trace context across Google infrastructure. */
   TRACE_CONTEXT_HEADER_NAME: 'x-cloud-trace-context',
 

--- a/src/plugins/plugin-grpc.ts
+++ b/src/plugins/plugin-grpc.ts
@@ -112,12 +112,13 @@ function patchClient(client: ClientModule, api: TraceAgent) {
    * Set trace context on a Metadata object if it exists.
    * @param metadata The Metadata object to which a trace context should be
    * added.
-   * @param span The span that contains the trace context to add as a metadata
-   * entry.
+   * @param stringifiedTraceContext The stringified trace context. If this is
+   * a falsey value, metadata will not be modified.
    */
-  function setTraceContextFromString(metadata: Metadata, span: Span): void {
+  function setTraceContextFromString(
+      metadata: Metadata, stringifiedTraceContext: string): void {
     const traceContext =
-        api.traceContextUtils.decodeFromString(span.getTraceContext());
+        api.traceContextUtils.decodeFromString(stringifiedTraceContext);
     if (traceContext) {
       const metadataValue =
           api.traceContextUtils.encodeAsByteArray(traceContext);
@@ -212,7 +213,7 @@ function patchClient(client: ClientModule, api: TraceAgent) {
       // TS: Safe cast as we either found the index of the Metadata argument
       //     or spliced it in at metaIndex.
       const metadata = args[metaIndex] as Metadata;
-      setTraceContextFromString(metadata, span);
+      setTraceContextFromString(metadata, span.getTraceContext());
       const call: EventEmitter = method.apply(this, args);
       // Add extra data only when call successfully goes through. At this point
       // we know that the arguments are correct.


### PR DESCRIPTION
BREAKING CHANGE: The change in distributed trace context propagation across gRPC is not backwards-compatible. In other words, distributed tracing will not work between two Node instances communicating using gRPC with v2 and v3 of the Trace Agent, respectively.

Trace context can now be propagated thru gRPC with the `'grpc-trace-bin'` key, and a binary-encoded value.