### PR TITLE
feat: allow incoming http header to override span name

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -63,6 +63,15 @@ export interface Config {
   enhancedDatabaseReporting?: boolean;
 
   /**
+   * If set to true, traces that represent incoming HTTP spans will prefer
+   * the header value under key Tracer#constants.TRACE_SPAN_NAME_OVERRIDE to
+   * the request path. This option should only be enabled if this server's
+   * endpoints aren't publicly exposed, as it allows misbehaving clients to
+   * set span names to arbitrary values.
+   */
+  useSpanNameOverrideHeader?: boolean;
+
+  /**
    * The maximum number of characters reported on a label value. This value
    * cannot exceed 16383, the maximum value accepted by the service.
    */
@@ -193,6 +202,7 @@ export const defaultConfig = {
   logLevel: 1,
   enabled: true,
   enhancedDatabaseReporting: false,
+  useSpanNameOverrideHeader: false,
   maximumLabelValueSize: 512,
   plugins: {
     // enable all by default

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -19,11 +19,17 @@
 /** Constant values. */
 // tslint:disable-next-line:variable-name
 export const Constants = {
-  /** The metadata key under which trace context  */
+  /** The metadata key under which trace context is stored as a binary value. */
   TRACE_CONTEXT_GRPC_METADATA_NAME: 'grpc-trace-bin',
 
   /** Header that carries trace context across Google infrastructure. */
   TRACE_CONTEXT_HEADER_NAME: 'x-cloud-trace-context',
+
+  /**
+   * A header that can be used to override the span name of an incoming HTTP
+   * request.
+   */
+  TRACE_SPAN_NAME_OVERRIDE: 'x-cloud-trace-span-name-override',
 
   /** Header that is used to identify outgoing http made by the agent. */
   TRACE_AGENT_REQUEST_HEADER: 'x-cloud-trace-agent-request',

--- a/src/plugin-types.ts
+++ b/src/plugin-types.ts
@@ -17,6 +17,7 @@
 // This file only describes public-facing interfaces.
 // tslint:disable:no-any
 
+import {Config} from './config';
 import {Constants, SpanType} from './constants';
 import {TraceLabels} from './trace-labels';
 import {TraceContext} from './util';
@@ -115,6 +116,12 @@ export interface Tracer {
    * to have an enhanced level of reporting enabled.
    */
   enhancedDatabaseReportingEnabled(): boolean;
+
+  /**
+   * Gets the current configuration, or throws if it can't be retrieved
+   * because the Trace Agent was not disabled.
+   */
+  getConfig(): Config;
 
   /**
    * Runs the given function in a root span corresponding to an incoming

--- a/src/plugins/plugin-connect.ts
+++ b/src/plugins/plugin-connect.ts
@@ -39,8 +39,13 @@ function getFirstHeader(req: IncomingMessage, key: string): string|null {
 function createMiddleware(api: PluginTypes.Tracer):
     connect_3.NextHandleFunction {
   return function middleware(req: Request, res, next) {
+    // For the span name:
+    // 1. Use the TRACE_SPAN_NAME_OVERRIDE header.
+    // 2. If non-existent, use the path name.
+    const name = getFirstHeader(req, api.constants.TRACE_SPAN_NAME_OVERRIDE) ||
+        (req.originalUrl ? (urlParse(req.originalUrl).pathname || '') : '');
     const options = {
-      name: req.originalUrl ? (urlParse(req.originalUrl).pathname || '') : '',
+      name,
       url: req.originalUrl,
       traceContext:
           getFirstHeader(req, api.constants.TRACE_CONTEXT_HEADER_NAME),

--- a/src/plugins/plugin-express.ts
+++ b/src/plugins/plugin-express.ts
@@ -35,8 +35,12 @@ function patchModuleRoot(express: Express4Module, api: PluginTypes.Tracer) {
   function middleware(
       req: express_4.Request, res: express_4.Response,
       next: express_4.NextFunction) {
+    // For the span name:
+    // 1. Use the TRACE_SPAN_NAME_OVERRIDE header.
+    // 2. If non-existent, use the path name.
+    const name = req.get(api.constants.TRACE_SPAN_NAME_OVERRIDE) || req.path;
     const options: PluginTypes.RootSpanOptions = {
-      name: req.path,
+      name,
       traceContext: req.get(api.constants.TRACE_CONTEXT_HEADER_NAME),
       url: req.originalUrl,
       skipFrames: 1

--- a/src/plugins/plugin-express.ts
+++ b/src/plugins/plugin-express.ts
@@ -30,17 +30,28 @@ const methods: Array<keyof express_4.Application> =
 
 const SUPPORTED_VERSIONS = '4.x';
 
+function getSpanName(
+    tracer: PluginTypes.Tracer, req: express_4.Request): string {
+  // For the span name:
+  // 1. Use the TRACE_SPAN_NAME_OVERRIDE header.
+  // 2. If non-existent, use the path name.
+  let name;
+  if (tracer.getConfig().useSpanNameOverrideHeader) {
+    name = req.get(tracer.constants.TRACE_SPAN_NAME_OVERRIDE);
+  }
+  if (!name) {
+    name = req.path;
+  }
+  return name;
+}
+
 function patchModuleRoot(express: Express4Module, api: PluginTypes.Tracer) {
   const labels = api.labels;
   function middleware(
       req: express_4.Request, res: express_4.Response,
       next: express_4.NextFunction) {
-    // For the span name:
-    // 1. Use the TRACE_SPAN_NAME_OVERRIDE header.
-    // 2. If non-existent, use the path name.
-    const name = req.get(api.constants.TRACE_SPAN_NAME_OVERRIDE) || req.path;
     const options: PluginTypes.RootSpanOptions = {
-      name,
+      name: getSpanName(api, req),
       traceContext: req.get(api.constants.TRACE_CONTEXT_HEADER_NAME),
       url: req.originalUrl,
       skipFrames: 1

--- a/src/plugins/plugin-hapi.ts
+++ b/src/plugins/plugin-hapi.ts
@@ -48,8 +48,13 @@ function instrument<T>(
   const req = request.raw.req;
   const res = request.raw.res;
   const originalEnd = res.end;
+  // For the span name:
+  // 1. Use the TRACE_SPAN_NAME_OVERRIDE header.
+  // 2. If non-existent, use the path name.
+  const name = getFirstHeader(req, api.constants.TRACE_SPAN_NAME_OVERRIDE) ||
+      (req.url ? (urlParse(req.url).pathname || '') : '');
   const options: PluginTypes.RootSpanOptions = {
-    name: req.url ? (urlParse(req.url).pathname || '') : '',
+    name,
     url: req.url,
     traceContext: getFirstHeader(req, api.constants.TRACE_CONTEXT_HEADER_NAME),
     skipFrames: 2

--- a/src/plugins/plugin-hapi.ts
+++ b/src/plugins/plugin-hapi.ts
@@ -42,19 +42,28 @@ function getFirstHeader(req: IncomingMessage, key: string): string|null {
   return headerValue;
 }
 
+function getSpanName(tracer: PluginTypes.Tracer, req: IncomingMessage): string {
+  // For the span name:
+  // 1. Use the TRACE_SPAN_NAME_OVERRIDE header.
+  // 2. If non-existent, use the path name.
+  let name;
+  if (tracer.getConfig().useSpanNameOverrideHeader) {
+    name = getFirstHeader(req, tracer.constants.TRACE_SPAN_NAME_OVERRIDE);
+  }
+  if (!name) {
+    name = req.url ? (urlParse(req.url).pathname || '') : '';
+  }
+  return name;
+}
+
 function instrument<T>(
     api: PluginTypes.Tracer, request: hapi_16.Request|hapi_17.Request,
     continueCb: () => T): T {
   const req = request.raw.req;
   const res = request.raw.res;
   const originalEnd = res.end;
-  // For the span name:
-  // 1. Use the TRACE_SPAN_NAME_OVERRIDE header.
-  // 2. If non-existent, use the path name.
-  const name = getFirstHeader(req, api.constants.TRACE_SPAN_NAME_OVERRIDE) ||
-      (req.url ? (urlParse(req.url).pathname || '') : '');
   const options: PluginTypes.RootSpanOptions = {
-    name,
+    name: getSpanName(api, req),
     url: req.url,
     traceContext: getFirstHeader(req, api.constants.TRACE_CONTEXT_HEADER_NAME),
     skipFrames: 2

--- a/src/plugins/plugin-koa.ts
+++ b/src/plugins/plugin-koa.ts
@@ -48,18 +48,27 @@ function getFirstHeader(req: IncomingMessage, key: string): string|null {
   return headerValue;
 }
 
+function getSpanName(tracer: PluginTypes.Tracer, req: IncomingMessage): string {
+  // For the span name:
+  // 1. Use the TRACE_SPAN_NAME_OVERRIDE header.
+  // 2. If non-existent, use the path name.
+  let name;
+  if (tracer.getConfig().useSpanNameOverrideHeader) {
+    name = getFirstHeader(req, tracer.constants.TRACE_SPAN_NAME_OVERRIDE);
+  }
+  if (!name) {
+    name = req.url ? (urlParse(req.url).pathname || '') : '';
+  }
+  return name;
+}
+
 function startSpanForRequest<T>(
     api: PluginTypes.Tracer, ctx: KoaContext, getNext: GetNextFn<T>): T {
   const req = ctx.req;
   const res = ctx.res;
   const originalEnd = res.end;
-  // For the span name:
-  // 1. Use the TRACE_SPAN_NAME_OVERRIDE header.
-  // 2. If non-existent, use the path name.
-  const name = getFirstHeader(req, api.constants.TRACE_SPAN_NAME_OVERRIDE) ||
-      (req.url ? (urlParse(req.url).pathname || '') : '');
   const options = {
-    name,
+    name: getSpanName(api, req),
     url: req.url,
     traceContext: getFirstHeader(req, api.constants.TRACE_CONTEXT_HEADER_NAME),
     skipFrames: 2

--- a/src/plugins/plugin-koa.ts
+++ b/src/plugins/plugin-koa.ts
@@ -53,8 +53,13 @@ function startSpanForRequest<T>(
   const req = ctx.req;
   const res = ctx.res;
   const originalEnd = res.end;
+  // For the span name:
+  // 1. Use the TRACE_SPAN_NAME_OVERRIDE header.
+  // 2. If non-existent, use the path name.
+  const name = getFirstHeader(req, api.constants.TRACE_SPAN_NAME_OVERRIDE) ||
+      (req.url ? (urlParse(req.url).pathname || '') : '');
   const options = {
-    name: req.url ? (urlParse(req.url).pathname || '') : '',
+    name,
     url: req.url,
     traceContext: getFirstHeader(req, api.constants.TRACE_CONTEXT_HEADER_NAME),
     skipFrames: 2

--- a/src/plugins/plugin-restify.ts
+++ b/src/plugins/plugin-restify.ts
@@ -46,10 +46,15 @@ function patchRestify(restify: Restify5, api: PluginTypes.Tracer) {
   }
 
   function middleware(req: Request, res: Response, next: Next): void {
+    // For the span name:
+    // 1. Use the TRACE_SPAN_NAME_OVERRIDE header.
+    // 2. If non-existent, use the path name.
+    const name =
+        req.header(api.constants.TRACE_SPAN_NAME_OVERRIDE) || req.path();
     const options = {
       // we use the path part of the url as the span name and add the full url
       // as a label later.
-      name: req.path(),
+      name,
       url: req.url,
       traceContext: req.header(api.constants.TRACE_CONTEXT_HEADER_NAME),
       skipFrames: 1

--- a/src/trace-api.ts
+++ b/src/trace-api.ts
@@ -19,6 +19,7 @@ import * as is from 'is';
 import * as uuid from 'uuid';
 
 import {cls, RootContext} from './cls';
+import {Config} from './config';
 import {Constants, SpanType} from './constants';
 import {Func, RootSpan, RootSpanOptions, Span, SpanOptions, Tracer} from './plugin-types';
 import {RootSpanData, UNCORRELATED_CHILD_SPAN, UNCORRELATED_ROOT_SPAN, UNTRACED_CHILD_SPAN, UNTRACED_ROOT_SPAN} from './span-data';
@@ -124,6 +125,13 @@ export class StackdriverTracer implements Tracer {
 
   enhancedDatabaseReportingEnabled(): boolean {
     return !!this.config && this.config.enhancedDatabaseReporting;
+  }
+
+  getConfig(): Config {
+    if (!this.config) {
+      throw new Error('Configuration is not available.');
+    }
+    return this.config;
   }
 
   runInRootSpan<T>(options: RootSpanOptions, fn: (span: RootSpan) => T): T {

--- a/test/test-trace-web-frameworks.ts
+++ b/test/test-trace-web-frameworks.ts
@@ -299,11 +299,15 @@ describe('Web framework tracing', () => {
         let serverSpan: TraceSpan;
 
         beforeEach(async () => {
+          const spanNameOverrideKey =
+              testTraceModule.get().constants.TRACE_SPAN_NAME_OVERRIDE;
           await testTraceModule.get().runInRootSpan(
               {name: 'outer'}, async (span) => {
                 assert.ok(testTraceModule.get().isRealSpan(span));
                 // Hit an endpoint with a query parameter.
-                await axios.get(`http://localhost:${port}/hello?this-is=dog`);
+                await axios.get(
+                    `http://localhost:${port}/hello?this-is=dog`,
+                    {headers: {[spanNameOverrideKey]: '/goodbye'}});
                 span!.endSpan();
               });
           assert.strictEqual(testTraceModule.getSpans().length, 3);
@@ -328,6 +332,10 @@ describe('Web framework tracing', () => {
               stackTrace.stack_frame[0].method_name, expectedTopStackFrame);
         });
 
+        it('doesn\'t read span name header when assoc. option is off', () => {
+          assert.strictEqual(serverSpan.name, '/hello');
+        });
+
         it('doesn\'t include query parameters in span name', () => {
           assert.strictEqual(
               serverSpan.name.indexOf('dog'), -1,
@@ -335,22 +343,25 @@ describe('Web framework tracing', () => {
         });
       });
 
-      it('uses the span name override header', async () => {
-        const spanNameOverrideKey =
-            testTraceModule.get().constants.TRACE_SPAN_NAME_OVERRIDE;
-        await testTraceModule.get().runInRootSpan(
-            {name: 'outer'}, async (span) => {
-              assert.ok(testTraceModule.get().isRealSpan(span));
-              // Specify a header which overrides the span name.
-              await axios.get(
-                  `http://localhost:${port}/hello`,
-                  {headers: {[spanNameOverrideKey]: '/goodbye'}});
-              span!.endSpan();
-            });
-        assert.strictEqual(testTraceModule.getSpans().length, 3);
-        const serverSpan = testTraceModule.getOneSpan(isServerSpan);
-        assert.strictEqual(serverSpan.name, '/goodbye');
-      });
+      it('uses the span name override header when assoc. option is on',
+         async () => {
+           testTraceModule.get().getConfig().useSpanNameOverrideHeader = true;
+           const spanNameOverrideKey =
+               testTraceModule.get().constants.TRACE_SPAN_NAME_OVERRIDE;
+           await testTraceModule.get().runInRootSpan(
+               {name: 'outer'}, async (span) => {
+                 assert.ok(testTraceModule.get().isRealSpan(span));
+                 // Specify a header which overrides the span name.
+                 await axios.get(
+                     `http://localhost:${port}/hello`,
+                     {headers: {[spanNameOverrideKey]: '/goodbye'}});
+                 span!.endSpan();
+               });
+           assert.strictEqual(testTraceModule.getSpans().length, 3);
+           const serverSpan = testTraceModule.getOneSpan(isServerSpan);
+           assert.strictEqual(serverSpan.name, '/goodbye');
+           testTraceModule.get().getConfig().useSpanNameOverrideHeader = false;
+         });
     });
   });
 });


### PR DESCRIPTION
This PR introduces `Tracer#constants.TRACE_SPAN_NAME_OVERRIDE` which, when used as a header key on an incoming request, changes the span name to the value of this header.